### PR TITLE
Consume display name from custom parameters

### DIFF
--- a/android/src/main/java/com/twiliovoicereactnative/Constants.java
+++ b/android/src/main/java/com/twiliovoicereactnative/Constants.java
@@ -17,4 +17,5 @@ public class Constants {
   public static final String FCM_TOKEN = "FCM_TOKEN";
   public static final String UUID = "UUID";
   public static final String NOTIFICATION_CONTENT = "Calling from ";
+  public static final String DISPLAY_NAME = "displayName";
 }

--- a/android/src/main/java/com/twiliovoicereactnative/IncomingCallNotificationService.java
+++ b/android/src/main/java/com/twiliovoicereactnative/IncomingCallNotificationService.java
@@ -32,6 +32,8 @@ import java.util.UUID;
 
 import android.media.AudioAttributes;
 import android.net.Uri;
+import java.net.URLDecoder;
+import java.util.Map;
 
 public class IncomingCallNotificationService extends Service {
 
@@ -96,8 +98,10 @@ public class IncomingCallNotificationService extends Service {
     Bundle extras = new Bundle();
     extras.putString(Constants.CALL_SID_KEY, callInvite.getCallSid());
 
+    String title = getDisplayName(callInvite);
+
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-      Notification notification = buildNotification(callInvite.getFrom(),
+      Notification notification = buildNotification(title,
         pendingIntent,
         extras,
         callInvite,
@@ -111,7 +115,7 @@ public class IncomingCallNotificationService extends Service {
       return new NotificationCompat.Builder(this)
         .setSmallIcon(R.drawable.ic_call_end_white_24dp)
         .setContentTitle("Incoming call")
-        .setContentText(callInvite.getFrom() + " is calling.")
+        .setContentText(title + " is calling.")
         .setAutoCancel(true)
         .setExtras(extras)
         .setContentIntent(pendingIntent)
@@ -342,5 +346,14 @@ public class IncomingCallNotificationService extends Service {
       e.printStackTrace();
       return null;
     }
+  }
+
+  private String getDisplayName(CallInvite callInvite) {
+    String title = callInvite.getFrom();
+    Map<String, String> customParameters = callInvite.getCustomParameters();
+    if (customParameters.get(Constants.DISPLAY_NAME) != null) {
+      title = URLDecoder.decode(customParameters.get(Constants.DISPLAY_NAME).replaceAll("\\+", "%20"));
+    }
+    return title;
   }
 }

--- a/android/src/main/java/com/twiliovoicereactnative/VoiceFirebaseMessagingService.java
+++ b/android/src/main/java/com/twiliovoicereactnative/VoiceFirebaseMessagingService.java
@@ -59,9 +59,11 @@ public class VoiceFirebaseMessagingService extends FirebaseMessagingService {
     Log.d(TAG, "Bundle data: " + remoteMessage.getData());
     Log.d(TAG, "From: " + remoteMessage.getFrom());
 
+    Map<String, String> remoteData = remoteMessage.getData();
+
     // Check if message contains a data payload.
     if (remoteMessage.getData().size() > 0) {
-      boolean valid = Voice.handleMessage(this, remoteMessage.getData(), new MessageListener() {
+      boolean valid = Voice.handleMessage(this, remoteData, new MessageListener() {
         @Override
         public void onCallInvite(@NonNull CallInvite callInvite) {
           final int notificationId = (int) System.currentTimeMillis();


### PR DESCRIPTION
Consume display name from custom parameters when available.
![screenshot-1629853381890](https://user-images.githubusercontent.com/10856725/130709866-3790d055-c392-44c1-a877-c2a76b619902.png)

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
