### PR TITLE
Use displayName custom param for CallKit display

### DIFF
--- a/ios/TwilioVoiceReactNative+CallKit.m
+++ b/ios/TwilioVoiceReactNative+CallKit.m
@@ -11,6 +11,8 @@
 #import "TwilioVoiceReactNative.h"
 #import "TwilioVoiceReactNativeConstants.h"
 
+NSString * const kCustomParametersKeyDisplayName = @"displayName";
+
 @interface TwilioVoiceReactNative (CallKit) <CXProviderDelegate, TVOCallDelegate>
 
 @end
@@ -33,8 +35,17 @@
 
 - (void)reportNewIncomingCall:(TVOCallInvite *)callInvite {
     self.callInviteMap[callInvite.uuid.UUIDString] = callInvite;
+    
+    // Frontline specific logic
+    NSString *handleName = callInvite.from;
+    NSDictionary *customParams = callInvite.customParameters;
+    if (customParams[kCustomParametersKeyDisplayName]) {
+        NSString *callerDisplayName = customParams[kCustomParametersKeyDisplayName];
+        callerDisplayName = [callerDisplayName stringByReplacingOccurrencesOfString:@"+" withString:@" "];
+        handleName = callerDisplayName;
+    }
 
-    CXHandle *callHandle = [[CXHandle alloc] initWithType:CXHandleTypeGeneric value:callInvite.from];
+    CXHandle *callHandle = [[CXHandle alloc] initWithType:CXHandleTypeGeneric value:handleName];
 
     CXCallUpdate *callUpdate = [[CXCallUpdate alloc] init];
     callUpdate.remoteHandle = callHandle;


### PR DESCRIPTION
- [x] I acknowledge that all my contributions will be made under the project's license.

### Description

Use the `displayName` custom parameter for CallKit incoming call handle. Note that this key currently only applies for the Frontline app. The `from` value of the call invite will be used if this key is not presented in the custom parameter list.

<kbd><img width=300 src="https://user-images.githubusercontent.com/16326574/130849698-020e418c-3102-41f0-822f-5b3c8a7670f6.PNG"></kbd>