### PR TITLE
VBLOCKS-251: Enable using single push notification service for multiple FirebaseMessagingService subclasses

### DIFF
--- a/android/src/main/java/com/twiliovoicereactnative/VoiceFirebaseMessagingService.java
+++ b/android/src/main/java/com/twiliovoicereactnative/VoiceFirebaseMessagingService.java
@@ -1,5 +1,6 @@
 package com.twiliovoicereactnative;
 
+import android.content.Context;
 import android.util.Log;
 
 import com.facebook.react.ReactApplication;
@@ -33,6 +34,17 @@ import java.util.UUID;
 public class VoiceFirebaseMessagingService extends FirebaseMessagingService {
 
   public static String TAG = "VoiceFirebaseMessagingService";
+  private Context context;
+
+  public VoiceFirebaseMessagingService() {
+    super();
+    this.context = this;
+  }
+
+  public VoiceFirebaseMessagingService(FirebaseMessagingService delegate) {
+    super();
+    this.context = delegate;
+  }
 
   @Override
   public void onCreate() {
@@ -59,11 +71,9 @@ public class VoiceFirebaseMessagingService extends FirebaseMessagingService {
     Log.d(TAG, "Bundle data: " + remoteMessage.getData());
     Log.d(TAG, "From: " + remoteMessage.getFrom());
 
-    Map<String, String> remoteData = remoteMessage.getData();
-
     // Check if message contains a data payload.
     if (remoteMessage.getData().size() > 0) {
-      boolean valid = Voice.handleMessage(this, remoteData, new MessageListener() {
+      boolean valid = Voice.handleMessage(this.context, remoteMessage.getData(), new MessageListener() {
         @Override
         public void onCallInvite(@NonNull CallInvite callInvite) {
           final int notificationId = (int) System.currentTimeMillis();
@@ -86,7 +96,7 @@ public class VoiceFirebaseMessagingService extends FirebaseMessagingService {
   private void handleInvite(CallInvite callInvite, int notificationId) {
     String uuid = UUID.randomUUID().toString();
 
-    Intent intent = new Intent(this, IncomingCallNotificationService.class);
+    Intent intent = new Intent(this.context, IncomingCallNotificationService.class);
     intent.setAction(Constants.ACTION_INCOMING_CALL);
     intent.putExtra(Constants.INCOMING_CALL_NOTIFICATION_ID, notificationId);
     intent.putExtra(Constants.INCOMING_CALL_INVITE, callInvite);
@@ -96,19 +106,19 @@ public class VoiceFirebaseMessagingService extends FirebaseMessagingService {
     Storage.callInviteCallSidUuidMap.put(callInvite.getCallSid(), uuid);
     Log.d(TAG, "CallInvite UUID handleInvite " + uuid);
 
-    startService(intent);
+    this.context.startService(intent);
   }
 
   private void handleCanceledCallInvite(CancelledCallInvite cancelledCallInvite) {
     String uuid = Storage.callInviteCallSidUuidMap.get(cancelledCallInvite.getCallSid());
 
-    Intent intent = new Intent(this, IncomingCallNotificationService.class);
+    Intent intent = new Intent(this.context, IncomingCallNotificationService.class);
     intent.setAction(Constants.ACTION_CANCEL_CALL);
     intent.putExtra(Constants.CANCELLED_CALL_INVITE, cancelledCallInvite);
     intent.putExtra(Constants.UUID, uuid);
 
     Storage.cancelledCallInviteMap.put(uuid, cancelledCallInvite);
 
-    startService(intent);
+    this.context.startService(intent);
   }
 }


### PR DESCRIPTION
Enable using single push notification service for multiple FirebaseMessagingService subclasses. Created a constructor in `VoiceFirebaseMessagingService` class that takes  `FirebaseMessagingService` as an argument.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
