### PR TITLE
VBLOCKS-340 Selected audio device corner case

### DIFF
--- a/ios/TwilioVoiceReactNative.m
+++ b/ios/TwilioVoiceReactNative.m
@@ -275,6 +275,13 @@ static TVODefaultAudioDevice *sTwilioAudioDevice;
 
             if (!found) {
                 NSLog(@"Unidentified output device selected: %@, %@, %@", port.portType, port.portName, port.UID);
+                NSUUID *uuid = [NSUUID UUID];
+                NSDictionary *unidentifiedDevice = @{ kTwilioVoiceAudioDeviceUuid: uuid.UUIDString,
+                                                      kTwilioVoiceAudioDeviceType: [self audioPortTypeMapping:port.portType],
+                                                      kTwilioVoiceAudioDeviceName: port.portName,
+                                                      kTwilioVoiceAudioDeviceUid: port.UID };
+                self.audioDevices[uuid.UUIDString] = unidentifiedDevice;
+                self.selectedAudioDevice = unidentifiedDevice;
             }
         }
     }


### PR DESCRIPTION
## Submission Checklist

 - [x] Updated the `CHANGELOG.md` to reflect any **feature**, **bug fixes**, or **known issues** made in the source code
 - [x] Tested code changes and observed expected behavior in the example app
 - [x] Performed a visual inspection of the `Files changed` tab prior to submitting the pull request for review to ensure proper usage of the style guide

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Description

Fix corner case when the selected audio device cannot be determined from the supported types (earpiece, speaker, bluetooth) during screen mirroring.

The SDK/app receives the audio route change notification when initiating a call. Inside the route change handler the SDK will put together a map of available audio devices as well as the selected device. The original logic would fail to assign the selected device because the output route is the HDMI and not part of the supported types.

The crash happened when `nil` was being added into the dictionary: https://github.com/twilio/twilio-voice-react-native/blob/main/ios/TwilioVoiceReactNative.m#L192

## Breakdown

- Assign selected output device even if the device cannot be found in the list of available input devices.

## Validation

- Tried making a call during Quicktime screen mirroring with both sample app and the Frontline app
