### PR TITLE
VBLOCKS-287 Check notificationIds before stopForeground()

### DIFF
--- a/android/src/main/java/com/twiliovoicereactnative/IncomingCallNotificationService.java
+++ b/android/src/main/java/com/twiliovoicereactnative/IncomingCallNotificationService.java
@@ -39,12 +39,12 @@ public class IncomingCallNotificationService extends Service {
       CallInvite callInvite = intent.getParcelableExtra(Constants.INCOMING_CALL_INVITE);
       CancelledCallInvite cancelledCallInvite = intent.getParcelableExtra(Constants.CANCELLED_CALL_INVITE);
       int notificationId = intent.getIntExtra(Constants.NOTIFICATION_ID, 0);
-      insertNotificationIdList(notificationId);
       String uuid = intent.getStringExtra(Constants.UUID);
       String callSid = intent.getStringExtra(Constants.CALL_SID_KEY);
       Log.d(TAG, "UUID " + uuid + " action " + action + " intent " + intent.toString() + " notificationId " + notificationId);
       switch (action) {
         case Constants.ACTION_INCOMING_CALL:
+          insertNotificationIdList(notificationId);
           handleIncomingCall(callInvite, notificationId, uuid);
           break;
         case Constants.ACTION_ACCEPT:
@@ -166,7 +166,10 @@ public class IncomingCallNotificationService extends Service {
     if (notificationId == Integer.MAX_VALUE) {
       stopForeground(true);
     } else {
+      NotificationManager notificationManager = (NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE);
+      notificationManager.cancel(notificationId);
       removeNotificationIdList(notificationId);
+
       if (notificationIdList.size() == 0) {
         stopForeground(true);
       }

--- a/android/src/main/java/com/twiliovoicereactnative/VoiceFirebaseMessagingService.java
+++ b/android/src/main/java/com/twiliovoicereactnative/VoiceFirebaseMessagingService.java
@@ -107,9 +107,12 @@ public class VoiceFirebaseMessagingService extends FirebaseMessagingService {
 
   private void handleCanceledCallInvite(CancelledCallInvite cancelledCallInvite) {
     String uuid = Storage.callInviteCallSidUuidMap.get(cancelledCallInvite.getCallSid());
+    int notificationId = Storage.uuidNotificaionIdMap.get(uuid);
 
     Intent intent = new Intent(this.context, IncomingCallNotificationService.class);
     intent.setAction(Constants.ACTION_CANCEL_CALL);
+
+    intent.putExtra(Constants.NOTIFICATION_ID, notificationId);
     intent.putExtra(Constants.CANCELLED_CALL_INVITE, cancelledCallInvite);
     intent.putExtra(Constants.UUID, uuid);
 


### PR DESCRIPTION
## Submission Checklist

 - [ ] Updated the `CHANGELOG.md` to reflect any **feature**, **bug fixes**, or **known issues** made in the source code
 - [ ] Tested code changes and observed expected behavior in the example app
 - [ ] Performed a visual inspection of the `Files changed` tab prior to submitting the pull request for review to ensure proper usage of the style guide

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [ ] I acknowledge that all my contributions will be made under the project's license.

## Description

Calling `stopForegroud(true)` will immediately stop all the activities of the app and dismiss all the notifications even if actions can still be performed. This PR checks if there are still other notificationIds left in the list before calling `stopForeground(true)`.

## Breakdown

- Use a list of integer to keep track of `notificationId`
- Only call `stopForeground(true)` when all the `notificationId`s are popped out

## Validation

- Tried locally with two incoming calls. Hung up the first call and checked that the notification for the 2nd call was not dismissed.
