### PR TITLE
[VBLOCKS-396] Remove JS call/callInvite cache.

### DIFF
--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -28,38 +28,52 @@ export default function App() {
     unregisterHandler,
     logAudioDevicesHandler,
     selectAudioDeviceHandler,
+    getCallsHandler,
+    getCallInvitesHandler,
   } = useVoice(token);
 
-  const headerComponents = React.useMemo(
-    () => [
-      [
-        <Text>SDK Version: {String(sdkVersion)}</Text>,
-        <Text>Registered: {String(registered)}</Text>,
-      ],
-    ],
+  const headerComponent = React.useMemo(
+    () => (
+      <Grid
+        gridComponents={[
+          [
+            <Text>SDK Version: {String(sdkVersion)}</Text>,
+            <Text>Registered: {String(registered)}</Text>,
+          ],
+        ]}
+      />
+    ),
     [sdkVersion, registered]
   );
 
-  const callGridComponents = React.useMemo(
-    () => [
-      [
-        <Text>From: {String(callInfo?.from)}</Text>,
-        <Text>To: {String(callInfo?.to)}</Text>,
-      ],
-      [<Text>State: {String(callInfo?.state)}</Text>],
-      [<Text>SID: {String(callInfo?.sid)}</Text>],
-    ],
+  const callComponent = React.useMemo(
+    () => (
+      <Grid
+        gridComponents={[
+          [
+            <Text>From: {String(callInfo?.from)}</Text>,
+            <Text>To: {String(callInfo?.to)}</Text>,
+          ],
+          [<Text>State: {String(callInfo?.state)}</Text>],
+          [<Text>SID: {String(callInfo?.sid)}</Text>],
+        ]}
+      />
+    ),
     [callInfo]
   );
 
-  const callInviteComponents = React.useMemo(
-    () => [
-      [
-        <Text>From: {String(recentCallInvite?.from)}</Text>,
-        <Text>To: {String(recentCallInvite?.to)}</Text>,
-      ],
-      [<Text>Call SID: {String(recentCallInvite?.callSid)}</Text>],
-    ],
+  const callInviteComponent = React.useMemo(
+    () => (
+      <Grid
+        gridComponents={[
+          [
+            <Text>From: {String(recentCallInvite?.from)}</Text>,
+            <Text>To: {String(recentCallInvite?.to)}</Text>,
+          ],
+          [<Text>Call SID: {String(recentCallInvite?.callSid)}</Text>],
+        ]}
+      />
+    ),
     [recentCallInvite]
   );
 
@@ -70,39 +84,46 @@ export default function App() {
     []
   );
 
-  const registerButton = React.useMemo(
-    () => <Button title={'Register'} onPress={registerHandler} />,
-    [registerHandler]
+  const getOngoingButtons = React.useMemo(
+    () => [
+      <Button title={'Get Calls'} onPress={getCallsHandler} />,
+      <Button title={'Get Call Invites'} onPress={getCallInvitesHandler} />,
+    ],
+    [getCallsHandler, getCallInvitesHandler]
   );
 
-  const unregisterButton = React.useMemo(
-    () => <Button title={'Unregister'} onPress={unregisterHandler} />,
-    [unregisterHandler]
+  const registrationButtons = React.useMemo(
+    () => [
+      <Button title={'Register'} onPress={registerHandler} />,
+      <Button title={'Unregister'} onPress={unregisterHandler} />,
+    ],
+    [registerHandler, unregisterHandler]
   );
 
-  const audioDeviceButtons = React.useMemo(() => {
-    return [
+  const audioDeviceButtons = React.useMemo(
+    () => [
       <Button title={'Log Audio Devices'} onPress={logAudioDevicesHandler} />,
       <Button
         title={'Select Next Audio Device'}
         onPress={selectAudioDeviceHandler}
       />,
-    ];
-  }, [logAudioDevicesHandler, selectAudioDeviceHandler]);
+    ],
+    [logAudioDevicesHandler, selectAudioDeviceHandler]
+  );
 
   return (
     <SafeAreaView style={styles.expand}>
       <View style={styles.padded}>
         <Text>App Info</Text>
-        <Grid gridComponents={headerComponents} />
+        {headerComponent}
       </View>
       <View style={styles.padded}>
         <Text>Call Info</Text>
-        <Grid gridComponents={callGridComponents} />
+        {callComponent}
       </View>
       <View style={styles.padded}>
         <Text>Call Invite</Text>
-        <Grid gridComponents={callInviteComponents} />
+        {callInviteComponent}
       </View>
       <View style={composedStyles.events}>
         <Text>Events</Text>
@@ -122,8 +143,9 @@ export default function App() {
                 recentCallInvite={recentCallInvite}
               />,
             ],
-            [registerButton, unregisterButton],
+            registrationButtons,
             audioDeviceButtons,
+            getOngoingButtons,
           ]}
         />
       </View>

--- a/example/src/hook.ts
+++ b/example/src/hook.ts
@@ -147,8 +147,7 @@ export function useCallInvites(
         {
           accept: async () => {
             removeCallInvite(callInvite.getCallSid());
-            const call = await callInvite.accept();
-            callHandler(call);
+            await callInvite.accept();
           },
           callSid,
           customParameters: callInvite.getCustomParameters(),
@@ -170,7 +169,7 @@ export function useCallInvites(
         )}`
       );
     },
-    [callHandler, logEvent, removeCallInvite]
+    [logEvent, removeCallInvite]
   );
 
   const callInviteAcceptedHandler = React.useCallback(
@@ -279,6 +278,29 @@ export function useVoice(token: string) {
     [logEvent]
   );
 
+  const getCallsHandler = React.useCallback(() => {
+    voice.getCalls().then((callsMap) => {
+      const readableCalls: Record<string, any> = {};
+      for (const [callUuid, _callInfo] of callsMap.entries()) {
+        readableCalls[callUuid] = _callInfo.getSid();
+      }
+      logEvent(JSON.stringify(readableCalls, null, 2));
+    });
+  }, [voice, logEvent]);
+
+  const getCallInvitesHandler = React.useCallback(() => {
+    voice.getCallInvites().then((callInvitesMap) => {
+      const readableCallInvites: Record<string, any> = {};
+      for (const [
+        callInviteUuid,
+        _callInviteInfo,
+      ] of callInvitesMap.entries()) {
+        readableCallInvites[callInviteUuid] = _callInviteInfo.getCallSid();
+      }
+      logEvent(JSON.stringify(readableCallInvites, null, 2));
+    });
+  }, [voice, logEvent]);
+
   React.useEffect(() => {
     voice.getVersion().then(setSdkVersion);
 
@@ -335,5 +357,7 @@ export function useVoice(token: string) {
     unregisterHandler,
     logAudioDevicesHandler,
     selectAudioDeviceHandler,
+    getCallsHandler,
+    getCallInvitesHandler,
   };
 }

--- a/src/Voice.tsx
+++ b/src/Voice.tsx
@@ -133,11 +133,11 @@ export declare interface Voice {
   on(voiceEvent: Voice.Event.Unregistered, listener: () => void): this;
 }
 
+/**
+ * Voice namespace.
+ * Exposes access to the entire feature-set of the Voice SDK.
+ */
 export class Voice extends EventEmitter {
-  private _bootstrapCallsPromise: Promise<void>;
-  private _bootstrapCallInvitesPromise: Promise<void>;
-  private _calls: Map<Uuid, Call> = new Map();
-  private _callInvites: Map<Uuid, CallInvite> = new Map();
   private _nativeEventEmitter: NativeEventEmitter;
   private _nativeModule: typeof TwilioVoiceReactNative;
   private _nativeEventHandler: Record<
@@ -168,35 +168,9 @@ export class Voice extends EventEmitter {
       NativeEventScope.Voice,
       this._handleNativeEvent
     );
-
-    this._bootstrapCallsPromise = this._nativeModule
-      .voice_getCalls()
-      .then((callInfos: NativeCallInfo[]) => {
-        callInfos.forEach((callInfo: NativeCallInfo) => {
-          const call = new Call(callInfo, {
-            nativeEventEmitter: this._nativeEventEmitter,
-            nativeModule: this._nativeModule,
-          });
-          this._calls.set(callInfo.uuid, call);
-        });
-      });
-
-    this._bootstrapCallInvitesPromise = this._nativeModule
-      .voice_getCallInvites()
-      .then((callInviteInfos: NativeCallInviteInfo[]) => {
-        callInviteInfos.forEach((callInviteInfo: NativeCallInviteInfo) => {
-          const callInvite = new CallInvite(callInviteInfo, {
-            nativeEventEmitter: this._nativeEventEmitter,
-            nativeModule: this._nativeModule,
-          });
-          this._callInvites.set(callInviteInfo.uuid, callInvite);
-        });
-      });
   }
 
   private _handleNativeEvent = (nativeVoiceEvent: NativeVoiceEvent) => {
-    console.log(nativeVoiceEvent);
-
     const { type } = nativeVoiceEvent;
 
     const handler = this._nativeEventHandler[type];
@@ -223,8 +197,6 @@ export class Voice extends EventEmitter {
       nativeModule: this._nativeModule,
     });
 
-    this._callInvites.set(callInviteInfo.uuid, callInvite);
-
     this.emit(Voice.Event.CallInvite, callInvite);
   };
 
@@ -237,10 +209,7 @@ export class Voice extends EventEmitter {
 
     const { callInvite: callInviteInfo } = nativeVoiceEvent;
 
-    const callInvite = this._callInvites.get(callInviteInfo.uuid);
-    if (typeof callInvite === 'undefined') {
-      return;
-    }
+    const callInvite = new CallInvite(callInviteInfo);
 
     const callInfo = {
       uuid: callInviteInfo.uuid,
@@ -255,8 +224,6 @@ export class Voice extends EventEmitter {
       nativeModule: this._nativeModule,
     });
 
-    this._calls.set(callInfo.uuid, call);
-
     this.emit(Voice.Event.CallInviteAccepted, callInvite, call);
   };
 
@@ -269,10 +236,7 @@ export class Voice extends EventEmitter {
 
     const { callInvite: callInviteInfo } = nativeVoiceEvent;
 
-    const callInvite = this._callInvites.get(callInviteInfo.uuid);
-    if (typeof callInvite === 'undefined') {
-      return;
-    }
+    const callInvite = new CallInvite(callInviteInfo);
 
     this.emit(Voice.Event.CallInviteRejected, callInvite);
   };
@@ -342,6 +306,15 @@ export class Voice extends EventEmitter {
     this.emit(Voice.Event.AudioDevicesUpdated, audioDevices, selectedDevice);
   };
 
+  /**
+   * Create an outgoing call.
+   * @param token a Twilio Access Token, usually minted by an
+   * authentication-gated endpoint using a Twilio helper library.
+   * @param params Custom parameters to send to the TwiML Application.
+   * @returns a Promise that resolves with a call when the call is created. Note
+   * that the resolution of this Promise does not imply any call event
+   * occurring, such as answered or rejected.
+   */
   async connect(
     token: string,
     params: Record<string, any> = {}
@@ -353,37 +326,85 @@ export class Voice extends EventEmitter {
       nativeModule: this._nativeModule,
     });
 
-    this._calls.set(callInfo.uuid, call);
-
     return call;
   }
 
+  /**
+   * Get the version of the native SDK. Note that this is not the version of the
+   * React Native SDK, this is the version of the mobile SDK that the RN SDK is
+   * utilizing.
+   * @returns a Promise that resolves with a string representing the version of
+   * the native SDK.
+   */
   getVersion(): Promise<string> {
     return this._nativeModule.voice_getVersion();
   }
 
+  /**
+   * Get the Device token from the native layer.
+   * @returns a Promise that resolves with a string representing the Device
+   * token.
+   */
   getDeviceToken(): Promise<string> {
     return this._nativeModule.voice_getDeviceToken();
   }
 
+  /**
+   * Get a list of existing calls, ongoing and pending. This will not return any
+   * call that has finished.
+   * @returns a Promise that resolves with a mapping of [[Uuid]]s to [[Call]]s.
+   */
   async getCalls(): Promise<ReadonlyMap<Uuid, Call>> {
-    await this._bootstrapCallsPromise;
-    return this._calls;
+    const callInfos = await this._nativeModule.voice_getCalls();
+    const callsMap = new Map<Uuid, Call>(
+      callInfos.map((callInfo: NativeCallInfo) => [
+        callInfo.uuid,
+        new Call(callInfo),
+      ])
+    );
+    return callsMap;
   }
 
+  /**
+   * Get a list of pending call invites. This will not return any call invite
+   * that has been answered or rejected.
+   * @returns a Promise that resolves with a mapping of [[Uuid]]s to
+   * [[CallInvite]]s.
+   */
   async getCallInvites(): Promise<ReadonlyMap<Uuid, CallInvite>> {
-    await this._bootstrapCallInvitesPromise;
-    return this._callInvites;
+    const callInviteInfos = await this._nativeModule.voice_getCallInvites();
+    const callInvitesMap = new Map<Uuid, CallInvite>(
+      callInviteInfos.map((callInviteInfo: NativeCallInviteInfo) => [
+        callInviteInfo.uuid,
+        new CallInvite(callInviteInfo),
+      ])
+    );
+    return callInvitesMap;
   }
 
+  /**
+   * Register this device for incoming calls.
+   * @param token a Twilio Access Token.
+   * @returns a Promise that resolves when the device has been registered.
+   */
   register(token: string): Promise<void> {
     return this._nativeModule.voice_register(token);
   }
 
+  /**
+   * Unregister this device for incoming calls.
+   * @param token a Twilio Access Token.
+   * @returns a Promise that resolves when the device has been unregistered.
+   */
   unregister(token: string): Promise<void> {
     return this._nativeModule.voice_unregister(token);
   }
 
+  /**
+   * Get audio device information from the native layer.
+   * @returns a Promise that resolves with a list of the native device's audio
+   * devices and the currently selected device.
+   */
   async getAudioDevices(): Promise<{
     audioDevices: AudioDevice[];
     selectedDevice: AudioDevice | null;
@@ -403,11 +424,18 @@ export class Voice extends EventEmitter {
     return { audioDevices, selectedDevice };
   }
 
+  /**
+   * TODO
+   */
   showAvRoutePickerView(): Promise<void> {
     return this._nativeModule.voice_showNativeAvRoutePicker();
   }
 }
 
+/**
+ * Voice SDK namespace. Provides an enum detailing the events that the SDK
+ * emits, as well as options to pass to the Voice class.
+ */
 export namespace Voice {
   export enum Event {
     'AudioDevicesUpdated' = 'audioDevicesUpdated',


### PR DESCRIPTION
## Submission Checklist

 - [ ] Updated the `CHANGELOG.md` to reflect any **feature**, **bug fixes**, or **known issues** made in the source code
 - [x] Tested code changes and observed expected behavior in the example app
 - [x] Performed a visual inspection of the `Files changed` tab prior to submitting the pull request for review to ensure proper usage of the style guide

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Description

This PR removes the JS layer Call and Call Invite caches. This ensures that invoking getCall or getCallInvites will always provide the most up to date information from the native layer.

This PR also updates the example app with more utility to test these changes.

## Breakdown

- Remove Call and Call Invite caches.
- Add docstrings for some existing functions.
- Update example app.

## Validation

- Manually tested with example app

## Additional Notes

JIRA Link: https://issues.corp.twilio.com/browse/VBLOCKS-396
