### PR TITLE
[VBLOCKS-1115] fix: rename references to addEventListener to addListener

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,9 @@
-1.0.0-beta.1 (November 1, 2022)
-===============================
+1.0.0-beta.1 (In Progress)
+==========================
 
 ## Fixes
 
-- Fix incorrectly exported types and references to `addEventListener`, instead now correctly exporting as `addListener`.
+- Fixed an issue where some types on the `Call` and `Voice` classes were being incorrectly exported. Types and references to `addEventListener` are instead now correctly exported as `addListener`.
 
 1.0.0-preview.1 (September 1, 2022)
 ===================================

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,11 @@
+1.0.0-beta.1 (November 1, 2022)
+===============================
+
+## Fixes
+
+- Fix incorrectly exported types and references to `addEventListener`, instead now correctly exporting as `addListener`.
+
 1.0.0-preview.1 (September 1, 2022)
-=================================
+===================================
 
 - This is the initial preview release of Twilio Voice React Native SDK. Please check out the [README](README.md) for more details.

--- a/api/voice-react-native-sdk.api.md
+++ b/api/voice-react-native-sdk.api.md
@@ -35,14 +35,14 @@ export namespace AudioDevice {
 
 // @public
 export interface Call {
-    addEventListener(callEvent: Call.Event, listener: Call.Listener.Generic): this;
-    addEventListener(connectedEvent: Call.Event.Connected, listener: Call.Listener.Connected): this;
-    addEventListener(connectFailureEvent: Call.Event.ConnectFailure, listener: Call.Listener.ConnectFailure): this;
-    addEventListener(reconnectingEvent: Call.Event.Reconnecting, listener: Call.Listener.Reconnecting): this;
-    addEventListener(reconnectedEvent: Call.Event.Reconnected, listener: Call.Listener.Reconnected): this;
-    addEventListener(disconnectedEvent: Call.Event.Disconnected, listener: Call.Listener.Disconnected): this;
-    addEventListener(ringingEvent: Call.Event.Ringing, listener: Call.Listener.Ringing): this;
-    addEventListener(qualityWarningsChangedEvent: Call.Event.QualityWarningsChanged, listener: Call.Listener.QualityWarningsChanged): this;
+    addListener(callEvent: Call.Event, listener: Call.Listener.Generic): this;
+    addListener(connectedEvent: Call.Event.Connected, listener: Call.Listener.Connected): this;
+    addListener(connectFailureEvent: Call.Event.ConnectFailure, listener: Call.Listener.ConnectFailure): this;
+    addListener(reconnectingEvent: Call.Event.Reconnecting, listener: Call.Listener.Reconnecting): this;
+    addListener(reconnectedEvent: Call.Event.Reconnected, listener: Call.Listener.Reconnected): this;
+    addListener(disconnectedEvent: Call.Event.Disconnected, listener: Call.Listener.Disconnected): this;
+    addListener(ringingEvent: Call.Event.Ringing, listener: Call.Listener.Ringing): this;
+    addListener(qualityWarningsChangedEvent: Call.Event.QualityWarningsChanged, listener: Call.Listener.QualityWarningsChanged): this;
     // @internal (undocumented)
     emit(connectedEvent: Call.Event.Connected): boolean;
     // @internal (undocumented)
@@ -367,15 +367,15 @@ export { TwilioErrors }
 
 // @public
 export interface Voice {
-    addEventListener(voiceEvent: Voice.Event, listener: Voice.Listener.Generic): this;
-    addEventListener(audioDevicesUpdatedEvent: Voice.Event.AudioDevicesUpdated, listener: Voice.Listener.AudioDevicesUpdated): this;
-    addEventListener(callInviteEvent: Voice.Event.CallInvite, listener: Voice.Listener.CallInvite): this;
-    addEventListener(callInviteAcceptedEvent: Voice.Event.CallInviteAccepted, listener: Voice.Listener.CallInviteAccepted): this;
-    addEventListener(callInviteRejectedEvent: Voice.Event.CallInviteRejected, listener: Voice.Listener.CallInviteRejected): this;
-    addEventListener(cancelledCallInviteEvent: Voice.Event.CancelledCallInvite, listener: Voice.Listener.CancelledCallInvite): this;
-    addEventListener(errorEvent: Voice.Event.Error, listener: Voice.Listener.Error): this;
-    addEventListener(registeredEvent: Voice.Event.Registered, listener: Voice.Listener.Registered): this;
-    addEventListener(unregisteredEvent: Voice.Event.Unregistered, listener: Voice.Listener.Unregistered): this;
+    addListener(voiceEvent: Voice.Event, listener: Voice.Listener.Generic): this;
+    addListener(audioDevicesUpdatedEvent: Voice.Event.AudioDevicesUpdated, listener: Voice.Listener.AudioDevicesUpdated): this;
+    addListener(callInviteEvent: Voice.Event.CallInvite, listener: Voice.Listener.CallInvite): this;
+    addListener(callInviteAcceptedEvent: Voice.Event.CallInviteAccepted, listener: Voice.Listener.CallInviteAccepted): this;
+    addListener(callInviteRejectedEvent: Voice.Event.CallInviteRejected, listener: Voice.Listener.CallInviteRejected): this;
+    addListener(cancelledCallInviteEvent: Voice.Event.CancelledCallInvite, listener: Voice.Listener.CancelledCallInvite): this;
+    addListener(errorEvent: Voice.Event.Error, listener: Voice.Listener.Error): this;
+    addListener(registeredEvent: Voice.Event.Registered, listener: Voice.Listener.Registered): this;
+    addListener(unregisteredEvent: Voice.Event.Unregistered, listener: Voice.Listener.Unregistered): this;
     // @internal (undocumented)
     emit(voiceEvent: Voice.Event, listener: (...args: any[]) => void): boolean;
     // @internal (undocumented)

--- a/src/Call.tsx
+++ b/src/Call.tsx
@@ -22,7 +22,7 @@ import { GenericError } from './error/GenericError';
  * | Call objects}.
  *
  * @remarks
- * Note that the `on` function is an alias for the `addEventListener` function.
+ * Note that the `on` function is an alias for the `addListener` function.
  * They share identical functionality and either may be used interchangeably.
  *
  * - See also the {@link (Call:class) | Call class}.
@@ -84,12 +84,9 @@ export declare interface Call {
    * is raised.
    * @returns - The call object.
    */
-  addEventListener(
-    callEvent: Call.Event,
-    listener: Call.Listener.Generic
-  ): this;
+  addListener(callEvent: Call.Event, listener: Call.Listener.Generic): this;
   /**
-   * {@inheritDoc (Call:interface).(addEventListener:1)}
+   * {@inheritDoc (Call:interface).(addListener:1)}
    */
   on(callEvent: Call.Event, listener: Call.Listener.Generic): this;
 
@@ -98,7 +95,7 @@ export declare interface Call {
    *
    * @example
    * ```typescript
-   * call.addEventListener(Call.Event.Connected, () => {
+   * call.addListener(Call.Event.Connected, () => {
    *   // call has been connected
    * });
    * ```
@@ -108,12 +105,12 @@ export declare interface Call {
    * is raised.
    * @returns - The call object.
    */
-  addEventListener(
+  addListener(
     connectedEvent: Call.Event.Connected,
     listener: Call.Listener.Connected
   ): this;
   /**
-   * {@inheritDoc (Call:interface).(addEventListener:2)}
+   * {@inheritDoc (Call:interface).(addListener:2)}
    */
   on(
     connectedEvent: Call.Event.Connected,
@@ -125,7 +122,7 @@ export declare interface Call {
    *
    * @example
    * ```typescript
-   * call.addEventListener(Call.Event.ConnectFailure, (error) => {
+   * call.addListener(Call.Event.ConnectFailure, (error) => {
    *   // call was unable to connect, handle error
    * });
    * ```
@@ -135,12 +132,12 @@ export declare interface Call {
    * is raised.
    * @returns - The call object.
    */
-  addEventListener(
+  addListener(
     connectFailureEvent: Call.Event.ConnectFailure,
     listener: Call.Listener.ConnectFailure
   ): this;
   /**
-   * {@inheritDoc (Call:interface).(addEventListener:3)}
+   * {@inheritDoc (Call:interface).(addListener:3)}
    */
   on(
     connectFailureEvent: Call.Event.ConnectFailure,
@@ -152,7 +149,7 @@ export declare interface Call {
    *
    * @example
    * ```typescript
-   * call.addEventListener(Call.Event.Reconnecting, (error) => {
+   * call.addListener(Call.Event.Reconnecting, (error) => {
    *   // call is attempting to reconnect, handle error
    * });
    * ```
@@ -162,12 +159,12 @@ export declare interface Call {
    * is raised.
    * @returns - The call object.
    */
-  addEventListener(
+  addListener(
     reconnectingEvent: Call.Event.Reconnecting,
     listener: Call.Listener.Reconnecting
   ): this;
   /**
-   * {@inheritDoc (Call:interface).(addEventListener:4)}
+   * {@inheritDoc (Call:interface).(addListener:4)}
    */
   on(
     reconnectingEvent: Call.Event.Reconnecting,
@@ -179,7 +176,7 @@ export declare interface Call {
    *
    * @example
    * ```typescript
-   * call.addEventListener(Call.Event.Reconnected, () => {
+   * call.addListener(Call.Event.Reconnected, () => {
    *   // call has reconnected
    * });
    * ```
@@ -189,12 +186,12 @@ export declare interface Call {
    * is raised.
    * @returns - The call object.
    */
-  addEventListener(
+  addListener(
     reconnectedEvent: Call.Event.Reconnected,
     listener: Call.Listener.Reconnected
   ): this;
   /**
-   * {@inheritDoc (Call:interface).(addEventListener:5)}
+   * {@inheritDoc (Call:interface).(addListener:5)}
    */
   on(
     reconnectedEvent: Call.Event.Reconnected,
@@ -212,7 +209,7 @@ export declare interface Call {
    *
    * @example
    * ```typescript
-   * call.addEventListener(Call.Event.Disconnected, (error) => {
+   * call.addListener(Call.Event.Disconnected, (error) => {
    *   // call has disconnected
    *   // if a natural disconnect occurred, then error is `undefined`
    *   // if an unnatural disconnect occurred, then error is defined
@@ -224,12 +221,12 @@ export declare interface Call {
    * is raised.
    * @returns - The call object.
    */
-  addEventListener(
+  addListener(
     disconnectedEvent: Call.Event.Disconnected,
     listener: Call.Listener.Disconnected
   ): this;
   /**
-   * {@inheritDoc (Call:interface).(addEventListener:6)}
+   * {@inheritDoc (Call:interface).(addListener:6)}
    */
   on(
     disconnectedEvent: Call.Event.Disconnected,
@@ -241,7 +238,7 @@ export declare interface Call {
    *
    * @example
    * ```typescript
-   * call.addEventListener(Call.Event.Ringing, () => {
+   * call.addListener(Call.Event.Ringing, () => {
    *   // call is ringing
    * });
    * ```
@@ -251,12 +248,12 @@ export declare interface Call {
    * is raised.
    * @returns - The call object.
    */
-  addEventListener(
+  addListener(
     ringingEvent: Call.Event.Ringing,
     listener: Call.Listener.Ringing
   ): this;
   /**
-   * {@inheritDoc (Call:interface).(addEventListener:7)}
+   * {@inheritDoc (Call:interface).(addListener:7)}
    */
   on(ringingEvent: Call.Event.Ringing, listener: Call.Listener.Ringing): this;
 
@@ -267,7 +264,7 @@ export declare interface Call {
    *
    * @example
    * ```typescript
-   * call.addEventListener(
+   * call.addListener(
    *   Call.Event.QualityWarningsChanged,
    *   (
    *      currentWarnings: Call.QualityWarning[],
@@ -283,12 +280,12 @@ export declare interface Call {
    * is raised.
    * @returns - The call object.
    */
-  addEventListener(
+  addListener(
     qualityWarningsChangedEvent: Call.Event.QualityWarningsChanged,
     listener: Call.Listener.QualityWarningsChanged
   ): this;
   /**
-   * {@inheritDoc (Call:interface).(addEventListener:8)}
+   * {@inheritDoc (Call:interface).(addListener:8)}
    */
   on(
     qualityWarningsChangedEvent: Call.Event.QualityWarningsChanged,
@@ -831,43 +828,43 @@ export namespace Call {
   export enum Event {
     /**
      * Event string for the `Connected` event.
-     * See {@link (Call:interface).(addEventListener:2)}.
+     * See {@link (Call:interface).(addListener:2)}.
      */
     'Connected' = 'connected',
 
     /**
      * Event string for the `ConnectedFailure` event.
-     * See {@link (Call:interface).(addEventListener:3)}.
+     * See {@link (Call:interface).(addListener:3)}.
      */
     'ConnectFailure' = 'connectFailure',
 
     /**
      * Event string for the `Reconnecting` event.
-     * See {@link (Call:interface).(addEventListener:4)}.
+     * See {@link (Call:interface).(addListener:4)}.
      */
     'Reconnecting' = 'reconnecting',
 
     /**
      * Event string for the `Reconnected` event.
-     * See {@link (Call:interface).(addEventListener:5)}.
+     * See {@link (Call:interface).(addListener:5)}.
      */
     'Reconnected' = 'reconnected',
 
     /**
      * Event string for the `Disconnected` event.
-     * See {@link (Call:interface).(addEventListener:6)}.
+     * See {@link (Call:interface).(addListener:6)}.
      */
     'Disconnected' = 'disconnected',
 
     /**
      * Event string for the `Ringing` event.
-     * See {@link (Call:interface).(addEventListener:7)}.
+     * See {@link (Call:interface).(addListener:7)}.
      */
     'Ringing' = 'ringing',
 
     /**
      * Event string for the `QualityWarningsChanged` event.
-     * See {@link (Call:interface).(addEventListener:8)}.
+     * See {@link (Call:interface).(addListener:8)}.
      */
     'QualityWarningsChanged' = 'qualityWarningsChanged',
   }
@@ -880,7 +877,7 @@ export namespace Call {
      * Call `Connected` state. Occurs when the `Connected` event is raised.
      *
      * @remarks
-     * See {@link (Call:interface).(addEventListener:2)}.
+     * See {@link (Call:interface).(addListener:2)}.
      */
     'Connected' = 'connected',
 
@@ -888,7 +885,7 @@ export namespace Call {
      * Call `Connecting` state. Occurs when the `Connecting` event is raised.
      *
      * @remarks
-     * See {@link (Call:interface).(addEventListener:3)}.
+     * See {@link (Call:interface).(addListener:3)}.
      */
     'Connecting' = 'connecting',
 
@@ -897,7 +894,7 @@ export namespace Call {
      * raised.
      *
      * @remarks
-     * See {@link (Call:interface).(addEventListener:4)}.
+     * See {@link (Call:interface).(addListener:4)}.
      */
     'Disconnected' = 'disconnected',
 
@@ -905,7 +902,7 @@ export namespace Call {
      * Call `Reconnected` state. Occurs when the `Reconnected` event is raised.
      *
      * @remarks
-     * See {@link (Call:interface).(addEventListener:5)}.
+     * See {@link (Call:interface).(addListener:5)}.
      */
     'Reconnecting' = 'reconnected',
 
@@ -913,7 +910,7 @@ export namespace Call {
      * Call `Ringing` state. Occurs when the `Ringing` event is raised.
      *
      * @remarks
-     * See {@link (Call:interface).(addEventListener:6)}.
+     * See {@link (Call:interface).(addListener:6)}.
      */
     'Ringing' = 'ringing',
   }
@@ -1042,7 +1039,7 @@ export namespace Call {
      * event listener bound to any call event.
      *
      * @remarks
-     * See {@link (Call:interface).(addEventListener:1)}.
+     * See {@link (Call:interface).(addListener:1)}.
      */
     export type Generic = (...args: any[]) => void;
 
@@ -1052,7 +1049,7 @@ export namespace Call {
      * event.
      *
      * @remarks
-     * See {@link (Call:interface).(addEventListener:2)}.
+     * See {@link (Call:interface).(addListener:2)}.
      */
     export type Connected = () => void;
 
@@ -1062,7 +1059,7 @@ export namespace Call {
      * {@link (Call:namespace).Event.ConnectFailure} event.
      *
      * @remarks
-     * See {@link (Call:interface).(addEventListener:3)}.
+     * See {@link (Call:interface).(addListener:3)}.
      */
     export type ConnectFailure = (error: GenericError) => void;
 
@@ -1072,7 +1069,7 @@ export namespace Call {
      * event.
      *
      * @remarks
-     * See {@link (Call:interface).(addEventListener:4)}.
+     * See {@link (Call:interface).(addListener:4)}.
      */
     export type Reconnecting = (error: GenericError) => void;
 
@@ -1082,7 +1079,7 @@ export namespace Call {
      * event.
      *
      * @remarks
-     * See {@link (Call:interface).(addEventListener:5)}.
+     * See {@link (Call:interface).(addListener:5)}.
      */
     export type Reconnected = () => void;
 
@@ -1092,7 +1089,7 @@ export namespace Call {
      * event.
      *
      * @remarks
-     * See {@link (Call:interface).(addEventListener:6)}.
+     * See {@link (Call:interface).(addListener:6)}.
      */
     export type Disconnected = (error?: GenericError) => void;
 
@@ -1101,7 +1098,7 @@ export namespace Call {
      * event listener bound to the {@link (Call:namespace).Event.Ringing} event.
      *
      * @remarks
-     * See {@link (Call:interface).(addEventListener:7)}.
+     * See {@link (Call:interface).(addListener:7)}.
      */
     export type Ringing = () => void;
 
@@ -1111,7 +1108,7 @@ export namespace Call {
      * {@link (Call:namespace).Event.QualityWarningsChanged} event.
      *
      * @remarks
-     * See {@link (Call:interface).(addEventListener:8)}.
+     * See {@link (Call:interface).(addListener:8)}.
      */
     export type QualityWarningsChanged = (
       currentQualityWarnings: Call.QualityWarning[],

--- a/src/Voice.tsx
+++ b/src/Voice.tsx
@@ -24,7 +24,7 @@ import type { NativeVoiceEvent, NativeVoiceEventType } from './type/Voice';
  * | Voice objects}.
  *
  * @remarks
- * Note that the `on` function is an alias for the `addEventListener` function.
+ * Note that the `on` function is an alias for the `addListener` function.
  * They share identical functionality and either may be used interchangeably.
  *
  * - See also the {@link (Voice:class) | Voice class}.
@@ -94,11 +94,8 @@ export declare interface Voice {
    * is raised.
    * @returns - The call object.
    */
-  addEventListener(
-    voiceEvent: Voice.Event,
-    listener: Voice.Listener.Generic
-  ): this;
-  /** {@inheritDoc (Voice:interface).(addEventListener:1)} */
+  addListener(voiceEvent: Voice.Event, listener: Voice.Listener.Generic): this;
+  /** {@inheritDoc (Voice:interface).(addListener:1)} */
   on(voiceEvent: Voice.Event, listener: Voice.Listener.Generic): this;
 
   /**
@@ -106,7 +103,7 @@ export declare interface Voice {
    *
    * @example
    * ```typescript
-   * voice.addEventListener(Voice.Event.AudioDevicesUpdated, () => {
+   * voice.addListener(Voice.Event.AudioDevicesUpdated, () => {
    *   // the list of available audio devices has changed and/or the selected
    *   // audio device has been changed
    * });
@@ -117,11 +114,11 @@ export declare interface Voice {
    * is raised.
    * @returns - The call object.
    */
-  addEventListener(
+  addListener(
     audioDevicesUpdatedEvent: Voice.Event.AudioDevicesUpdated,
     listener: Voice.Listener.AudioDevicesUpdated
   ): this;
-  /** {@inheritDoc (Voice:interface).(addEventListener:2)} */
+  /** {@inheritDoc (Voice:interface).(addListener:2)} */
   on(
     audioDevicesUpdatedEvent: Voice.Event.AudioDevicesUpdated,
     listener: Voice.Listener.AudioDevicesUpdated
@@ -132,7 +129,7 @@ export declare interface Voice {
    *
    * @example
    * ```typescript
-   * voice.addEventListener(Voice.Event.CallInvite, (callInvite: CallInvite) => {
+   * voice.addListener(Voice.Event.CallInvite, (callInvite: CallInvite) => {
    *   // handle the incoming call invite
    * });
    * ```
@@ -142,11 +139,11 @@ export declare interface Voice {
    * is raised.
    * @returns - The call object.
    */
-  addEventListener(
+  addListener(
     callInviteEvent: Voice.Event.CallInvite,
     listener: Voice.Listener.CallInvite
   ): this;
-  /** {@inheritDoc (Voice:interface).(addEventListener:3)} */
+  /** {@inheritDoc (Voice:interface).(addListener:3)} */
   on(
     callInviteEvent: Voice.Event.CallInvite,
     listener: Voice.Listener.CallInvite
@@ -162,7 +159,7 @@ export declare interface Voice {
    *
    * @example
    * ```typescript
-   * voice.addEventListener(Voice.Event.CallInviteAccepted, (callInvite: CallInvite, call: Call) => {
+   * voice.addListener(Voice.Event.CallInviteAccepted, (callInvite: CallInvite, call: Call) => {
    *   // handle the incoming call invite and the call associated with it
    * });
    * ```
@@ -172,11 +169,11 @@ export declare interface Voice {
    * is raised.
    * @returns - The call object.
    */
-  addEventListener(
+  addListener(
     callInviteAcceptedEvent: Voice.Event.CallInviteAccepted,
     listener: Voice.Listener.CallInviteAccepted
   ): this;
-  /** {@inheritDoc (Voice:interface).(addEventListener:4)} */
+  /** {@inheritDoc (Voice:interface).(addListener:4)} */
   on(
     callInviteAcceptedEvent: Voice.Event.CallInviteAccepted,
     listener: Voice.Listener.CallInviteAccepted
@@ -192,7 +189,7 @@ export declare interface Voice {
    *
    * @example
    * ```typescript
-   * voice.addEventListener(Voice.Event.CallInviteRejected, (callInvite: CallInvite) => {
+   * voice.addListener(Voice.Event.CallInviteRejected, (callInvite: CallInvite) => {
    *   // handle the rejection of the incoming call invite
    * });
    * ```
@@ -202,11 +199,11 @@ export declare interface Voice {
    * is raised.
    * @returns - The call object.
    */
-  addEventListener(
+  addListener(
     callInviteRejectedEvent: Voice.Event.CallInviteRejected,
     listener: Voice.Listener.CallInviteRejected
   ): this;
-  /** {@inheritDoc (Voice:interface).(addEventListener:5)} */
+  /** {@inheritDoc (Voice:interface).(addListener:5)} */
   on(
     callInviteRejectedEvent: Voice.Event.CallInviteRejected,
     listener: Voice.Listener.CallInviteRejected
@@ -218,7 +215,7 @@ export declare interface Voice {
    *
    * @example
    * ```typescript
-   * voice.addEventListener(Voice.Event.CancelledCallInvite, (cancelledCallInvite: CancelledCallInvite) => {
+   * voice.addListener(Voice.Event.CancelledCallInvite, (cancelledCallInvite: CancelledCallInvite) => {
    *   // handle the cancellation of the incoming call invite
    * });
    * ```
@@ -228,11 +225,11 @@ export declare interface Voice {
    * is raised.
    * @returns - The call object.
    */
-  addEventListener(
+  addListener(
     cancelledCallInviteEvent: Voice.Event.CancelledCallInvite,
     listener: Voice.Listener.CancelledCallInvite
   ): this;
-  /** {@inheritDoc (Voice:interface).(addEventListener:6)} */
+  /** {@inheritDoc (Voice:interface).(addListener:6)} */
   on(
     cancelledCallInviteEvent: Voice.Event.CancelledCallInvite,
     listener: Voice.Listener.CancelledCallInvite
@@ -243,7 +240,7 @@ export declare interface Voice {
    *
    * @example
    * ```typescript
-   * voice.addEventListener(Voice.Event.Error, (error: TwilioError.GenericError) => {
+   * voice.addListener(Voice.Event.Error, (error: TwilioError.GenericError) => {
    *   // handle a generic Voice SDK error
    * });
    * ```
@@ -253,11 +250,11 @@ export declare interface Voice {
    * is raised.
    * @returns - The call object.
    */
-  addEventListener(
+  addListener(
     errorEvent: Voice.Event.Error,
     listener: Voice.Listener.Error
   ): this;
-  /** {@inheritDoc (Voice:interface).(addEventListener:7)} */
+  /** {@inheritDoc (Voice:interface).(addListener:7)} */
   on(errorEvent: Voice.Event.Error, listener: Voice.Listener.Error): this;
 
   /**
@@ -265,7 +262,7 @@ export declare interface Voice {
    *
    * @example
    * ```typescript
-   * voice.addEventListener(Voice.Event.Registered, () => {
+   * voice.addListener(Voice.Event.Registered, () => {
    *   // handle successful registration for incoming calls
    * });
    * ```
@@ -275,11 +272,11 @@ export declare interface Voice {
    * is raised.
    * @returns - The call object.
    */
-  addEventListener(
+  addListener(
     registeredEvent: Voice.Event.Registered,
     listener: Voice.Listener.Registered
   ): this;
-  /** {@inheritDoc (Voice:interface).(addEventListener:8)} */
+  /** {@inheritDoc (Voice:interface).(addListener:8)} */
   on(
     registeredEvent: Voice.Event.Registered,
     listener: Voice.Listener.Registered
@@ -290,7 +287,7 @@ export declare interface Voice {
    *
    * @example
    * ```typescript
-   * voice.addEventListener(Voice.Event.Unregistered, () => {
+   * voice.addListener(Voice.Event.Unregistered, () => {
    *   // handle successful unregistration for incoming calls
    * });
    * ```
@@ -300,11 +297,11 @@ export declare interface Voice {
    * is raised.
    * @returns - The call object.
    */
-  addEventListener(
+  addListener(
     unregisteredEvent: Voice.Event.Unregistered,
     listener: Voice.Listener.Unregistered
   ): this;
-  /** {@inheritDoc (Voice:interface).(addEventListener:9)} */
+  /** {@inheritDoc (Voice:interface).(addListener:9)} */
   on(
     unregisteredEvent: Voice.Event.Unregistered,
     listener: Voice.Listener.Unregistered
@@ -763,55 +760,55 @@ export namespace Voice {
   export enum Event {
     /**
      * Raised when there is a change in available audio devices.
-     * See {@link (Voice:interface).(addEventListener:2)
-     * | Voice.addEventListener(AudioDevicesUpdated)}.
+     * See {@link (Voice:interface).(addListener:2)
+     * | Voice.addListener(AudioDevicesUpdated)}.
      */
     'AudioDevicesUpdated' = 'audioDevicesUpdated',
     /**
      * Raised when there is an incoming call invite.
-     * See {@link (Voice:interface).(addEventListener:3)
-     * | Voice.addEventListener(CallInvite)}.
+     * See {@link (Voice:interface).(addListener:3)
+     * | Voice.addListener(CallInvite)}.
      */
     'CallInvite' = 'callInvite',
     /**
      * Raised when an incoming call invite has been accepted.
      * This event can be raised either through the SDK or outside of the SDK
      * (i.e. through native UI/UX such as push notifications).
-     * See {@link (Voice:interface).(addEventListener:4)
-     * | Voice.addEventListener(CallInviteAccepted)}.
+     * See {@link (Voice:interface).(addListener:4)
+     * | Voice.addListener(CallInviteAccepted)}.
      */
     'CallInviteAccepted' = 'callInviteAccepted',
     /**
      * Raised when an incoming call invite has been rejected.
      * This event can be raised either through the SDK or outside of the SDK
      * (i.e. through native UI/UX such as push notifications).
-     * See {@link (Voice:interface).(addEventListener:5)
-     * | Voice.addEventListener(CallInviteRejected)}.
+     * See {@link (Voice:interface).(addListener:5)
+     * | Voice.addListener(CallInviteRejected)}.
      */
     'CallInviteRejected' = 'callInviteRejected',
     /**
      * Raised when an incoming call invite has been cancelled, thus invalidating
      * the associated call invite.
-     * See {@link (Voice:interface).(addEventListener:6)
-     * | Voice.addEventListener(CancelledCallInvite)}.
+     * See {@link (Voice:interface).(addListener:6)
+     * | Voice.addListener(CancelledCallInvite)}.
      */
     'CancelledCallInvite' = 'cancelledCallInvite',
     /**
      * Raised when the SDK encounters an error.
-     * See {@link (Voice:interface).(addEventListener:7)
-     * | Voice.addEventListener(Error)}.
+     * See {@link (Voice:interface).(addListener:7)
+     * | Voice.addListener(Error)}.
      */
     'Error' = 'error',
     /**
      * Raised when the SDK is registered for incoming calls.
-     * See {@link (Voice:interface).(addEventListener:8)
-     * | Voice.addEventListener(Registered)}.
+     * See {@link (Voice:interface).(addListener:8)
+     * | Voice.addListener(Registered)}.
      */
     'Registered' = 'registered',
     /**
      * Raised when the SDK is unregistered for incoming calls.
-     * See {@link (Voice:interface).(addEventListener:9)
-     * | Voice.addEventListener(Unregistered)}.
+     * See {@link (Voice:interface).(addListener:9)
+     * | Voice.addListener(Unregistered)}.
      */
     'Unregistered' = 'unregistered',
   }
@@ -826,7 +823,7 @@ export namespace Voice {
      * event listener bound to any voice event.
      *
      * @remarks
-     * See {@link (Voice:interface).(addEventListener:1)}.
+     * See {@link (Voice:interface).(addListener:1)}.
      */
     export type Generic = (...args: any[]) => void;
 
@@ -836,7 +833,7 @@ export namespace Voice {
      * {@link (Voice:namespace).Event.AudioDevicesUpdated} event.
      *
      * @remarks
-     * See {@link (Voice:interface).(addEventListener:2)}.
+     * See {@link (Voice:interface).(addListener:2)}.
      */
     export type AudioDevicesUpdated = (
       audioDevices: AudioDevice[],
@@ -849,7 +846,7 @@ export namespace Voice {
      * {@link (Voice:namespace).Event.CallInvite} event.
      *
      * @remarks
-     * See {@link (Voice:interface).(addEventListener:3)}.
+     * See {@link (Voice:interface).(addListener:3)}.
      */
     export type CallInvite = (callInvite: CallInvite) => void;
 
@@ -859,7 +856,7 @@ export namespace Voice {
      * {@link (Voice:namespace).Event.CallInviteAccepted} event.
      *
      * @remarks
-     * See {@link (Voice:interface).(addEventListener:4)}.
+     * See {@link (Voice:interface).(addListener:4)}.
      */
     export type CallInviteAccepted = (
       callInvite: CallInvite,
@@ -872,7 +869,7 @@ export namespace Voice {
      * {@link (Voice:namespace).Event.CallInviteRejected} event.
      *
      * @remarks
-     * See {@link (Voice:interface).(addEventListener:5)}.
+     * See {@link (Voice:interface).(addListener:5)}.
      */
     export type CallInviteRejected = (callInvite: CallInvite) => void;
 
@@ -882,7 +879,7 @@ export namespace Voice {
      * {@link (Voice:namespace).Event.CancelledCallInvite} event.
      *
      * @remarks
-     * See {@link (Voice:interface).(addEventListener:6)}.
+     * See {@link (Voice:interface).(addListener:6)}.
      */
     export type CancelledCallInvite = (
       cancelledCallInvite: CancelledCallInvite,
@@ -895,7 +892,7 @@ export namespace Voice {
      * {@link (Voice:namespace).Event.Error} event.
      *
      * @remarks
-     * See {@link (Voice:interface).(addEventListener:7)}.
+     * See {@link (Voice:interface).(addListener:7)}.
      */
     export type Error = (error: GenericError) => void;
 
@@ -905,7 +902,7 @@ export namespace Voice {
      * {@link (Voice:namespace).Event.Registered} event.
      *
      * @remarks
-     * See {@link (Voice:interface).(addEventListener:7)}.
+     * See {@link (Voice:interface).(addListener:7)}.
      */
     export type Registered = () => void;
 
@@ -915,7 +912,7 @@ export namespace Voice {
      * {@link (Voice:namespace).Event.Unregistered} event.
      *
      * @remarks
-     * See {@link (Voice:interface).(addEventListener:8)}.
+     * See {@link (Voice:interface).(addListener:8)}.
      */
     export type Unregistered = () => void;
   }


### PR DESCRIPTION
## Submission Checklist

 - [x] Updated the `CHANGELOG.md` to reflect any **feature**, **bug fixes**, or **known issues** made in the source code
 - [x] Tested code changes and observed expected behavior in the example app
 - [x] Performed a visual inspection of the `Files changed` tab prior to submitting the pull request for review to ensure proper usage of the style guide

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Description

This PR fixes references and type exports from the incorrect `addEventListener` to the correct `addListener`.

## Breakdown

- Change `addEventListener` in `Call.tsx`
- Change `addEventListener` in `Voice.tsx`

## Validation

- Test that the app properly binds to the `EventEmitter` objects using the `test-application` and the "new" `addListener` call signature.
- VSCode properly detects docstrings and Intellisense for the "new" function signatures.
- The public API rollup has the "new" function signatures.

## Additional Notes

Tested on Android, cannot personally test on iOS but the iOS e2e tests pass.
