### PR TITLE
VBLOCK-1157 Reenable iOS end-to-end tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,7 +64,7 @@ commands:
       - run:
           name: "Decode creds"
           command: |
-            echo "export const token ='$(curl $ACCESS_TOKEN_URL)'" >> example/src/e2e-tests-token.ts
+            echo "export const token ='$(curl $ACCESS_TOKEN_URL)'" >> test-application/src/e2e-tests-token.ts
   clear-detox-cache:
     description: "Clears detox framework cache"
     steps:
@@ -72,7 +72,7 @@ commands:
           working_directory: .
           name: Clear detox cache
           command: |
-            cd example
+            cd test-application
             detox clean-framework-cache
             detox build-framework-cache
             cd ../
@@ -86,7 +86,7 @@ commands:
       - run:
           name: Detox Build
           command: |
-            cd example
+            cd test-application
             detox build -c <<parameters.configuration>>
             cd ..
           no_output_timeout: 20m
@@ -114,7 +114,7 @@ commands:
       - run:
           name: Detox Test
           command: |
-            cd example
+            cd test-application
             detox test -c <<parameters.configuration>> -l <<parameters.loglevel>> -a=<<parameters.artifacts>> --take-screenshots=<<parameters.screenshots>> --ci --forceExit --detectOpenHandles
             cd ..
 
@@ -130,15 +130,15 @@ jobs:
             - dependencies-
       - restore_cache:
           keys:
-            - dependencies-example-{{ checksum "example/package.json" }}
-            - dependencies-example-
+            - dependencies-test-application-{{ checksum "test-application/package.json" }}
+            - dependencies-test-application-
       - install-dependencies
       - save_cache:
           key: dependencies-{{ checksum "package.json" }}
           paths: node_modules
       - save_cache:
-          key: dependencies-example-{{ checksum "example/package.json" }}
-          paths: example/node_modules
+          key: dependencies-test-application-{{ checksum "test-application/package.json" }}
+          paths: test-application/node_modules
       - persist_to_workspace:
           root: .
           paths: .
@@ -224,7 +224,7 @@ jobs:
           configuration: <<parameters.detox_configuration>>
           artifacts: <<parameters.artifacts_location>>
       - store_artifacts:
-          path: ./example/test-report.html
+          path: ./test-application/test-report.html
 
 ###
 # Workflows

--- a/test-application/e2e/tests/voice/call.voice.spec.ts
+++ b/test-application/e2e/tests/voice/call.voice.spec.ts
@@ -1,0 +1,23 @@
+import { by, element, waitFor } from 'detox';
+
+export const DEFAULT_TIME_OUT = 10000;
+
+async function isVisibleByText(text: string, timeout: number = DEFAULT_TIME_OUT) {
+  await waitFor(element(by.text(text)))
+    .toBeVisible()
+    .withTimeout(timeout);
+}
+
+describe('Voice & Call APIs', () => {
+    it('Voice | Connect | :ios:', async () => {
+        await isVisibleByText('State: undefined');
+        await isVisibleByText('SID: undefined');
+        await isVisibleByText('Connect');
+        await element(by.text('Connect')).tap();
+        await isVisibleByText('State: ringing');
+        await isVisibleByText('State: connected');
+        await isVisibleByText('Disconnect');
+        await element(by.text('Disconnect')).tap();
+        await isVisibleByText('State: disconnected');
+    });
+});


### PR DESCRIPTION
## Submission Checklist

 - [x] Updated the `CHANGELOG.md` to reflect any **feature**, **bug fixes**, or **known issues** made in the source code
 - [x] Tested code changes and observed expected behavior in the example app
 - [x] Performed a visual inspection of the `Files changed` tab prior to submitting the pull request for review to ensure proper usage of the style guide

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Description

Reenable iOS end-to-end tests under the `test-application` folder. A basic call test that executes a <Say> TwiML is added to the tests.

## Breakdown

- Update test application path
- Add basic call test

## Validation

- CircleCI: https://app.circleci.com/pipelines/github/twilio/twilio-voice-react-native/303/workflows/61762915-b497-4f13-874d-d8a48ed050bf/jobs/1556
  - Test report: https://output.circle-artifacts.com/output/job/b0582dbc-f772-4bf7-9b83-9440b0d73cea/artifacts/0/test-application/test-report.html
