### PR TITLE
VBLOCKS-1357: Added a generic blurb about how displayName can be used when passed as a custom param

### DIFF
--- a/android/src/main/java/com/twiliovoicereactnative/NotificationUtility.java
+++ b/android/src/main/java/com/twiliovoicereactnative/NotificationUtility.java
@@ -336,6 +336,8 @@ public class NotificationUtility {
   private static String getDisplayName(CallInvite callInvite) {
     String title = callInvite.getFrom();
     Map<String, String> customParameters = callInvite.getCustomParameters();
+    // If "displayName" is passed as a custom parameters in the TwiML application, 
+    // it will be used as the caller name.
     if (customParameters.get(Constants.DISPLAY_NAME) != null) {
       title = URLDecoder.decode(customParameters.get(Constants.DISPLAY_NAME).replaceAll("\\+", "%20"));
     }

--- a/android/src/main/java/com/twiliovoicereactnative/NotificationUtility.java
+++ b/android/src/main/java/com/twiliovoicereactnative/NotificationUtility.java
@@ -336,7 +336,7 @@ public class NotificationUtility {
   private static String getDisplayName(CallInvite callInvite) {
     String title = callInvite.getFrom();
     Map<String, String> customParameters = callInvite.getCustomParameters();
-    // If "displayName" is passed as a custom parameters in the TwiML application, 
+    // If "displayName" is passed as a custom parameter in the TwiML application, 
     // it will be used as the caller name.
     if (customParameters.get(Constants.DISPLAY_NAME) != null) {
       title = URLDecoder.decode(customParameters.get(Constants.DISPLAY_NAME).replaceAll("\\+", "%20"));

--- a/ios/TwilioVoiceReactNative+CallKit.m
+++ b/ios/TwilioVoiceReactNative+CallKit.m
@@ -37,7 +37,7 @@ NSString * const kCustomParametersKeyDisplayName = @"displayName";
 - (void)reportNewIncomingCall:(TVOCallInvite *)callInvite {
     self.callInviteMap[callInvite.uuid.UUIDString] = callInvite;
     
-    // If "displayName" is passed as a custom parameters in the TwiML application, 
+    // If "displayName" is passed as a custom parameter in the TwiML application, 
     // it will be used as the caller name.
     NSString *handleName = callInvite.from;
     NSDictionary *customParams = callInvite.customParameters;

--- a/ios/TwilioVoiceReactNative+CallKit.m
+++ b/ios/TwilioVoiceReactNative+CallKit.m
@@ -37,7 +37,7 @@ NSString * const kCustomParametersKeyDisplayName = @"displayName";
 - (void)reportNewIncomingCall:(TVOCallInvite *)callInvite {
     self.callInviteMap[callInvite.uuid.UUIDString] = callInvite;
     
-    // Twilio Frontline specific logic
+    // If "displayName" is passed as a custom parameters in the TwiML application, it will be used as the caller name
     NSString *handleName = callInvite.from;
     NSDictionary *customParams = callInvite.customParameters;
     if (customParams[kCustomParametersKeyDisplayName]) {

--- a/ios/TwilioVoiceReactNative+CallKit.m
+++ b/ios/TwilioVoiceReactNative+CallKit.m
@@ -37,7 +37,8 @@ NSString * const kCustomParametersKeyDisplayName = @"displayName";
 - (void)reportNewIncomingCall:(TVOCallInvite *)callInvite {
     self.callInviteMap[callInvite.uuid.UUIDString] = callInvite;
     
-    // If "displayName" is passed as a custom parameters in the TwiML application, it will be used as the caller name
+    // If "displayName" is passed as a custom parameters in the TwiML application, 
+    // it will be used as the caller name.
     NSString *handleName = callInvite.from;
     NSDictionary *customParams = callInvite.customParameters;
     if (customParams[kCustomParametersKeyDisplayName]) {


### PR DESCRIPTION

## Submission Checklist

 - [x] Updated the `CHANGELOG.md` to reflect any **feature**, **bug fixes**, or **known issues** made in the source code
 - [x] Tested code changes and observed expected behavior in the example app
 - [x] Performed a visual inspection of the `Files changed` tab prior to submitting the pull request for review to ensure proper usage of the style guide

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Description

Removed frontline specific comment around `displayName`. Added a generic blurb about how `displayName` can be used when passed as a custom param.

## Validation

- No code change