### PR TITLE
[VBLOCKS-1237] Android 12 updates.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@
 - Fixed an issue where some types on the `Call` and `Voice` classes were being incorrectly exported. Types and references to `addEventListener` are instead now correctly exported as `addListener`.
 - Fixed an issue where available audio devices were sometimes incorrectly emitted and returned by the SDK on Android platforms. This occurs more frequently in development environments when the JS bundle is reloaded, but could happen in production environments as well.
 - Fixed a warning that occurred on more recent versions of React Native when the SDK constructed a `NativeEventEmitter`.
-- Fixed an issue where devices running Android 12+ encountered crashing when receiving an incoming call.
+- Fixed an issue where devices running Android 12+ encountered crashes when receiving an incoming call or making an outgoing call.
 
 1.0.0-preview.1 (September 1, 2022)
 ===================================

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 - Fixed an issue where some types on the `Call` and `Voice` classes were being incorrectly exported. Types and references to `addEventListener` are instead now correctly exported as `addListener`.
 - Fixed an issue where available audio devices were sometimes incorrectly emitted and returned by the SDK on Android platforms. This occurs more frequently in development environments when the JS bundle is reloaded, but could happen in production environments as well.
 - Fixed a warning that occurred on more recent versions of React Native when the SDK constructed a `NativeEventEmitter`.
+- Fixed an issue where devices running Android 12+ encountered crashing when receiving an incoming call.
 
 1.0.0-preview.1 (September 1, 2022)
 ===================================

--- a/COMMON_ISSUES.md
+++ b/COMMON_ISSUES.md
@@ -3,3 +3,5 @@
 * Running the example app on Android using `yarn run android` may fail if the emulator is still starting up. When this happens, you can re-run the app once the emulator is fully started.
 
 * Running the example app on iOS using `yarn run ios` may fail if the target simulator is not running or a different simulator instance is already running. Usually, quiting the simulator and running `yarn run ios` again will fix the issue.
+
+* Interacting with notifications on Android will not foreground the application.

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -32,11 +32,10 @@ android {
     compileSdkVersion safeExtGet('TwilioVoiceReactNative_compileSdkVersion', 31)
     buildToolsVersion safeExtGet('TwilioVoiceReactNative_buildToolsVersion', '30.0.2')
     defaultConfig {
-        minSdkVersion safeExtGet('TwilioVoiceReactNative_minSdkVersion', 16)
+        minSdkVersion safeExtGet('TwilioVoiceReactNative_minSdkVersion', 21)
         targetSdkVersion safeExtGet('TwilioVoiceReactNative_targetSdkVersion', 29)
         versionCode 1
         versionName "1.0"
-
     }
 
     buildTypes {

--- a/android/src/main/java/com/twiliovoicereactnative/AudioSwitchManager.java
+++ b/android/src/main/java/com/twiliovoicereactnative/AudioSwitchManager.java
@@ -1,9 +1,6 @@
 package com.twiliovoicereactnative;
 
 import android.content.Context;
-import android.os.Build;
-
-import androidx.annotation.RequiresApi;
 
 import com.twilio.audioswitch.AudioDevice;
 import com.twilio.audioswitch.AudioSwitch;
@@ -17,7 +14,6 @@ import java.util.UUID;
  * device changes. Generates UUIDs per audio device when the AudioSwitch library updates available
  * audio devices.
  */
-@RequiresApi(api = Build.VERSION_CODES.N)
 public class AudioSwitchManager {
   /**
    * The functional interface of a listener to be bound to the AudioSwitchManager.

--- a/android/src/main/java/com/twiliovoicereactnative/AudioSwitchManager.java
+++ b/android/src/main/java/com/twiliovoicereactnative/AudioSwitchManager.java
@@ -71,16 +71,17 @@ public class AudioSwitchManager {
     audioSwitch = new AudioSwitch(context);
 
     audioSwitch.start((devices, selectedDevice) -> {
-      devices.forEach((device) -> {
-        audioDevices.clear();
+      audioDevices.clear();
 
+      for (AudioDevice device : devices) {
         String uuid = UUID.randomUUID().toString();
+
         audioDevices.put(uuid, device);
 
         if (device.equals(selectedDevice)) {
           selectedAudioDeviceUuid = uuid;
         }
-      });
+      }
 
       if (this.listener != null) {
         this.listener.apply(audioDevices, selectedAudioDeviceUuid, selectedDevice);

--- a/android/src/main/java/com/twiliovoicereactnative/CallListenerProxy.java
+++ b/android/src/main/java/com/twiliovoicereactnative/CallListenerProxy.java
@@ -2,12 +2,10 @@ package com.twiliovoicereactnative;
 
 import android.content.Context;
 import android.content.Intent;
-import android.os.Build;
 import android.util.Log;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import androidx.annotation.RequiresApi;
 
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.WritableArray;
@@ -34,7 +32,6 @@ import static com.twiliovoicereactnative.ReactNativeArgumentsSerializer.*;
 
 import java.util.Set;
 
-@RequiresApi(api = Build.VERSION_CODES.N)
 class CallListenerProxy implements Call.Listener {
   static final String TAG = "CallListenerProxy";
   private final String uuid;

--- a/android/src/main/java/com/twiliovoicereactnative/IncomingCallNotificationService.java
+++ b/android/src/main/java/com/twiliovoicereactnative/IncomingCallNotificationService.java
@@ -193,7 +193,7 @@ public class IncomingCallNotificationService extends Service {
   private void bringAppToForeground(String callSid, int notificationId, String uuid) {
     NotificationManager notificationManager = (NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE);
     notificationManager.cancel(notificationId);
-    sendBroadcast(new Intent(Intent.ACTION_CLOSE_SYSTEM_DIALOGS));
+    // sendBroadcast(new Intent(Intent.ACTION_CLOSE_SYSTEM_DIALOGS));
     Log.i(TAG, "bringAppToForeground " + uuid + " notificationId" + notificationId);
     startForeground(notificationId, NotificationUtility.createWakeupAppNotification(callSid, notificationId, uuid, NotificationManager.IMPORTANCE_LOW, this));
     Intent intent = new Intent(this, getMainActivityClass(getApplicationContext()));

--- a/android/src/main/java/com/twiliovoicereactnative/IncomingCallNotificationService.java
+++ b/android/src/main/java/com/twiliovoicereactnative/IncomingCallNotificationService.java
@@ -14,6 +14,8 @@ import androidx.lifecycle.Lifecycle;
 import androidx.lifecycle.ProcessLifecycleOwner;
 import androidx.localbroadcastmanager.content.LocalBroadcastManager;
 
+import java.util.Map.Entry;
+
 import com.twilio.voice.AcceptOptions;
 import com.twilio.voice.Call;
 import com.twilio.voice.CallInvite;
@@ -96,7 +98,12 @@ public class IncomingCallNotificationService extends Service {
     Call call = callInvite.accept(this, acceptOptions, new CallListenerProxy(uuid, this));
     Log.i(TAG, "acceptCall" + uuid + " notificationId" + notificationId);
     Storage.callMap.put(uuid, call);
-    Storage.callMap.forEach((key, value) -> Log.i(TAG, "CallInvite UUID accept callMap value " + key + ":" + value));
+    for (Entry<String, Call> entry : Storage.callMap.entrySet()) {
+      String key = entry.getKey();
+      Call value = entry.getValue();
+
+      Log.i(TAG, "CallInvite UUID accept callMap value " + key + ":" + value);
+    }
     Storage.releaseCallInviteStorage(uuid, callInvite.getCallSid(), notificationId, "accept");
 
     NotificationManager notificationManager = (NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE);

--- a/android/src/main/java/com/twiliovoicereactnative/IncomingCallNotificationService.java
+++ b/android/src/main/java/com/twiliovoicereactnative/IncomingCallNotificationService.java
@@ -10,7 +10,6 @@ import android.os.Build;
 import android.os.IBinder;
 import android.util.Log;
 
-import androidx.annotation.RequiresApi;
 import androidx.lifecycle.Lifecycle;
 import androidx.lifecycle.ProcessLifecycleOwner;
 import androidx.localbroadcastmanager.content.LocalBroadcastManager;
@@ -24,7 +23,6 @@ public class IncomingCallNotificationService extends Service {
 
   private static final String TAG = IncomingCallNotificationService.class.getSimpleName();
 
-  @RequiresApi(api = Build.VERSION_CODES.N)
   @Override
   public int onStartCommand(Intent intent, int flags, int startId) {
     String action = intent.getAction();
@@ -84,7 +82,6 @@ public class IncomingCallNotificationService extends Service {
     return null;
   }
 
-  @RequiresApi(api = Build.VERSION_CODES.N)
   private void acceptCall(CallInvite callInvite, int notificationId, String uuid) {
     Log.e(TAG, "CallInvite UUID accept " + uuid);
     endForeground();

--- a/android/src/main/java/com/twiliovoicereactnative/IncomingCallNotificationService.java
+++ b/android/src/main/java/com/twiliovoicereactnative/IncomingCallNotificationService.java
@@ -197,7 +197,6 @@ public class IncomingCallNotificationService extends Service {
   private void bringAppToForeground(String callSid, int notificationId, String uuid) {
     NotificationManager notificationManager = (NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE);
     notificationManager.cancel(notificationId);
-    // sendBroadcast(new Intent(Intent.ACTION_CLOSE_SYSTEM_DIALOGS));
     Log.i(TAG, "bringAppToForeground " + uuid + " notificationId" + notificationId);
     startForeground(notificationId, NotificationUtility.createWakeupAppNotification(callSid, notificationId, uuid, NotificationManager.IMPORTANCE_LOW, this));
     Intent intent = new Intent(this, getMainActivityClass(getApplicationContext()));

--- a/android/src/main/java/com/twiliovoicereactnative/NotificationUtility.java
+++ b/android/src/main/java/com/twiliovoicereactnative/NotificationUtility.java
@@ -19,7 +19,6 @@ import android.os.Bundle;
 import android.util.Log;
 import android.widget.RemoteViews;
 
-import androidx.annotation.RequiresApi;
 import androidx.core.app.NotificationCompat;
 
 import com.twilio.voice.CallInvite;
@@ -29,7 +28,6 @@ import static android.content.Context.AUDIO_SERVICE;
 import java.net.URLDecoder;
 import java.util.Map;
 
-@RequiresApi(api = Build.VERSION_CODES.N)
 public class NotificationUtility {
   private static final String TAG = IncomingCallNotificationService.class.getSimpleName();
 

--- a/android/src/main/java/com/twiliovoicereactnative/NotificationUtility.java
+++ b/android/src/main/java/com/twiliovoicereactnative/NotificationUtility.java
@@ -19,6 +19,7 @@ import android.os.Bundle;
 import android.util.Log;
 import android.widget.RemoteViews;
 
+import androidx.annotation.RequiresApi;
 import androidx.core.app.NotificationCompat;
 
 import com.twilio.voice.CallInvite;
@@ -28,6 +29,7 @@ import static android.content.Context.AUDIO_SERVICE;
 import java.net.URLDecoder;
 import java.util.Map;
 
+@RequiresApi(api = Build.VERSION_CODES.N)
 public class NotificationUtility {
   private static final String TAG = IncomingCallNotificationService.class.getSimpleName();
 
@@ -38,22 +40,21 @@ public class NotificationUtility {
 
     Resources res = context.getResources();
     String packageName = context.getPackageName();
-    int smallIconResId = 0;
-    smallIconResId = res.getIdentifier("ic_notification", "drawable", packageName);
+    int smallIconResId = res.getIdentifier("ic_notification", "drawable", packageName);
 
     Intent rejectIntent = new Intent(context.getApplicationContext(), IncomingCallNotificationService.class);
     rejectIntent.setAction(Constants.ACTION_REJECT);
     rejectIntent.putExtra(Constants.INCOMING_CALL_INVITE, callInvite);
     rejectIntent.putExtra(Constants.NOTIFICATION_ID, notificationId);
     rejectIntent.putExtra(Constants.UUID, uuid);
-    PendingIntent piRejectIntent = PendingIntent.getService(context.getApplicationContext(), 0, rejectIntent, PendingIntent.FLAG_UPDATE_CURRENT);
+    PendingIntent piRejectIntent = PendingIntent.getService(context.getApplicationContext(), 0, rejectIntent, PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE);
 
     Intent acceptIntent = new Intent(context.getApplicationContext(), IncomingCallNotificationService.class);
     acceptIntent.setAction(Constants.ACTION_ACCEPT);
     acceptIntent.putExtra(Constants.INCOMING_CALL_INVITE, callInvite);
     acceptIntent.putExtra(Constants.NOTIFICATION_ID, notificationId);
     acceptIntent.putExtra(Constants.UUID, uuid);
-    PendingIntent piAcceptIntent = PendingIntent.getService(context.getApplicationContext(), 0, acceptIntent, PendingIntent.FLAG_UPDATE_CURRENT);
+    PendingIntent piAcceptIntent = PendingIntent.getService(context.getApplicationContext(), 0, acceptIntent, PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE);
 
     Bitmap icon = BitmapFactory.decodeResource(context.getResources(), R.drawable.ic_call_end_white_24dp);
     String title = getDisplayName(callInvite);
@@ -66,7 +67,7 @@ public class NotificationUtility {
     remoteViews.setOnClickPendingIntent(R.id.button_decline, piRejectIntent);
 
     Intent notification_intent = new Intent(context.getApplicationContext(), IncomingCallNotificationService.class);
-    PendingIntent pendingIntent = PendingIntent.getActivity(context.getApplicationContext(), 0, notification_intent, 0);
+    PendingIntent pendingIntent = PendingIntent.getActivity(context.getApplicationContext(), 0, notification_intent, PendingIntent.FLAG_IMMUTABLE);
 
     remoteViews.setOnClickPendingIntent(R.id.notification, pendingIntent);
 
@@ -123,7 +124,7 @@ public class NotificationUtility {
     notification_intent.setAction(Constants.ACTION_PUSH_APP_TO_FOREGROUND);
     notification_intent.putExtra(Constants.NOTIFICATION_ID, notificationId);
     notification_intent.putExtra(Constants.UUID, uuid);
-    PendingIntent pendingIntent = PendingIntent.getService(context.getApplicationContext(), 0, notification_intent, PendingIntent.FLAG_UPDATE_CURRENT);
+    PendingIntent pendingIntent = PendingIntent.getService(context.getApplicationContext(), 0, notification_intent, PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE);
 
     remoteViews.setOnClickPendingIntent(R.id.tap_to_app, pendingIntent);
 
@@ -133,7 +134,7 @@ public class NotificationUtility {
       endCallIntent.setAction(Constants.ACTION_CALL_DISCONNECT);
       endCallIntent.putExtra(Constants.NOTIFICATION_ID, notificationId);
       endCallIntent.putExtra(Constants.UUID, uuid);
-      PendingIntent piEndCallIntent = PendingIntent.getService(context.getApplicationContext(), 0, endCallIntent, PendingIntent.FLAG_UPDATE_CURRENT);
+      PendingIntent piEndCallIntent = PendingIntent.getService(context.getApplicationContext(), 0, endCallIntent, PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE);
 
       remoteViews.setOnClickPendingIntent(R.id.end_call, piEndCallIntent);
 
@@ -187,7 +188,7 @@ public class NotificationUtility {
     notification_intent.setAction(Constants.ACTION_PUSH_APP_TO_FOREGROUND);
     notification_intent.putExtra(Constants.NOTIFICATION_ID, notificationId);
     notification_intent.putExtra(Constants.UUID, uuid);
-    PendingIntent pendingIntent = PendingIntent.getService(context.getApplicationContext(), 0, notification_intent, PendingIntent.FLAG_UPDATE_CURRENT);
+    PendingIntent pendingIntent = PendingIntent.getService(context.getApplicationContext(), 0, notification_intent, PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE);
 
     remoteViews.setOnClickPendingIntent(R.id.tap_to_app, pendingIntent);
 
@@ -196,7 +197,7 @@ public class NotificationUtility {
       endCallIntent.setAction(Constants.ACTION_CALL_DISCONNECT);
       endCallIntent.putExtra(Constants.NOTIFICATION_ID, notificationId);
       endCallIntent.putExtra(Constants.UUID, uuid);
-      PendingIntent piEndCallIntent = PendingIntent.getService(context.getApplicationContext(), 0, endCallIntent, PendingIntent.FLAG_UPDATE_CURRENT);
+      PendingIntent piEndCallIntent = PendingIntent.getService(context.getApplicationContext(), 0, endCallIntent, PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE);
 
       remoteViews.setOnClickPendingIntent(R.id.end_call, piEndCallIntent);
 
@@ -248,7 +249,7 @@ public class NotificationUtility {
     notification_intent.setAction(Constants.ACTION_PUSH_APP_TO_FOREGROUND);
     notification_intent.putExtra(Constants.NOTIFICATION_ID, notificationId);
     notification_intent.putExtra(Constants.UUID, uuid);
-    PendingIntent pendingIntent = PendingIntent.getService(context.getApplicationContext(), 0, notification_intent, PendingIntent.FLAG_UPDATE_CURRENT);
+    PendingIntent pendingIntent = PendingIntent.getService(context.getApplicationContext(), 0, notification_intent, PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE);
 
     remoteViews.setOnClickPendingIntent(R.id.tap_to_app, pendingIntent);
 
@@ -257,7 +258,7 @@ public class NotificationUtility {
       endCallIntent.setAction(Constants.ACTION_CALL_DISCONNECT);
       endCallIntent.putExtra(Constants.NOTIFICATION_ID, notificationId);
       endCallIntent.putExtra(Constants.UUID, uuid);
-      PendingIntent piEndCallIntent = PendingIntent.getService(context.getApplicationContext(), 0, endCallIntent, PendingIntent.FLAG_UPDATE_CURRENT);
+      PendingIntent piEndCallIntent = PendingIntent.getService(context.getApplicationContext(), 0, endCallIntent, PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE);
 
       remoteViews.setOnClickPendingIntent(R.id.end_call, piEndCallIntent);
 
@@ -294,7 +295,7 @@ public class NotificationUtility {
       // play inbound call ringer on the speaker
     AudioManager audioManager = (AudioManager) context.getSystemService(AUDIO_SERVICE);
     audioManager.setSpeakerphoneOn(true);
-    
+
     NotificationChannel callInviteChannel = new NotificationChannel(Constants.VOICE_CHANNEL_HIGH_IMPORTANCE,
       "Primary Voice Channel", NotificationManager.IMPORTANCE_HIGH);
     String channelId = Constants.VOICE_CHANNEL_HIGH_IMPORTANCE;
@@ -336,7 +337,7 @@ public class NotificationUtility {
   private static String getDisplayName(CallInvite callInvite) {
     String title = callInvite.getFrom();
     Map<String, String> customParameters = callInvite.getCustomParameters();
-    // If "displayName" is passed as a custom parameter in the TwiML application, 
+    // If "displayName" is passed as a custom parameter in the TwiML application,
     // it will be used as the caller name.
     if (customParameters.get(Constants.DISPLAY_NAME) != null) {
       title = URLDecoder.decode(customParameters.get(Constants.DISPLAY_NAME).replaceAll("\\+", "%20"));

--- a/android/src/main/java/com/twiliovoicereactnative/ReactNativeArgumentsSerializer.java
+++ b/android/src/main/java/com/twiliovoicereactnative/ReactNativeArgumentsSerializer.java
@@ -27,6 +27,7 @@ import com.twilio.voice.CallInvite;
 import com.twilio.voice.CancelledCallInvite;
 
 import java.util.Map;
+import java.util.Map.Entry;
 
 /**
  * This class provides static helper functions that serializes native objects into
@@ -40,7 +41,12 @@ public class ReactNativeArgumentsSerializer {
    */
   public static WritableMap serializeCallInviteCustomParameters(CallInvite callInvite) {
     WritableMap customParameters = Arguments.createMap();
-    callInvite.getCustomParameters().forEach(customParameters::putString);
+    for (Entry<String, String> entry : callInvite.getCustomParameters().entrySet()) {
+      String customParameterKey = entry.getKey();
+      String customParameterValue = entry.getValue();
+
+      customParameters.putString(customParameterKey, customParameterValue);
+    }
     return customParameters;
   }
 
@@ -124,10 +130,13 @@ public class ReactNativeArgumentsSerializer {
   public static WritableArray serializeAudioDeviceMapIntoArray(Map<String, AudioDevice> audioDevices) {
     WritableArray audioDeviceInfoArray = Arguments.createArray();
 
-    audioDevices.forEach((uuid, audioDevice) -> {
+    for (Entry<String, AudioDevice> entry : audioDevices.entrySet()) {
+      String uuid = entry.getKey();
+      AudioDevice audioDevice = entry.getValue();
+
       WritableMap audioDeviceInfoMap = serializeAudioDevice(uuid, audioDevice);
       audioDeviceInfoArray.pushMap(audioDeviceInfoMap);
-    });
+    }
 
     return audioDeviceInfoArray;
   }

--- a/android/src/main/java/com/twiliovoicereactnative/ReactNativeArgumentsSerializer.java
+++ b/android/src/main/java/com/twiliovoicereactnative/ReactNativeArgumentsSerializer.java
@@ -18,10 +18,6 @@ import static com.twiliovoicereactnative.CommonConstants.CancelledCallInviteInfo
 import static com.twiliovoicereactnative.CommonConstants.CancelledCallInviteInfoFrom;
 import static com.twiliovoicereactnative.CommonConstants.CancelledCallInviteInfoTo;
 
-import android.os.Build;
-
-import androidx.annotation.RequiresApi;
-
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.WritableArray;
 import com.facebook.react.bridge.WritableMap;
@@ -36,7 +32,6 @@ import java.util.Map;
  * This class provides static helper functions that serializes native objects into
  * React Native (RN) bridge objects emit-able to the JS layer.
  */
-@RequiresApi(api = Build.VERSION_CODES.N)
 public class ReactNativeArgumentsSerializer {
   /**
    * Serializes the custom parameters of a CallInvite.

--- a/android/src/main/java/com/twiliovoicereactnative/TwilioVoiceReactNativeModule.java
+++ b/android/src/main/java/com/twiliovoicereactnative/TwilioVoiceReactNativeModule.java
@@ -32,6 +32,7 @@ import com.twilio.voice.Voice;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.UUID;
 
 import static com.twiliovoicereactnative.AndroidEventEmitter.EVENT_KEY_CALL_INVITE_INFO;
@@ -258,10 +259,13 @@ public class TwilioVoiceReactNativeModule extends ReactContextBaseJavaModule {
   public void voice_getCalls(Promise promise) {
     WritableArray callInfos = Arguments.createArray();
 
-    Storage.callMap.forEach((uuid, call) -> {
+    for (Entry<String, Call> entry : Storage.callMap.entrySet()) {
+      String uuid = entry.getKey();
+      Call call = entry.getValue();
+
       WritableMap callInfo = serializeCall(uuid, call);
       callInfos.pushMap(callInfo);
-    });
+    }
 
     promise.resolve(callInfos);
   }
@@ -270,10 +274,13 @@ public class TwilioVoiceReactNativeModule extends ReactContextBaseJavaModule {
   public void voice_getCallInvites(Promise promise) {
     WritableArray callInviteInfos = Arguments.createArray();
 
-    Storage.callInviteMap.forEach((uuid, callInvite) -> {
+    for (Entry<String, CallInvite> entry : Storage.callInviteMap.entrySet()) {
+      String uuid = entry.getKey();
+      CallInvite callInvite = entry.getValue();
+
       WritableMap callInviteInfo = serializeCallInvite(uuid, callInvite);
       callInviteInfos.pushMap(callInviteInfo);
-    });
+    }
 
     promise.resolve(callInviteInfos);
   }

--- a/android/src/main/java/com/twiliovoicereactnative/TwilioVoiceReactNativeModule.java
+++ b/android/src/main/java/com/twiliovoicereactnative/TwilioVoiceReactNativeModule.java
@@ -182,7 +182,7 @@ public class TwilioVoiceReactNativeModule extends ReactContextBaseJavaModule {
   @RequiresApi(api = Build.VERSION_CODES.N)
   @ReactMethod
   public void voice_connect_android(String accessToken, ReadableMap twimlParams, Promise promise) {
-    Log.e(TAG, String.format("Calling voice_connect"));
+    Log.d(TAG, "Calling voice_connect_android");
     HashMap<String, String> parsedTwimlParams = new HashMap<>();
 
     ReadableMapKeySetIterator iterator = twimlParams.keySetIterator();

--- a/android/src/main/java/com/twiliovoicereactnative/TwilioVoiceReactNativeModule.java
+++ b/android/src/main/java/com/twiliovoicereactnative/TwilioVoiceReactNativeModule.java
@@ -1,11 +1,9 @@
 package com.twiliovoicereactnative;
 
 import android.content.Intent;
-import android.os.Build;
 import android.util.Log;
 
 import androidx.annotation.NonNull;
-import androidx.annotation.RequiresApi;
 
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.Promise;
@@ -59,7 +57,6 @@ public class TwilioVoiceReactNativeModule extends ReactContextBaseJavaModule {
   private final ReactApplicationContext reactContext;
   private final AudioSwitchManager audioSwitchManager;
 
-  @RequiresApi(api = Build.VERSION_CODES.N)
   public TwilioVoiceReactNativeModule(ReactApplicationContext reactContext) {
     super(reactContext);
     this.reactContext = reactContext;
@@ -179,7 +176,6 @@ public class TwilioVoiceReactNativeModule extends ReactContextBaseJavaModule {
     };
   }
 
-  @RequiresApi(api = Build.VERSION_CODES.N)
   @ReactMethod
   public void voice_connect_android(String accessToken, ReadableMap twimlParams, Promise promise) {
     Log.d(TAG, "Calling voice_connect_android");
@@ -258,7 +254,6 @@ public class TwilioVoiceReactNativeModule extends ReactContextBaseJavaModule {
     promise.resolve(null);
   }
 
-  @RequiresApi(api = Build.VERSION_CODES.N)
   @ReactMethod
   public void voice_getCalls(Promise promise) {
     WritableArray callInfos = Arguments.createArray();
@@ -271,7 +266,6 @@ public class TwilioVoiceReactNativeModule extends ReactContextBaseJavaModule {
     promise.resolve(callInfos);
   }
 
-  @RequiresApi(api = Build.VERSION_CODES.N)
   @ReactMethod
   public void voice_getCallInvites(Promise promise) {
     WritableArray callInviteInfos = Arguments.createArray();
@@ -284,7 +278,6 @@ public class TwilioVoiceReactNativeModule extends ReactContextBaseJavaModule {
     promise.resolve(callInviteInfos);
   }
 
-  @RequiresApi(api = Build.VERSION_CODES.N)
   @ReactMethod
   public void voice_getAudioDevices(Promise promise) {
     Map<String, AudioDevice> audioDevices = audioSwitchManager.getAudioDevices();
@@ -300,7 +293,6 @@ public class TwilioVoiceReactNativeModule extends ReactContextBaseJavaModule {
     promise.resolve(audioDeviceInfo);
   }
 
-  @RequiresApi(api = Build.VERSION_CODES.N)
   @ReactMethod
   public void voice_selectAudioDevice(String uuid, Promise promise) {
     AudioDevice audioDevice = audioSwitchManager.getAudioDevices().get(uuid);
@@ -427,7 +419,6 @@ public class TwilioVoiceReactNativeModule extends ReactContextBaseJavaModule {
   }
 
 
-  @RequiresApi(api = Build.VERSION_CODES.N)
   @ReactMethod
   public void call_getStats(String uuid,  Promise promise) {
     Call activeCall = Storage.callMap.get(uuid);
@@ -506,7 +497,6 @@ public class TwilioVoiceReactNativeModule extends ReactContextBaseJavaModule {
 
   // CallInvite
 
-  @RequiresApi(api = Build.VERSION_CODES.N)
   @ReactMethod
   public void callInvite_accept(String callInviteUuid, ReadableMap options, Promise promise) {
     Log.d(TAG, "callInvite_accept uuid" + callInviteUuid);

--- a/android/src/main/java/com/twiliovoicereactnative/TwilioVoiceReactNativePackage.java
+++ b/android/src/main/java/com/twiliovoicereactnative/TwilioVoiceReactNativePackage.java
@@ -1,9 +1,6 @@
 package com.twiliovoicereactnative;
 
-import android.os.Build;
-
 import androidx.annotation.NonNull;
-import androidx.annotation.RequiresApi;
 
 import com.facebook.react.ReactPackage;
 import com.facebook.react.bridge.NativeModule;
@@ -15,8 +12,6 @@ import java.util.Collections;
 import java.util.List;
 
 public class TwilioVoiceReactNativePackage implements ReactPackage {
-
-    @RequiresApi(api = Build.VERSION_CODES.N)
     @NonNull
     @Override
     public List<NativeModule> createNativeModules(@NonNull ReactApplicationContext reactContext) {

--- a/android/src/main/java/com/twiliovoicereactnative/VoiceBroadcastReceiver.java
+++ b/android/src/main/java/com/twiliovoicereactnative/VoiceBroadcastReceiver.java
@@ -17,10 +17,8 @@ import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
-import android.os.Build;
 import android.util.Log;
 
-import androidx.annotation.RequiresApi;
 import androidx.localbroadcastmanager.content.LocalBroadcastManager;
 
 import com.facebook.react.bridge.Arguments;
@@ -91,7 +89,6 @@ public class VoiceBroadcastReceiver extends BroadcastReceiver {
     return instance;
   }
 
-  @RequiresApi(api = Build.VERSION_CODES.N)
   @Override
   public void onReceive(Context context, Intent intent) {
     String action = intent.getAction();


### PR DESCRIPTION
## Submission Checklist

 - [x] Updated the `CHANGELOG.md` to reflect any **feature**, **bug fixes**, or **known issues** made in the source code
 - [x] Tested code changes and observed expected behavior in the example app
 - [x] Performed a visual inspection of the `Files changed` tab prior to submitting the pull request for review to ensure proper usage of the style guide

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Description

This PR updates the required API for the codebase and removes `RequiresApi`. `.forEach` invocations that required API level `24` have been reverted to a more traditional `for each` loop.

This PR also adds `Intent` flags necessary for higher versions of Android.

## Breakdown

- Add `Intent` flags.
- Remove `RequiresApi` decorators.
- Revert `for each` loops.

## Validation

- Ran test app and made client-to-client and client-to-PSTN calls outgoing calls, and incoming client-to-client and PSTN-to-client calls.
- Ran unit tests.

## Additional Notes

N/A
