### PR TITLE
Manage iOS PushKit instance in the iOS TwilioVoiceReactNative native module

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,32 +44,6 @@ yarn add @twilio/voice-react-native-sdk
 The following simple example demonstrates how to make and receive calls. You will need to implement your own `getAccessToken()` method for it to work properly. Please see [Access Tokens](#access-tokens) section for more details or check out the [iOS](https://github.com/twilio/voice-quickstart-ios) and [Android](https://github.com/twilio/voice-quickstart-android) quickstart for examples on how to generate the tokens.
 For more information on the Voice React Native SDK API, refer to the [API Docs](https://github.com/twilio/twilio-voice-react-native/blob/1.0.0-preview.1/docs/voice-react-native-sdk.md) or try running the [example app](example).
 
-## iOS PushKit
-
-The Voice iOS SDK uses the PushKit framework for receiving incoming call push notifications. In order for the app to handle and report the VoIP notifications to CallKit as incoming calls in a timely manner, especially when the app was terminated and launched by the push notification, add the `TwilioVoicePushRegistry` object and initialization to the `AppDelegate.m` (file name may differ) so the app can always respond to the PushKit callbacks and present the incoming call to the users.
-
-
-```.objc
-@interface AppDelegate ()
-
-@property (nonatomic, strong) TwilioVoicePushRegistry *twilioVoicePushRegistry;
-
-@end
-
-- (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
-    // ...
-
-    // Initialize PKPushRegistry at launch
-    self.twilioVoicePushRegistry = [TwilioVoicePushRegistry new];
-    [self.twilioVoicePushRegistry updatePushRegistry];
-
-    return YES;
-}
-```
-
-Failing to follow [the PushKit & CallKit policy](https://developer.apple.com/documentation/pushkit/responding_to_voip_notifications_from_pushkit?language=objc) will result in app not able to receive push notifications from the system and present incoming calls.
-
-
 ```ts
 import { Voice } from '@twilio/voice-react-native-sdk';
 

--- a/ios/TwilioVoiceReactNative.m
+++ b/ios/TwilioVoiceReactNative.m
@@ -66,6 +66,8 @@ static TVODefaultAudioDevice *sTwilioAudioDevice;
 
 @interface TwilioVoiceReactNative ()
 
+@property (nonatomic, strong) TwilioVoicePushRegistry *twilioVoicePushRegistry;
+
 @property(nonatomic, strong) NSData *deviceTokenData;
 @property(nonatomic, strong) NSMutableDictionary *audioDevices;
 @property(nonatomic, strong) NSDictionary *selectedAudioDevice;
@@ -95,6 +97,10 @@ static TVODefaultAudioDevice *sTwilioAudioDevice;
         [self subscribeToNotifications];
         [self initializeCallKit];
         [self initializeAudioDeviceList];
+        
+        // Initialize PKPushRegistry at launch
+        self.twilioVoicePushRegistry = [TwilioVoicePushRegistry new];
+        [self.twilioVoicePushRegistry updatePushRegistry];
     }
 
     return self;

--- a/test/app/ios/TwilioVoiceReactNativeExample/AppDelegate.m
+++ b/test/app/ios/TwilioVoiceReactNativeExample/AppDelegate.m
@@ -7,8 +7,6 @@
 
 #import "AppDelegate.h"
 
-#import "TwilioVoicePushRegistry.h"
-
 #import <React/RCTBridge.h>
 #import <React/RCTBundleURLProvider.h>
 #import <React/RCTRootView.h>
@@ -33,8 +31,6 @@ static void InitializeFlipper(UIApplication *application) {
 
 @interface AppDelegate ()
 
-@property (nonatomic, strong) TwilioVoicePushRegistry *twilioVoicePushRegistry;
-
 @end
 
 @implementation AppDelegate
@@ -56,10 +52,6 @@ static void InitializeFlipper(UIApplication *application) {
   rootViewController.view = rootView;
   self.window.rootViewController = rootViewController;
   [self.window makeKeyAndVisible];
-  
-  // Initialize PKPushRegistry at launch
-  self.twilioVoicePushRegistry = [TwilioVoicePushRegistry new];
-  [self.twilioVoicePushRegistry updatePushRegistry];
   
   return YES;
 }


### PR DESCRIPTION
## Submission Checklist

 - [ ] Updated the `CHANGELOG.md` to reflect any **feature**, **bug fixes**, or **known issues** made in the source code
 - [ ] Tested code changes and observed expected behavior in the example app
 - [ ] Performed a visual inspection of the `Files changed` tab prior to submitting the pull request for review to ensure proper usage of the style guide

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Description

Move iOS PushKit initialization into the `TwilioVoiceReactNative` native module and correct the order of event notification-observation and device token update.

The original guideline from the Voice iOS SDK quickstart initializes the PushKit instance in AppDelegate to ensure push notifications and CallKit VoIP incoming calls work properly (especially when the app is not running). Turns out having the PushKit registry instance in the `TwilioVoiceReactNative` module also guarantees the app to be launched and respond to the incoming notification without violating the iOS PushKit/CallKit policy.

## Breakdown

- Move `TwilioVoicePushRegistry` module initialization from `AppDelegate` to `TwiloVoiceReactNative`
- Update README

## Validation

- Tested incoming call with different app states: running, backgrounded, terminated
- CircleCI
