### PR TITLE
[VBLOCKS-1238] fix(js): native event emitter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 
 - Fixed an issue where some types on the `Call` and `Voice` classes were being incorrectly exported. Types and references to `addEventListener` are instead now correctly exported as `addListener`.
 - Fixed an issue where available audio devices were sometimes incorrectly emitted and returned by the SDK on Android platforms. This occurs more frequently in development environments when the JS bundle is reloaded, but could happen in production environments as well.
+- Fixed a warning that occurred on more recent versions of React Native when the SDK constructed a `NativeEventEmitter`.
 
 1.0.0-preview.1 (September 1, 2022)
 ===================================

--- a/android/src/main/java/com/twiliovoicereactnative/TwilioVoiceReactNativeModule.java
+++ b/android/src/main/java/com/twiliovoicereactnative/TwilioVoiceReactNativeModule.java
@@ -92,6 +92,32 @@ public class TwilioVoiceReactNativeModule extends ReactContextBaseJavaModule {
     MediaPlayerManager.getInstance(reactContext);
   }
 
+  /**
+   * Invoked by React Native, necessary when passing this NativeModule to the constructor of a
+   * NativeEventEmitter on the JS layer.
+   *
+   * Invoked when a listener is added to the NativeEventEmitter.
+   *
+   * @param eventName The string representation of the event.
+   */
+  @ReactMethod
+  public void addListener(String eventName) {
+    Log.d(TAG, String.format("Calling addListener: %s", eventName));
+  }
+
+  /**
+   * Invoked by React Native, necessary when passing this NativeModule to the constructor of a
+   * NativeEventEmitter on the JS layer.
+   *
+   * Invoked when listeners are removed from the NativeEventEmitter.
+   *
+   * @param count The string representation of the event.
+   */
+  @ReactMethod
+  public void removeListeners(Integer count) {
+    Log.d(TAG, String.format("Calling removeListeners: %d", count));
+  }
+
   @Override
   @NonNull
   public String getName() {

--- a/android/src/main/java/com/twiliovoicereactnative/TwilioVoiceReactNativeModule.java
+++ b/android/src/main/java/com/twiliovoicereactnative/TwilioVoiceReactNativeModule.java
@@ -111,7 +111,7 @@ public class TwilioVoiceReactNativeModule extends ReactContextBaseJavaModule {
    *
    * Invoked when listeners are removed from the NativeEventEmitter.
    *
-   * @param count The string representation of the event.
+   * @param count The number of event listeners removed.
    */
   @ReactMethod
   public void removeListeners(Integer count) {

--- a/src/common.ts
+++ b/src/common.ts
@@ -10,7 +10,5 @@ import type { TwilioVoiceReactNative as TwilioVoiceReactNativeType } from './typ
 
 export const NativeModule = ReactNative.NativeModules
   .TwilioVoiceReactNative as TwilioVoiceReactNativeType;
-export const NativeEventEmitter = new ReactNative.NativeEventEmitter(
-  NativeModule
-);
+export const NativeEventEmitter = new ReactNative.NativeEventEmitter();
 export const Platform = ReactNative.Platform;

--- a/src/common.ts
+++ b/src/common.ts
@@ -10,5 +10,7 @@ import type { TwilioVoiceReactNative as TwilioVoiceReactNativeType } from './typ
 
 export const NativeModule = ReactNative.NativeModules
   .TwilioVoiceReactNative as TwilioVoiceReactNativeType;
-export const NativeEventEmitter = new ReactNative.NativeEventEmitter();
+export const NativeEventEmitter = new ReactNative.NativeEventEmitter(
+  NativeModule
+);
 export const Platform = ReactNative.Platform;


### PR DESCRIPTION
## Submission Checklist

 - [x] Updated the `CHANGELOG.md` to reflect any **feature**, **bug fixes**, or **known issues** made in the source code
 - [x] Tested code changes and observed expected behavior in the example app
 - [x] Performed a visual inspection of the `Files changed` tab prior to submitting the pull request for review to ensure proper usage of the style guide

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Description

JIRA Ticket https://issues.corp.twilio.com/browse/VBLOCKS-1238

This PR fixes the warning about instantiating a `NativeEventEmitter` with an argument that lacks an `addListener` and `removeListener` method. Perhaps outdated, the official RN docs recommend constructing a `NativeEventEmitter` by passing the `NativeModule` as an argument, but the TS types show that we can opt out of passing anything at all.

## Breakdown

- Alter construction of the `NativeEventEmitter`.

## Validation

- Tested event propagation from the native layer to the JS layer.

## Additional Notes

N/A
