### PR TITLE
[VBLOCKS-1486] fix(js): custom parameter type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@
 - The integration testing app formerly under `example/` has been renamed/moved to `test/app/`.
 - The React Native dependency within the integration testing app has been updated from `0.63.4` to `0.66.5`.
 
+### API Changes
+- The `voice.connect` method now has the following function signature
+  ```ts
+  voice.connect(token: string, options?: Voice.ConnectOptions);
+
+  interface Voice.ConnectOptions {
+    contactHandle?: string;
+    params?: Record<string, string>;
+  }
+  ```
+  Not passing an options object or leaving any member of the options object undefined will result in those options using default values.
+  See the API documentation for descriptions of options.
+
 ## Features
 
 - The SDK now exports error classes and emits error objects specific to an error code. See the below code snippet for usage.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
   }
   ```
   Not passing an options object or leaving any member of the options object undefined will result in those options using default values.
-  See the API documentation for descriptions of options.
+  See the API documentation for descriptions of options [here](https://github.com/twilio/twilio-voice-react-native/blob/1.0.0-beta.1/docs/voice-react-native-sdk.md).
 
 ## Features
 

--- a/api/voice-react-native-sdk.api.md
+++ b/api/voice-react-native-sdk.api.md
@@ -909,7 +909,7 @@ export class Voice extends EventEmitter {
 // @public
 export namespace Voice {
     export type ConnectOptions = {
-        params?: Record<string, any>;
+        params?: Record<string, string>;
         contactHandle?: string;
     };
     export enum Event {

--- a/src/Voice.tsx
+++ b/src/Voice.tsx
@@ -857,7 +857,7 @@ export namespace Voice {
     /**
      * Custom parameters to send to the TwiML Application.
      */
-    params?: Record<string, any>;
+    params?: Record<string, string>;
     /**
      * A CallKit display name that will show in the call history as the contact
      * handle.

--- a/src/__tests__/Voice.test.ts
+++ b/src/__tests__/Voice.test.ts
@@ -417,7 +417,7 @@ describe('Voice class', () => {
   describe('public methods', () => {
     describe('.connect', () => {
       let token: string;
-      let options: { params?: Record<string, any>; contactHandle?: string };
+      let options: { params?: Record<string, string>; contactHandle?: string };
 
       beforeEach(() => {
         token = 'mock-voice-token-foo';
@@ -461,7 +461,7 @@ describe('Voice class', () => {
         'throws when params is defined and not an object',
         async () => {
           for (const invalidParams of ['string', 101, false]) {
-            options.params = invalidParams as unknown as Record<string, any>;
+            options.params = invalidParams as unknown as Record<string, string>;
             await expect(
               new Voice().connect(token, options)
             ).rejects.toThrowError(


### PR DESCRIPTION
## Submission Checklist

 - [x] Updated the `CHANGELOG.md` to reflect any **feature**, **bug fixes**, or **known issues** made in the source code
 - [x] Tested code changes and observed expected behavior in the example app
 - [x] Performed a visual inspection of the `Files changed` tab prior to submitting the pull request for review to ensure proper usage of the style guide

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Description

This PR changes the custom parameter type to a more restrictive `Record<string, string>` instead of `Record<string, any>`. Note that Android would support `Record<string, boolean | number | string>` but iOS cannot. However, Android will convert `boolean | number | string` into `string` using string representations of the former two, so `Record<string, string>` loses no functionality.

## Breakdown

- Change connect function signature.
- Add changelog entry.

## Validation

- Typescript compiles.

## Additional Notes

Not a lot of testing was done considering it's a type change, only validated by ensuring Typescript compilation.
