### PR TITLE
VBLOCKS-1595: fixed application so that notifications can awake (Android 31)

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -6,13 +6,13 @@ buildscript {
       'googleServices'     : '4.3.10',
       'voiceAndroid'       : '6.1.3',
       'androidxLifecycle'  : '2.2.0',
-      'audioSwitch'        : '1.1.4',
-      'firebaseMessaging'  : '21.1.0'
+      'audioSwitch'        : '1.1.7',
+      'firebaseMessaging'  : '23.1.2'
     ]
     if (project == rootProject) {
         repositories {
             google()
-            jcenter()
+            mavenCentral()
         }
 
         dependencies {
@@ -55,7 +55,6 @@ android {
 repositories {
   google()
   mavenCentral()
-  jcenter()
   maven {
     url 'https://maven.google.com/'
     name 'Google'

--- a/android/src/main/java/com/twiliovoicereactnative/IncomingCallNotificationService.java
+++ b/android/src/main/java/com/twiliovoicereactnative/IncomingCallNotificationService.java
@@ -69,9 +69,8 @@ public class IncomingCallNotificationService extends Service {
           handleOutgoingCall(callSid, notificationId, uuid);
           break;
         case Constants.ACTION_PUSH_APP_TO_FOREGROUND:
-          Log.i(TAG, "ACTION_PUSH_APP_TO_FOREGROUND " + uuid + " notificationId" + notificationId);
-          callSid = intent.getStringExtra(Constants.CALL_SID_KEY);
-          bringAppToForeground(callSid, notificationId, uuid);
+          Log.d(TAG, "Service should never receive FOREGROUND event, there is a bug");
+          break;
         default:
           break;
       }
@@ -191,20 +190,6 @@ public class IncomingCallNotificationService extends Service {
     this.startActivity(intent);
   }
 
-  /*
-   * Send the CallInvite to the main activity. Start the activity if it is not running already.
-   */
-  private void bringAppToForeground(String callSid, int notificationId, String uuid) {
-    NotificationManager notificationManager = (NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE);
-    notificationManager.cancel(notificationId);
-    Log.i(TAG, "bringAppToForeground " + uuid + " notificationId" + notificationId);
-    startForeground(notificationId, NotificationUtility.createWakeupAppNotification(callSid, notificationId, uuid, NotificationManager.IMPORTANCE_LOW, this));
-    Intent intent = new Intent(this, getMainActivityClass(getApplicationContext()));
-    intent.addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP);
-    intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-    this.startActivity(intent);
-  }
-
   private boolean isAppVisible() {
     return ProcessLifecycleOwner
       .get()
@@ -213,7 +198,7 @@ public class IncomingCallNotificationService extends Service {
       .isAtLeast(Lifecycle.State.STARTED);
   }
 
-  private static Class getMainActivityClass(Context context) {
+  public static Class getMainActivityClass(Context context) {
     String packageName = context.getPackageName();
     Intent launchIntent = context.getPackageManager().getLaunchIntentForPackage(packageName);
     String className = launchIntent.getComponent().getClassName();

--- a/android/src/main/java/com/twiliovoicereactnative/NotificationProxyActivity.java
+++ b/android/src/main/java/com/twiliovoicereactnative/NotificationProxyActivity.java
@@ -1,0 +1,54 @@
+package com.twiliovoicereactnative;
+
+import android.app.Activity;
+import android.content.Intent;
+import android.os.Bundle;
+
+public class NotificationProxyActivity extends Activity {
+  @Override
+  protected void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+    handleIntent(getIntent());
+    finish();
+  }
+
+  @Override
+  protected void onNewIntent(Intent intent) {
+    super.onNewIntent(intent);
+    handleIntent(intent);
+    finish();
+  }
+
+  private void handleIntent(Intent intent) {
+    String action = intent.getAction();
+    if (action != null) {
+      switch (action) {
+        case Constants.ACTION_PUSH_APP_TO_FOREGROUND:
+          launchMainActivity();
+          break;
+        case Constants.ACTION_ACCEPT:
+          launchService(intent);
+          launchMainActivity();
+          break;
+        default:
+          launchService(intent);
+          break;
+      }
+    }
+  }
+
+  private void launchMainActivity() {
+    try{
+      Intent launchIntent = getPackageManager().getLaunchIntentForPackage(getPackageName());
+      launchIntent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_NEW_TASK);
+      startActivity(launchIntent);
+    }catch (Exception e){
+      e.printStackTrace();
+    }
+  }
+  private void launchService(Intent intent) {
+    Intent launchIntent = new Intent(intent);
+    launchIntent.setClass(this, IncomingCallNotificationService.class);
+    startService(launchIntent);
+  }
+}

--- a/android/src/main/java/com/twiliovoicereactnative/NotificationUtility.java
+++ b/android/src/main/java/com/twiliovoicereactnative/NotificationUtility.java
@@ -25,6 +25,7 @@ import com.twilio.voice.CallInvite;
 
 import static android.content.Context.AUDIO_SERVICE;
 
+
 import java.net.URLDecoder;
 import java.util.Map;
 
@@ -40,19 +41,19 @@ public class NotificationUtility {
     String packageName = context.getPackageName();
     int smallIconResId = res.getIdentifier("ic_notification", "drawable", packageName);
 
-    Intent rejectIntent = new Intent(context.getApplicationContext(), IncomingCallNotificationService.class);
+    Intent rejectIntent = new Intent(context.getApplicationContext(), NotificationProxyActivity.class);
     rejectIntent.setAction(Constants.ACTION_REJECT);
     rejectIntent.putExtra(Constants.INCOMING_CALL_INVITE, callInvite);
     rejectIntent.putExtra(Constants.NOTIFICATION_ID, notificationId);
     rejectIntent.putExtra(Constants.UUID, uuid);
-    PendingIntent piRejectIntent = PendingIntent.getService(context.getApplicationContext(), 0, rejectIntent, PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE);
+    PendingIntent piRejectIntent = PendingIntent.getActivity(context.getApplicationContext(), 0, rejectIntent, PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE);
 
-    Intent acceptIntent = new Intent(context.getApplicationContext(), IncomingCallNotificationService.class);
+    Intent acceptIntent = new Intent(context.getApplicationContext(), NotificationProxyActivity.class);
     acceptIntent.setAction(Constants.ACTION_ACCEPT);
     acceptIntent.putExtra(Constants.INCOMING_CALL_INVITE, callInvite);
     acceptIntent.putExtra(Constants.NOTIFICATION_ID, notificationId);
     acceptIntent.putExtra(Constants.UUID, uuid);
-    PendingIntent piAcceptIntent = PendingIntent.getService(context.getApplicationContext(), 0, acceptIntent, PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE);
+    PendingIntent piAcceptIntent = PendingIntent.getActivity(context.getApplicationContext(), 0, acceptIntent, PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE);
 
     Bitmap icon = BitmapFactory.decodeResource(context.getResources(), R.drawable.ic_call_end_white_24dp);
     String title = getDisplayName(callInvite);
@@ -64,7 +65,7 @@ public class NotificationUtility {
     remoteViews.setOnClickPendingIntent(R.id.button_answer, piAcceptIntent);
     remoteViews.setOnClickPendingIntent(R.id.button_decline, piRejectIntent);
 
-    Intent notification_intent = new Intent(context.getApplicationContext(), IncomingCallNotificationService.class);
+    Intent notification_intent = new Intent(context.getApplicationContext(), NotificationProxyActivity.class);
     PendingIntent pendingIntent = PendingIntent.getActivity(context.getApplicationContext(), 0, notification_intent, PendingIntent.FLAG_IMMUTABLE);
 
     remoteViews.setOnClickPendingIntent(R.id.notification, pendingIntent);
@@ -118,21 +119,21 @@ public class NotificationUtility {
 
     Log.i(TAG, "createCallAnsweredNotification " + uuid + " notificationId" + notificationId);
 
-    Intent notification_intent = new Intent(context.getApplicationContext(), IncomingCallNotificationService.class);
+    Intent notification_intent = new Intent(context.getApplicationContext(), NotificationProxyActivity.class);
     notification_intent.setAction(Constants.ACTION_PUSH_APP_TO_FOREGROUND);
     notification_intent.putExtra(Constants.NOTIFICATION_ID, notificationId);
     notification_intent.putExtra(Constants.UUID, uuid);
-    PendingIntent pendingIntent = PendingIntent.getService(context.getApplicationContext(), 0, notification_intent, PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE);
+    PendingIntent pendingIntent = PendingIntent.getActivity(context.getApplicationContext(), 0, notification_intent, PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE);
 
     remoteViews.setOnClickPendingIntent(R.id.tap_to_app, pendingIntent);
 
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
 
-      Intent endCallIntent = new Intent(context.getApplicationContext(), IncomingCallNotificationService.class);
+      Intent endCallIntent = new Intent(context.getApplicationContext(), NotificationProxyActivity.class);
       endCallIntent.setAction(Constants.ACTION_CALL_DISCONNECT);
       endCallIntent.putExtra(Constants.NOTIFICATION_ID, notificationId);
       endCallIntent.putExtra(Constants.UUID, uuid);
-      PendingIntent piEndCallIntent = PendingIntent.getService(context.getApplicationContext(), 0, endCallIntent, PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE);
+      PendingIntent piEndCallIntent = PendingIntent.getActivity(context.getApplicationContext(), 0, endCallIntent, PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE);
 
       remoteViews.setOnClickPendingIntent(R.id.end_call, piEndCallIntent);
 
@@ -182,20 +183,20 @@ public class NotificationUtility {
     RemoteViews remoteViews = new RemoteViews(context.getPackageName(), R.layout.custom_call_in_progress);
     remoteViews.setTextViewText(R.id.make_call_text, getContentBanner(context));
 
-    Intent notification_intent = new Intent(context.getApplicationContext(), IncomingCallNotificationService.class);
+    Intent notification_intent = new Intent(context.getApplicationContext(), NotificationProxyActivity.class);
     notification_intent.setAction(Constants.ACTION_PUSH_APP_TO_FOREGROUND);
     notification_intent.putExtra(Constants.NOTIFICATION_ID, notificationId);
     notification_intent.putExtra(Constants.UUID, uuid);
-    PendingIntent pendingIntent = PendingIntent.getService(context.getApplicationContext(), 0, notification_intent, PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE);
+    PendingIntent pendingIntent = PendingIntent.getActivity(context.getApplicationContext(), 0, notification_intent, PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE);
 
     remoteViews.setOnClickPendingIntent(R.id.tap_to_app, pendingIntent);
 
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-      Intent endCallIntent = new Intent(context.getApplicationContext(), IncomingCallNotificationService.class);
+      Intent endCallIntent = new Intent(context.getApplicationContext(), NotificationProxyActivity.class);
       endCallIntent.setAction(Constants.ACTION_CALL_DISCONNECT);
       endCallIntent.putExtra(Constants.NOTIFICATION_ID, notificationId);
       endCallIntent.putExtra(Constants.UUID, uuid);
-      PendingIntent piEndCallIntent = PendingIntent.getService(context.getApplicationContext(), 0, endCallIntent, PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE);
+      PendingIntent piEndCallIntent = PendingIntent.getActivity(context.getApplicationContext(), 0, endCallIntent, PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE);
 
       remoteViews.setOnClickPendingIntent(R.id.end_call, piEndCallIntent);
 
@@ -243,16 +244,16 @@ public class NotificationUtility {
     RemoteViews remoteViews = new RemoteViews(context.getPackageName(), R.layout.custom_call_in_progress);
     remoteViews.setTextViewText(R.id.make_call_text, getContentBanner(context));
 
-    Intent notification_intent = new Intent(context.getApplicationContext(), IncomingCallNotificationService.class);
+    Intent notification_intent = new Intent(context.getApplicationContext(), NotificationProxyActivity.class);
     notification_intent.setAction(Constants.ACTION_PUSH_APP_TO_FOREGROUND);
     notification_intent.putExtra(Constants.NOTIFICATION_ID, notificationId);
     notification_intent.putExtra(Constants.UUID, uuid);
-    PendingIntent pendingIntent = PendingIntent.getService(context.getApplicationContext(), 0, notification_intent, PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE);
+    PendingIntent pendingIntent = PendingIntent.getActivity(context.getApplicationContext(), 0, notification_intent, PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE);
 
     remoteViews.setOnClickPendingIntent(R.id.tap_to_app, pendingIntent);
 
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-      Intent endCallIntent = new Intent(context.getApplicationContext(), IncomingCallNotificationService.class);
+      Intent endCallIntent = new Intent(context.getApplicationContext(), NotificationProxyActivity.class);
       endCallIntent.setAction(Constants.ACTION_CALL_DISCONNECT);
       endCallIntent.putExtra(Constants.NOTIFICATION_ID, notificationId);
       endCallIntent.putExtra(Constants.UUID, uuid);

--- a/test/app/android/app/src/main/AndroidManifest.xml
+++ b/test/app/android/app/src/main/AndroidManifest.xml
@@ -45,6 +45,15 @@
         <action android:name="ACTION_REJECT" />
       </intent-filter>
     </service>
+    <activity
+      android:name="com.twiliovoicereactnative.NotificationProxyActivity"
+      android:parentActivityName=".MainActivity"
+      android:noHistory="true"
+      android:excludeFromRecents="true"
+      android:taskAffinity=""
+      android:launchMode="singleTask"
+      android:theme="@android:style/Theme.Translucent.NoTitleBar"
+      android:exported="true" />
   </application>
 
 </manifest>

--- a/test/app/android/build.gradle
+++ b/test/app/android/build.gradle
@@ -4,18 +4,17 @@ buildscript {
     ext {
         buildToolsVersion = "30.0.2"
         minSdkVersion = 21
-        compileSdkVersion = 31
-        targetSdkVersion = 31
+        compileSdkVersion = 32
+        targetSdkVersion = 32
         ndkVersion = "21.4.7075529"
     }
     repositories {
         google()
         mavenCentral()
-        jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.2.1'
-        classpath 'com.google.gms:google-services:4.3.10'
+        classpath 'com.android.tools.build:gradle:7.2.2'
+        classpath 'com.google.gms:google-services:4.3.15'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }
@@ -35,7 +34,6 @@ allprojects {
         }
 
         google()
-        jcenter()
         maven { url 'https://www.jitpack.io' }
     }
 }


### PR DESCRIPTION
## Submission Checklist

 - [x] Updated the `CHANGELOG.md` to reflect any **feature**, **bug fixes**, or **known issues** made in the source code
 - [x] Tested code changes and observed expected behavior in the example app
 - [x] Performed a visual inspection of the `Files changed` tab prior to submitting the pull request for review to ensure proper usage of the style guide

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Description

Due to a change on Android 31, services can no longer launch applications and as such, our application could not awake due to notifications. This was fixed by making a proxy activity that interfaces with the service but also receives notification intents, which it can then use to launch other activities.

## Breakdown

- added a invisible activity which acts as a broker between the service and the main application
- Modified notifications to route to the invisible activity

## Validation

- Tested that reacting to an in coming call launches the app


## Additional Notes

[Any additional comments, notes, or information relevant to reviewers.]
