### PR TITLE
fix: update ios call_mute and call_hold to resolve with their updated…

### DIFF
--- a/ios/TwilioVoiceReactNative.m
+++ b/ios/TwilioVoiceReactNative.m
@@ -45,7 +45,7 @@ static TVODefaultAudioDevice *sTwilioAudioDevice;
     if (self = [super initWithFrame:frame]) {
         self.hidden = YES;
     }
-    
+
     return self;
 }
 
@@ -97,7 +97,7 @@ static TVODefaultAudioDevice *sTwilioAudioDevice;
         [self subscribeToNotifications];
         [self initializeCallKit];
         [self initializeAudioDeviceList];
-        
+
         // Initialize PKPushRegistry at launch
         self.twilioVoicePushRegistry = [TwilioVoicePushRegistry new];
         [self.twilioVoicePushRegistry updatePushRegistry];
@@ -355,7 +355,7 @@ static TVODefaultAudioDevice *sTwilioAudioDevice;
                                        kTwilioVoiceReactNativeCallInfoIsOnHold: @(call.isOnHold),
                                        kTwilioVoiceReactNativeCallInfoSid: call.sid,
                                        kTwilioVoiceReactNativeCallInfoTo: call.to? call.to : @""} mutableCopy];
-    
+
     TVOCallInvite *callInvite = self.callInviteMap[call.uuid.UUIDString];
     if (callInvite && callInvite.customParameters) {
         callInfo[kTwilioVoiceReactNativeCallInviteInfoCustomParameters] = [callInvite.customParameters copy];
@@ -456,14 +456,14 @@ RCT_EXPORT_METHOD(voice_register:(NSString *)accessToken
         self.deviceTokenData = [testDeviceToken dataUsingEncoding:NSUTF8StringEncoding];
     }
 #endif
-    
+
     if (self.registrationInProgress) {
         reject(kTwilioVoiceReactNativeVoiceError, @"Registration in progress. Please try again later", nil);
         return;
     }
 
     self.registrationInProgress = YES;
-    
+
     [self asyncPushRegistryInitialization:kPushRegistryDeviceTokenRetryTimeout
                                completion:^(NSData *deviceTokenData) {
         if (deviceTokenData) {
@@ -521,14 +521,14 @@ RCT_EXPORT_METHOD(voice_unregister:(NSString *)accessToken
         self.deviceTokenData = [testDeviceToken dataUsingEncoding:NSUTF8StringEncoding];
     }
 #endif
-    
+
     if (self.registrationInProgress) {
         reject(kTwilioVoiceReactNativeVoiceError, @"Registration in progress. Please try again later", nil);
         return;
     }
 
     self.registrationInProgress = YES;
-    
+
     [self asyncPushRegistryInitialization:kPushRegistryDeviceTokenRetryTimeout
                                completion:^(NSData *deviceTokenData) {
         if (deviceTokenData) {
@@ -613,7 +613,7 @@ RCT_EXPORT_METHOD(voice_showNativeAvRoutePicker:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject)
 {
     TVRNAVRoutePickerView *routePicker = [[TVRNAVRoutePickerView alloc] initWithFrame:CGRectZero];
-    
+
     UIWindow *window = [UIApplication sharedApplication].windows[0];
     UIViewController *rootViewController = window.rootViewController;
     if (rootViewController) {
@@ -621,13 +621,13 @@ RCT_EXPORT_METHOD(voice_showNativeAvRoutePicker:(RCTPromiseResolveBlock)resolve
         while (topViewController.presentedViewController) {
             topViewController = topViewController.presentedViewController;
         }
-        
+
         dispatch_async(dispatch_get_main_queue(), ^{
             [topViewController.view addSubview:routePicker];
             [routePicker present];
         });
     }
-    
+
     resolve(nil);
 }
 
@@ -696,7 +696,7 @@ RCT_EXPORT_METHOD(call_hold:(NSString *)uuid
     TVOCall *call = self.callMap[uuid];
     if (call) {
         [call setOnHold:onHold];
-        resolve(nil);
+        resolve(@(call.isOnHold));
     } else {
         reject(kTwilioVoiceReactNativeVoiceError, [NSString stringWithFormat:@"Call with %@ not found", uuid], nil);
     }
@@ -722,7 +722,7 @@ RCT_EXPORT_METHOD(call_mute:(NSString *)uuid
     TVOCall *call = self.callMap[uuid];
     if (call) {
         [call setMuted:muted];
-        resolve(nil);
+        resolve(@(call.isMuted));
     } else {
         reject(kTwilioVoiceReactNativeVoiceError, [NSString stringWithFormat:@"Call with %@ not found", uuid], nil);
     }


### PR DESCRIPTION
## Submission Checklist

 - [ ] Updated the `CHANGELOG.md` to reflect any **feature**, **bug fixes**, or **known issues** made in the source code
 - [x] Tested code changes and observed expected behavior in the example app
 - [x] Performed a visual inspection of the `Files changed` tab prior to submitting the pull request for review to ensure proper usage of the style guide

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Description

This PR resolves an issue with the return type of `call_mute` and `call_hold` on iOS.

The native iOS code always resolves with `nil` for calls to `call_mute`. The React code updates its `_isMuted` value with the result of this call. So, once when you call `call.mute(...)` the value is set to, and remains, `undefined`.

The same applies to `call_hold`.

The native module should resolve those calls with a boolean indicating the updated value (the Android code correctly does this.)

## Breakdown

- Updated iOS `call_mute` and `call_hold` to resolve with booleans, to match their stated types.

## Validation

- I pulled this branch into the project I'm working on and confirmed that `call._isMuted` is properly updated after calls to `call.mute()`

## Additional Notes

My editor automatically removed trailing spaces from a few lines.