### PR TITLE
VBLOCKS-1787 Move audio device types to common constants

### DIFF
--- a/android/src/main/java/com/twiliovoicereactnative/AudioSwitchManager.java
+++ b/android/src/main/java/com/twiliovoicereactnative/AudioSwitchManager.java
@@ -9,6 +9,10 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
 
+import static com.twiliovoicereactnative.CommonConstants.AudioDeviceKeyEarpiece;
+import static com.twiliovoicereactnative.CommonConstants.AudioDeviceKeySpeaker;
+import static com.twiliovoicereactnative.CommonConstants.AudioDeviceKeyBluetooth;
+
 /**
  * AudioSwitchManager singleton class. Maintains a persistent AudioSwitch object and listens for audio
  * device changes. Generates UUIDs per audio device when the AudioSwitch library updates available
@@ -60,10 +64,10 @@ public class AudioSwitchManager {
    */
   private AudioSwitchManager(Context context) {
     if (AUDIO_DEVICE_TYPE.isEmpty()) {
-      AUDIO_DEVICE_TYPE.put("Speakerphone", "speaker");
-      AUDIO_DEVICE_TYPE.put("BluetoothHeadset", "bluetooth");
-      AUDIO_DEVICE_TYPE.put("WiredHeadset", "earpiece");
-      AUDIO_DEVICE_TYPE.put("Earpiece", "earpiece");
+      AUDIO_DEVICE_TYPE.put("Speakerphone", AudioDeviceKeySpeaker);
+      AUDIO_DEVICE_TYPE.put("BluetoothHeadset", AudioDeviceKeyBluetooth);
+      AUDIO_DEVICE_TYPE.put("WiredHeadset", AudioDeviceKeyEarpiece);
+      AUDIO_DEVICE_TYPE.put("Earpiece", AudioDeviceKeyEarpiece);
     }
 
     audioDevices = new HashMap<String, AudioDevice>();

--- a/constants/constants.src
+++ b/constants/constants.src
@@ -56,6 +56,9 @@ AudioDeviceKeyName=name
 AudioDeviceKeyType=type
 AudioDeviceKeyAudioDevices=audioDevices
 AudioDeviceKeySelectedDevice=selectedDevice
+AudioDeviceKeyEarpiece=earpiece
+AudioDeviceKeySpeaker=speaker
+AudioDeviceKeyBluetooth=bluetooth
 
 // Call events
 // State

--- a/ios/TwilioVoiceReactNative.m
+++ b/ios/TwilioVoiceReactNative.m
@@ -23,9 +23,6 @@ NSString * const kTwilioVoiceReactNativeEventKeyCancelledCallInvite = @"cancelle
 
 // Audio device
 NSString * const kTwilioVoiceAudioDeviceUid = @"uid";
-NSString * const kTwilioVoiceAudioDeviceEarpiece = @"Earpiece";
-NSString * const kTwilioVoiceAudioDeviceSpeaker = @"Speaker";
-NSString * const kTwilioVoiceAudioDeviceBluetooth = @"Bluetooth";
 
 static TVODefaultAudioDevice *sTwilioAudioDevice;
 
@@ -179,14 +176,14 @@ static TVODefaultAudioDevice *sTwilioAudioDevice;
 - (void)initializeAudioDeviceList {
     NSUUID *receiverUuid = [NSUUID UUID];
     NSDictionary *builtInReceiver = @{ kTwilioVoiceReactNativeAudioDeviceKeyUuid: receiverUuid.UUIDString,
-                                       kTwilioVoiceReactNativeAudioDeviceKeyType: kTwilioVoiceAudioDeviceEarpiece,
+                                       kTwilioVoiceReactNativeAudioDeviceKeyType: kTwilioVoiceReactNativeAudioDeviceKeyEarpiece,
                                        kTwilioVoiceReactNativeAudioDeviceKeyName: @"iPhone",
                                        kTwilioVoiceAudioDeviceUid: AVAudioSessionPortBuiltInReceiver};
     self.audioDevices[receiverUuid.UUIDString] = builtInReceiver;
 
     NSUUID *speakerUuid = [NSUUID UUID];
     NSDictionary *builtInSpeaker = @{ kTwilioVoiceReactNativeAudioDeviceKeyUuid: speakerUuid.UUIDString,
-                                      kTwilioVoiceReactNativeAudioDeviceKeyType: kTwilioVoiceAudioDeviceSpeaker,
+                                      kTwilioVoiceReactNativeAudioDeviceKeyType: kTwilioVoiceReactNativeAudioDeviceKeySpeaker,
                                       kTwilioVoiceReactNativeAudioDeviceKeyName: @"Speaker",
                                       kTwilioVoiceAudioDeviceUid: AVAudioSessionPortBuiltInSpeaker};
     self.audioDevices[speakerUuid.UUIDString] = builtInSpeaker;
@@ -234,7 +231,7 @@ static TVODefaultAudioDevice *sTwilioAudioDevice;
         if ([port.portType isEqualToString:AVAudioSessionPortBuiltInReceiver]) {
             for (NSString *key in [self.audioDevices allKeys]) {
                 NSDictionary *device = self.audioDevices[key];
-                if ([device[kTwilioVoiceReactNativeAudioDeviceKeyType] isEqualToString:kTwilioVoiceAudioDeviceEarpiece]) {
+                if ([device[kTwilioVoiceReactNativeAudioDeviceKeyType] isEqualToString:kTwilioVoiceReactNativeAudioDeviceKeyEarpiece]) {
                     self.selectedAudioDevice = device;
                     break;
                 }
@@ -242,7 +239,7 @@ static TVODefaultAudioDevice *sTwilioAudioDevice;
         } else if ([port.portType isEqualToString:AVAudioSessionPortBuiltInSpeaker]) {
             for (NSString *key in [self.audioDevices allKeys]) {
                 NSDictionary *device = self.audioDevices[key];
-                if ([device[kTwilioVoiceReactNativeAudioDeviceKeyType] isEqualToString:kTwilioVoiceAudioDeviceSpeaker]) {
+                if ([device[kTwilioVoiceReactNativeAudioDeviceKeyType] isEqualToString:kTwilioVoiceReactNativeAudioDeviceKeySpeaker]) {
                     self.selectedAudioDevice = device;
                 }
             }
@@ -275,11 +272,11 @@ static TVODefaultAudioDevice *sTwilioAudioDevice;
 
 - (NSString *)audioPortTypeMapping:(NSString *)portType {
     if ([portType isEqualToString:AVAudioSessionPortBuiltInReceiver]) {
-        return kTwilioVoiceAudioDeviceEarpiece;
+        return kTwilioVoiceReactNativeAudioDeviceKeyEarpiece;
     } else if ([portType isEqualToString:AVAudioSessionPortBuiltInSpeaker]) {
-        return kTwilioVoiceAudioDeviceSpeaker;
+        return kTwilioVoiceReactNativeAudioDeviceKeySpeaker;
     } else if ([portType isEqualToString:AVAudioSessionPortBluetoothHFP]) {
-        return kTwilioVoiceAudioDeviceBluetooth;
+        return kTwilioVoiceReactNativeAudioDeviceKeyBluetooth;
     }
 
     return portType;
@@ -298,7 +295,7 @@ static TVODefaultAudioDevice *sTwilioAudioDevice;
     NSLog(@"Selecting %@(%@), %@", device[kTwilioVoiceReactNativeAudioDeviceKeyName], device[kTwilioVoiceReactNativeAudioDeviceKeyType], device[kTwilioVoiceAudioDeviceUid]);
 
     AVAudioSessionPortDescription *portDescription = nil;
-    if ([portType isEqualToString:kTwilioVoiceAudioDeviceEarpiece]) {
+    if ([portType isEqualToString:@"Earpiece"]) {
         NSArray *availableInputs = [[AVAudioSession sharedInstance] availableInputs];
         for (AVAudioSessionPortDescription *port in availableInputs) {
             if ([port.portType isEqualToString:AVAudioSessionPortBuiltInMic]) {
@@ -311,7 +308,7 @@ static TVODefaultAudioDevice *sTwilioAudioDevice;
             NSLog(@"Built-in mic not found");
             return NO;
         }
-    } else if ([portType isEqualToString:kTwilioVoiceAudioDeviceBluetooth]) {
+    } else if ([portType isEqualToString:@"Bluetooth"]) {
         NSArray *availableInputs = [[AVAudioSession sharedInstance] availableInputs];
         for (AVAudioSessionPortDescription *port in availableInputs) {
             if ([port.UID isEqualToString:portUid]) {
@@ -335,7 +332,7 @@ static TVODefaultAudioDevice *sTwilioAudioDevice;
     }
 
     // Override output to speaker if speaker is selected, otherwise choose "none"
-    AVAudioSessionPortOverride outputOverride = ([portType isEqualToString:kTwilioVoiceAudioDeviceSpeaker])?
+    AVAudioSessionPortOverride outputOverride = ([portType isEqualToString:@"Speaker"])?
                                                 AVAudioSessionPortOverrideSpeaker : AVAudioSessionPortOverrideNone;
     NSError *outputError;
     [[AVAudioSession sharedInstance] overrideOutputAudioPort:outputOverride error:&outputError];


### PR DESCRIPTION
## Submission Checklist

 - [ ] Updated the `CHANGELOG.md` to reflect any **feature**, **bug fixes**, or **known issues** made in the source code
 - [ ] Tested code changes and observed expected behavior in the example app
 - [ ] Performed a visual inspection of the `Files changed` tab prior to submitting the pull request for review to ensure proper usage of the style guide

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [ ] I acknowledge that all my contributions will be made under the project's license.

## Description

Move audio device types to common constants

## Breakdown

- New common constants for audio device types
- Update iOS audio device logic
- Update Android audio device constant variables

## Validation

- Ran app and listed audio devices locally 

## Additional Notes

[Any additional comments, notes, or information relevant to reviewers.]
