### PR TITLE
[VBLOCKS-1913] Persist extra call info

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -183,6 +183,26 @@ jobs:
           command: |
             yarn run prepare
 
+  build-docs:
+    executor: default
+    steps:
+      - attach_project
+      - run:
+          name: Build docs and check for API changes
+          command: |
+            yarn run build:docs
+            git diff --exit-code api/
+
+  build-errors:
+    executor: default
+    steps:
+      - attach_project
+      - run:
+          name: Build errors and check for changes
+          command: |
+            yarn run build:errors
+            git diff --exit-code src/error/generated.ts
+
   run-release:
     executor:
       name: default
@@ -251,6 +271,12 @@ workflows:
           requires:
             - cache-install-dependencies
       - build-package:
+          requires:
+            - cache-install-dependencies
+      - build-docs:
+          requires:
+            - cache-install-dependencies
+      - build-errors:
           requires:
             - cache-install-dependencies
       - e2e-ios:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ Twilio Voice React Native SDK has now reached milestone `beta.2`. Included in th
 
 - Pinned to a specific version of the Twilio Voice iOS SDK. This fixes issues with some builds failing on iOS platforms.
 - Fixed the Intent flags on Android platforms. This fixes issues with the application crashing on newer versions of Android.
+- Calls will now persist their state through JS runtimes. Now, if the React Native JS layer encounters a restart, and if your code performs `Voice.getCalls`, the `Call` objects will now have the proper state.
+
+## Features
+
+- Calls will now persist a timestamp (millseconds since epoch) of when they initially receive the `Call.Event.Connected` event.
+  See `Call.getInitialConnectedTimestamp`.
 
 1.0.0-beta.1 (March 10, 2023)
 =============================

--- a/android/src/main/java/com/twiliovoicereactnative/CallListenerProxy.java
+++ b/android/src/main/java/com/twiliovoicereactnative/CallListenerProxy.java
@@ -30,6 +30,7 @@ import static com.twiliovoicereactnative.CommonConstants.CallEventConnectFailure
 import static com.twiliovoicereactnative.CommonConstants.CallEventQualityWarningsChanged;
 import static com.twiliovoicereactnative.ReactNativeArgumentsSerializer.*;
 
+import java.util.Date;
 import java.util.Set;
 
 class CallListenerProxy implements Call.Listener {
@@ -85,6 +86,8 @@ class CallListenerProxy implements Call.Listener {
 
     AudioSwitchManager.getInstance(context).getAudioSwitch().activate();
     MediaPlayerManager.getInstance(this.context).stopRinging();
+
+    Storage.callConnectMap.put(uuid, (double) new Date().getTime());
 
     WritableMap params = Arguments.createMap();
     params.putString(VoiceEventType, CallEventConnected);

--- a/android/src/main/java/com/twiliovoicereactnative/ReactNativeArgumentsSerializer.java
+++ b/android/src/main/java/com/twiliovoicereactnative/ReactNativeArgumentsSerializer.java
@@ -1,14 +1,23 @@
 package com.twiliovoicereactnative;
 
+import android.util.Log;
+
 import static com.twiliovoicereactnative.CommonConstants.AudioDeviceKeyAudioDevices;
 import static com.twiliovoicereactnative.CommonConstants.AudioDeviceKeyName;
 import static com.twiliovoicereactnative.CommonConstants.AudioDeviceKeySelectedDevice;
 import static com.twiliovoicereactnative.CommonConstants.AudioDeviceKeyType;
 import static com.twiliovoicereactnative.CommonConstants.AudioDeviceKeyUuid;
 import static com.twiliovoicereactnative.CommonConstants.CallInfoFrom;
+import static com.twiliovoicereactnative.CommonConstants.CallInfoInitialConnectedTimestamp;
 import static com.twiliovoicereactnative.CommonConstants.CallInfoSid;
 import static com.twiliovoicereactnative.CommonConstants.CallInfoTo;
 import static com.twiliovoicereactnative.CommonConstants.CallInfoUuid;
+import static com.twiliovoicereactnative.CommonConstants.CallInfoState;
+import static com.twiliovoicereactnative.CommonConstants.CallStateConnected;
+import static com.twiliovoicereactnative.CommonConstants.CallStateConnecting;
+import static com.twiliovoicereactnative.CommonConstants.CallStateDisconnected;
+import static com.twiliovoicereactnative.CommonConstants.CallStateReconnecting;
+import static com.twiliovoicereactnative.CommonConstants.CallStateRinging;
 import static com.twiliovoicereactnative.CommonConstants.CallInviteInfoCallSid;
 import static com.twiliovoicereactnative.CommonConstants.CallInviteInfoCustomParameters;
 import static com.twiliovoicereactnative.CommonConstants.CallInviteInfoFrom;
@@ -34,6 +43,8 @@ import java.util.Map.Entry;
  * React Native (RN) bridge objects emit-able to the JS layer.
  */
 public class ReactNativeArgumentsSerializer {
+  static final String TAG = "RNArgSerializer";
+
   /**
    * Serializes the custom parameters of a CallInvite.
    * @param callInvite A CallInvite object
@@ -84,6 +95,29 @@ public class ReactNativeArgumentsSerializer {
   }
 
   /**
+   * Convert the call state enumeration to a string that the JS layer expects.
+   * @param state The call state
+   * @return A string representing the state
+   */
+  public static String callStateToString(Call.State state) {
+    switch (state) {
+      case CONNECTED:
+        return CallStateConnected;
+      case CONNECTING:
+        return CallStateConnecting;
+      case DISCONNECTED:
+        return CallStateDisconnected;
+      case RECONNECTING:
+        return CallStateReconnecting;
+      case RINGING:
+        return CallStateRinging;
+    }
+
+    Log.d(TAG, "Unknown call state: " + state.toString());
+    return CallStateConnecting;
+  }
+
+  /**
    * Serializes a Call.
    * @param uuid The UUID of the Call
    * @param call The Call
@@ -95,6 +129,12 @@ public class ReactNativeArgumentsSerializer {
     callInfo.putString(CallInfoSid, call.getSid());
     callInfo.putString(CallInfoFrom, call.getFrom());
     callInfo.putString(CallInfoTo, call.getTo());
+    callInfo.putString(CallInfoState, callStateToString(call.getState()));
+
+    Double timestamp = Storage.callConnectMap.get(uuid);
+    if (timestamp != null) {
+      callInfo.putDouble(CallInfoInitialConnectedTimestamp, timestamp);
+    }
 
     CallInvite callInvite = Storage.callInviteMap.get(uuid);
     if (callInvite != null) {

--- a/android/src/main/java/com/twiliovoicereactnative/Storage.java
+++ b/android/src/main/java/com/twiliovoicereactnative/Storage.java
@@ -14,6 +14,8 @@ public class Storage {
 
   // A map to keep uuid and active Call mapping
   static final Map<String, Call> callMap = new HashMap<>();
+  // A map to keep uuid and initial connection timestamp
+  static final Map<String, Double> callConnectMap = new HashMap<>();
   // A map to keep uuid and active CallInvite mapping
   static final Map<String, CallInvite> callInviteMap = new HashMap<>();
   // A map to keep CallSid and uuid mapping

--- a/api/voice-react-native-sdk.api.md
+++ b/api/voice-react-native-sdk.api.md
@@ -172,10 +172,11 @@ export class Call extends EventEmitter {
     // Warning: (ae-forgotten-export) The symbol "NativeCallInfo" needs to be exported by the entry point index.d.ts
     //
     // @internal
-    constructor({ uuid, customParameters, from, sid, to, isMuted, isOnHold, }: NativeCallInfo);
+    constructor({ uuid, customParameters, from, sid, state, to, isMuted, isOnHold, initialConnectedTimestamp, }: NativeCallInfo);
     disconnect(): Promise<void>;
     getCustomParameters(): CustomParameters;
     getFrom(): string | undefined;
+    getInitialConnectedTimestamp(): number | undefined;
     getSid(): string | undefined;
     getState(): Call.State;
     getStats(): Promise<RTCStats.StatsReport>;
@@ -241,7 +242,7 @@ export namespace Call {
         'Connected' = "connected",
         'Connecting' = "connecting",
         'Disconnected' = "disconnected",
-        'Reconnecting' = "reconnected",
+        'Reconnecting' = "reconnecting",
         'Ringing' = "ringing"
     }
 }

--- a/constants/constants.src
+++ b/constants/constants.src
@@ -26,6 +26,15 @@ CallInfoFrom=from
 CallInfoTo=to
 CallInfoIsMuted=isMuted
 CallInfoIsOnHold=isOnHold
+CallInfoState=state
+CallInfoInitialConnectedTimestamp=initialConnectedTimestamp
+
+// Call States
+CallStateConnected=connected
+CallStateConnecting=connecting
+CallStateDisconnected=disconnected
+CallStateReconnecting=reconnecting
+CallStateRinging=ringing
 
 // Call Invite Info
 CallInviteInfoUuid=uuid

--- a/ios/TwilioVoiceReactNative+CallKit.m
+++ b/ios/TwilioVoiceReactNative+CallKit.m
@@ -321,7 +321,7 @@ NSString * const kCustomParametersKeyDisplayName = @"displayName";
     
     NSTimeInterval timeStamp = [[NSDate date] timeIntervalSince1970];
     // NSTimeInterval is defined as double
-    NSNumber *timeStampObj = [NSNumber numberWithDouble: timeStamp];
+    NSNumber *timeStampObj = [NSNumber numberWithDouble:timeStamp];
     [self.callConnectMap setValue:timeStampObj forKey:call.uuid.UUIDString];
 }
 

--- a/ios/TwilioVoiceReactNative+CallKit.m
+++ b/ios/TwilioVoiceReactNative+CallKit.m
@@ -68,7 +68,7 @@ NSString * const kCustomParametersKeyDisplayName = @"displayName";
 - (void)reportNewIncomingCall:(TVOCallInvite *)callInvite {
     self.callInviteMap[callInvite.uuid.UUIDString] = callInvite;
     
-    // If "displayName" is passed as a custom parameter in the TwiML application, 
+    // If "displayName" is passed as a custom parameter in the TwiML application,
     // it will be used as the caller name.
     NSString *handleName = callInvite.from;
     NSDictionary *customParams = callInvite.customParameters;
@@ -318,6 +318,11 @@ NSString * const kCustomParametersKeyDisplayName = @"displayName";
         self.callKitCompletionCallback(YES);
         self.callKitCompletionCallback = nil;
     }
+    
+    NSTimeInterval timeStamp = [[NSDate date] timeIntervalSince1970];
+    // NSTimeInterval is defined as double
+    NSNumber *timeStampObj = [NSNumber numberWithDouble: timeStamp];
+    [self.callConnectMap setValue:timeStampObj forKey:call.uuid.UUIDString];
 }
 
 - (void)call:(TVOCall *)call didDisconnectWithError:(NSError *)error {
@@ -367,6 +372,7 @@ NSString * const kCustomParametersKeyDisplayName = @"displayName";
         TVOCall *activeCall = self.callMap[uuidKey];
         if (activeCall == call) {
             [self.callMap removeObjectForKey:uuidKey];
+            [self.callConnectMap removeObjectForKey:call.uuid.UUIDString];
             break;
         }
     }
@@ -482,4 +488,3 @@ previousWarnings:(NSSet<NSNumber *> *)previousWarnings {
 }
 
 @end
-

--- a/ios/TwilioVoiceReactNative.h
+++ b/ios/TwilioVoiceReactNative.h
@@ -24,6 +24,7 @@ FOUNDATION_EXPORT NSString * const kTwilioVoiceReactNativeEventKeyCancelledCallI
 @interface TwilioVoiceReactNative : RCTEventEmitter <RCTBridgeModule>
 
 @property (nonatomic, readonly, strong) NSMutableDictionary<NSString *, TVOCall *> *callMap;
+@property (nonatomic, readonly, strong) NSMutableDictionary<NSString *, NSNumber *> *callConnectMap;
 @property (nonatomic, readonly, strong) NSMutableDictionary<NSString *, TVOCallInvite *> *callInviteMap;
 @property (nonatomic, readonly, strong) NSMutableDictionary<NSString *, TVOCancelledCallInvite *> *cancelledCallInviteMap;
 

--- a/ios/TwilioVoiceReactNative.m
+++ b/ios/TwilioVoiceReactNative.m
@@ -347,16 +347,19 @@ static TVODefaultAudioDevice *sTwilioAudioDevice;
 
 // TODO: Move to separate utility file someday
 - (NSDictionary *)callInfo:(TVOCall *)call {
-    NSNumber *initialConnectTimestamp = self.callConnectMap[call.uuid.UUIDString];
     NSMutableDictionary *callInfo = [@{kTwilioVoiceReactNativeCallInfoUuid: call.uuid? call.uuid.UUIDString : @"",
                                        kTwilioVoiceReactNativeCallInfoFrom: call.from? call.from : @"",
                                        kTwilioVoiceReactNativeCallInfoIsMuted: @(call.isMuted),
                                        kTwilioVoiceReactNativeCallInfoIsOnHold: @(call.isOnHold),
                                        kTwilioVoiceReactNativeCallInfoSid: call.sid,
                                        kTwilioVoiceReactNativeCallInfoState: [self stringOfState:call.state],
-                                       kTwilioVoiceReactNativeCallInfoInitialConnectedTimestamp: initialConnectTimestamp,
                                        kTwilioVoiceReactNativeCallInfoTo: call.to? call.to : @""} mutableCopy];
 
+    NSNumber *initialConnectedTimestamp = self.callConnectMap[call.uuid.UUIDString];
+    if (initialConnectedTimestamp != nil) {
+        callInfo[kTwilioVoiceReactNativeCallInfoInitialConnectedTimestamp] = initialConnectedTimestamp;
+    }
+    
     TVOCallInvite *callInvite = self.callInviteMap[call.uuid.UUIDString];
     if (callInvite && callInvite.customParameters) {
         callInfo[kTwilioVoiceReactNativeCallInviteInfoCustomParameters] = [callInvite.customParameters copy];

--- a/ios/TwilioVoiceReactNative.m
+++ b/ios/TwilioVoiceReactNative.m
@@ -79,6 +79,7 @@ static TVODefaultAudioDevice *sTwilioAudioDevice;
 - (instancetype)init {
     if (self = [super init]) {
         _callMap = [NSMutableDictionary dictionary];
+        _callConnectMap = [NSMutableDictionary dictionary];
         _callInviteMap = [NSMutableDictionary dictionary];
         _cancelledCallInviteMap = [NSMutableDictionary dictionary];
         _audioDevices = [NSMutableDictionary dictionary];
@@ -346,11 +347,14 @@ static TVODefaultAudioDevice *sTwilioAudioDevice;
 
 // TODO: Move to separate utility file someday
 - (NSDictionary *)callInfo:(TVOCall *)call {
+    NSNumber *initialConnectTimestamp = self.callConnectMap[call.uuid.UUIDString];
     NSMutableDictionary *callInfo = [@{kTwilioVoiceReactNativeCallInfoUuid: call.uuid? call.uuid.UUIDString : @"",
                                        kTwilioVoiceReactNativeCallInfoFrom: call.from? call.from : @"",
                                        kTwilioVoiceReactNativeCallInfoIsMuted: @(call.isMuted),
                                        kTwilioVoiceReactNativeCallInfoIsOnHold: @(call.isOnHold),
                                        kTwilioVoiceReactNativeCallInfoSid: call.sid,
+                                       kTwilioVoiceReactNativeCallInfoState: [self stringOfState:call.state],
+                                       kTwilioVoiceReactNativeCallInfoInitialConnectedTimestamp: initialConnectTimestamp,
                                        kTwilioVoiceReactNativeCallInfoTo: call.to? call.to : @""} mutableCopy];
 
     TVOCallInvite *callInvite = self.callInviteMap[call.uuid.UUIDString];
@@ -908,17 +912,17 @@ RCT_EXPORT_METHOD(util_generateId:(RCTPromiseResolveBlock)resolve
 - (NSString *)stringOfState:(TVOCallState)state {
     switch (state) {
         case TVOCallStateConnecting:
-            return @"connecting";
+            return kTwilioVoiceReactNativeCallStateConnecting;
         case TVOCallStateRinging:
-            return @"ringing";
+            return kTwilioVoiceReactNativeCallStateRinging;
         case TVOCallStateConnected:
-            return @"conencted";
+            return kTwilioVoiceReactNativeCallStateConnected;
         case TVOCallStateReconnecting:
-            return @"reconnecting";
+            return kTwilioVoiceReactNativeCallStateReconnecting;
         case TVOCallStateDisconnected:
-            return @"disconnected";
+            return kTwilioVoiceReactNativeCallStateDisconnected;
         default:
-            return @"connecting";
+            return kTwilioVoiceReactNativeCallStateConnecting;
     }
 }
 

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "check:lint": "eslint \"**/*.{js,ts,tsx}\"",
     "check:test": "jest",
     "check:type": "tsc --noEmit",
-    "check": "yarn run build:constants && yarn run build:errors && tsc --noEmit && yarn run check:lint",
+    "check": "yarn run build:constants && yarn run build:errors && yarn run build:docs && tsc --noEmit && yarn run check:lint && git diff --exit-code src/error/generated.ts api/",
     "pods": "cd test/app && pod-install --quiet",
     "prepare": "yarn run build:constants && bob build",
     "release": "release",
@@ -91,7 +91,7 @@
   "husky": {
     "hooks": {
       "commit-msg": "commitlint -E HUSKY_GIT_PARAMS",
-      "pre-commit": "yarn run check && yarn run build:errors && yarn run build:docs && git diff --exit-code src/error/generated.ts api/"
+      "pre-commit": "yarn run check"
     }
   },
   "commitlint": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "check:lint": "eslint \"**/*.{js,ts,tsx}\"",
     "check:test": "jest",
     "check:type": "tsc --noEmit",
-    "check": "yarn run build:constants yarn run build:errors && tsc --noEmit && yarn run check:lint",
+    "check": "yarn run build:constants && yarn run build:errors && tsc --noEmit && yarn run check:lint",
     "pods": "cd test/app && pod-install --quiet",
     "prepare": "yarn run build:constants && bob build",
     "release": "release",

--- a/src/__mocks__/Call.ts
+++ b/src/__mocks__/Call.ts
@@ -13,6 +13,7 @@ export function createNativeCallInfo(): NativeCallInfo {
     },
     from: 'mock-nativecallinfo-from',
     isMuted: false,
+    initialConnectedTimestamp: 0,
     isOnHold: false,
     sid: 'mock-nativecallinfo-sid',
     to: 'mock-nativecallinfo-to',

--- a/src/__tests__/Call.test.ts
+++ b/src/__tests__/Call.test.ts
@@ -387,7 +387,7 @@ describe('Call class', () => {
     });
 
     describe('.getInitialConnectedTimestamp', () => {
-      it('does the thing', () => {
+      it('gets the timestamp', () => {
         const nativeInfo = createNativeCallInfo();
         nativeInfo.initialConnectedTimestamp = 12321;
         const call = new Call(nativeInfo);

--- a/src/__tests__/Call.test.ts
+++ b/src/__tests__/Call.test.ts
@@ -386,6 +386,15 @@ describe('Call class', () => {
       });
     });
 
+    describe('.getInitialConnectedTimestamp', () => {
+      it('does the thing', () => {
+        const nativeInfo = createNativeCallInfo();
+        nativeInfo.initialConnectedTimestamp = 12321;
+        const call = new Call(nativeInfo);
+        expect(call.getInitialConnectedTimestamp()).toBe(12321);
+      });
+    });
+
     describe('.getSid', () => {
       it('returns the sid value', () => {
         const sid = new Call(createNativeCallInfo()).getSid();
@@ -395,8 +404,17 @@ describe('Call class', () => {
 
     describe('.getState', () => {
       it('returns the call state', () => {
-        const state = new Call(createNativeCallInfo()).getState();
-        expect(state).toBe(Call.State.Connecting);
+        const nativeInfo = createNativeCallInfo();
+        nativeInfo.state = Call.State.Ringing;
+        const call = new Call(nativeInfo);
+        expect(call.getState()).toBe(Call.State.Ringing);
+      });
+
+      it('returns the default call state if missing from the native info', () => {
+        const nativeInfo = createNativeCallInfo();
+        nativeInfo.state = undefined;
+        const call = new Call(nativeInfo);
+        expect(call.getState()).toBe(Call.State.Connecting);
       });
     });
 

--- a/src/type/Call.ts
+++ b/src/type/Call.ts
@@ -1,14 +1,17 @@
 import type { Constants } from '../constants';
 import type { CustomParameters, Uuid } from './common';
 import type { NativeErrorInfo } from './Error';
+import type { Call } from '../Call';
 
 export interface NativeCallInfo {
   uuid: Uuid;
   customParameters?: CustomParameters;
   from?: string;
+  initialConnectedTimestamp?: number;
   isMuted?: boolean;
   isOnHold?: boolean;
   sid?: string;
+  state?: Call.State;
   to?: string;
 }
 

--- a/test/app/src/hook.ts
+++ b/test/app/src/hook.ts
@@ -311,7 +311,11 @@ export function useVoice(token: string) {
     voice.getCalls().then((callsMap) => {
       const readableCalls: Record<string, any> = {};
       for (const [callUuid, _callInfo] of callsMap.entries()) {
-        readableCalls[callUuid] = _callInfo.getSid();
+        readableCalls[callUuid] = {
+          sid: _callInfo.getSid(),
+          state: _callInfo.getState(),
+          initialConnectedTimestamp: _callInfo.getInitialConnectedTimestamp(),
+        };
       }
       logEvent(JSON.stringify(readableCalls, null, 2));
     });

--- a/test/app/src/type.ts
+++ b/test/app/src/type.ts
@@ -13,7 +13,7 @@ export interface BoundCallInfo {
   customParameters: Record<any, any>;
   from?: string;
   to?: string;
-  state?: string;
+  state?: Call.State;
   sid?: string;
   isMuted?: boolean;
   isOnHold?: boolean;


### PR DESCRIPTION
## Submission Checklist

 - [x] Updated the `CHANGELOG.md` to reflect any **feature**, **bug fixes**, or **known issues** made in the source code
 - [x] Tested code changes and observed expected behavior in the example app
 - [x] Performed a visual inspection of the `Files changed` tab prior to submitting the pull request for review to ensure proper usage of the style guide

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Description

This PR introduces `Call.getInitialConnectedTimestamp` (milliseconds since epoch)` and the native layer support for it. Also introduces `Call.State` caching on the native layer.

Minor fixes include better CI and precommit checks.

## Breakdown

- Android changes to serialize the call state and cache the initial connected timestamp.
- iOS changes for the above.
- JS changes for the above.
- Improve checks.

## Validation

- Manually tested using the test app on Android and on iOS.

## Additional Notes

N/A
