### PR TITLE
VBLOCKS-2012 Switching from Bluetooth to iPhone earpiece

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ Twilio Voice React Native SDK has now reached milestone `beta.3`. Included in th
 
 - Incoming call notifications can now be tapped to bring the application into the foreground.
 
+## Fixes
+
+- Fixed a bug where switching from Bluetooth to the iOS earpiece during a call does not have any effect or error.
+
 1.0.0-beta.2 (June 23, 2023)
 ============================
 

--- a/ios/TwilioVoiceReactNative.m
+++ b/ios/TwilioVoiceReactNative.m
@@ -295,7 +295,7 @@ static TVODefaultAudioDevice *sTwilioAudioDevice;
     NSLog(@"Selecting %@(%@), %@", device[kTwilioVoiceReactNativeAudioDeviceKeyName], device[kTwilioVoiceReactNativeAudioDeviceKeyType], device[kTwilioVoiceAudioDeviceUid]);
 
     AVAudioSessionPortDescription *portDescription = nil;
-    if ([portType isEqualToString:@"Earpiece"]) {
+    if ([portType isEqualToString:kTwilioVoiceReactNativeAudioDeviceKeyEarpiece]) {
         NSArray *availableInputs = [[AVAudioSession sharedInstance] availableInputs];
         for (AVAudioSessionPortDescription *port in availableInputs) {
             if ([port.portType isEqualToString:AVAudioSessionPortBuiltInMic]) {
@@ -308,7 +308,7 @@ static TVODefaultAudioDevice *sTwilioAudioDevice;
             NSLog(@"Built-in mic not found");
             return NO;
         }
-    } else if ([portType isEqualToString:@"Bluetooth"]) {
+    } else if ([portType isEqualToString:kTwilioVoiceReactNativeAudioDeviceKeyBluetooth]) {
         NSArray *availableInputs = [[AVAudioSession sharedInstance] availableInputs];
         for (AVAudioSessionPortDescription *port in availableInputs) {
             if ([port.UID isEqualToString:portUid]) {
@@ -331,14 +331,15 @@ static TVODefaultAudioDevice *sTwilioAudioDevice;
         return NO;
     }
 
-    // Override output to speaker if speaker is selected, otherwise choose "none"
-    AVAudioSessionPortOverride outputOverride = ([portType isEqualToString:@"Speaker"])?
-                                                AVAudioSessionPortOverrideSpeaker : AVAudioSessionPortOverrideNone;
-    NSError *outputError;
-    [[AVAudioSession sharedInstance] overrideOutputAudioPort:outputOverride error:&outputError];
-    if (outputError) {
-        NSLog(@"Failed to override output port: %@", outputError);
-        return NO;
+    // Override output to speaker if speaker is selected
+    if ([portType isEqualToString:kTwilioVoiceReactNativeAudioDeviceKeySpeaker]) {
+        AVAudioSessionPortOverride outputOverride = AVAudioSessionPortOverrideSpeaker;
+        NSError *outputError;
+        [[AVAudioSession sharedInstance] overrideOutputAudioPort:outputOverride error:&outputError];
+        if (outputError) {
+            NSLog(@"Failed to override output port: %@", outputError);
+            return NO;
+        }
     }
 
     return YES;


### PR DESCRIPTION
## Submission Checklist

 - [ ] Updated the `CHANGELOG.md` to reflect any **feature**, **bug fixes**, or **known issues** made in the source code
 - [ ] Tested code changes and observed expected behavior in the example app
 - [ ] Performed a visual inspection of the `Files changed` tab prior to submitting the pull request for review to ensure proper usage of the style guide

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [ ] I acknowledge that all my contributions will be made under the project's license.

## Description

Fixed an issue when switching from Bluetooth to earpiece does not have any effect or error on iOS. Turns out the audio-port override at the end of the device selection function is only needed when switching to the speaker.

## Breakdown

- Only do audio port override when switching to the speaker

## Validation

- Ran call test and tried switching between speaker, earpiece and Bluetooth

## Additional Notes

[Any additional comments, notes, or information relevant to reviewers.]
