### PR TITLE
VBLOCKS-2080 Remove canceled call invite before ending CallKit call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+1.0.0-beta.4 (Ongoing)
+==============================
+
+Twilio Voice React Native SDK has now reached milestone `beta.4`. Included in this version are the following.
+
+## Fixes
+
+#### iOS
+- Fixed a bug where the call invite results in a rejected event when the call is hung up by the caller.
+
 1.0.0-beta.3 (August 26, 2023)
 ==============================
 

--- a/ios/TwilioVoiceReactNative+CallInvite.m
+++ b/ios/TwilioVoiceReactNative+CallInvite.m
@@ -44,6 +44,8 @@
                               kTwilioVoiceReactNativeVoiceErrorKeyError: @{kTwilioVoiceReactNativeVoiceErrorKeyCode: @(error.code),
                                                                            kTwilioVoiceReactNativeVoiceErrorKeyMessage: [error localizedDescription]}}];
     
+    [self.callInviteMap removeObjectForKey:uuid];
+    
     [self endCallWithUuid:[[NSUUID alloc] initWithUUIDString:uuid]];
 }
 


### PR DESCRIPTION
## Submission Checklist

 - [x] Updated the `CHANGELOG.md` to reflect any **feature**, **bug fixes**, or **known issues** made in the source code
 - [ ] Tested code changes and observed expected behavior in the example app
 - [ ] Performed a visual inspection of the `Files changed` tab prior to submitting the pull request for review to ensure proper usage of the style guide

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Description

(iOS) Performing the CallKit end-call action while the UUID of the call invite is still in the map will result in an extra invite-rejected event (#211 )

## Breakdown

- Remove from call-invite map before performing CallKit end-call action
- Mention bugfix in changelog

## Validation

- Validated behavior locally
