### PR TITLE
VBLOCKS-2086 longlong value for millisecond timestamp (iOS call initial-connected-timestamp)

### DIFF
--- a/ios/TwilioVoiceReactNative+CallKit.m
+++ b/ios/TwilioVoiceReactNative+CallKit.m
@@ -319,10 +319,9 @@ NSString * const kCustomParametersKeyDisplayName = @"displayName";
         self.callKitCompletionCallback = nil;
     }
     
-    NSTimeInterval timeStamp = [[NSDate date] timeIntervalSince1970];
-    // NSTimeInterval is defined as double
-    NSNumber *timeStampObj = [NSNumber numberWithDouble:timeStamp];
-    [self.callConnectMap setValue:timeStampObj forKey:call.uuid.UUIDString];
+    NSDate *timestamp = [NSDate date];
+    long long timestampMs = [[NSNumber numberWithDouble:[timestamp timeIntervalSince1970]] doubleValue] * 1000;
+    self.callConnectMap[call.uuid.UUIDString] = [NSNumber numberWithLongLong:timestampMs];
 }
 
 - (void)call:(TVOCall *)call didDisconnectWithError:(NSError *)error {

--- a/ios/TwilioVoiceReactNative+CallKit.m
+++ b/ios/TwilioVoiceReactNative+CallKit.m
@@ -308,6 +308,10 @@ NSString * const kCustomParametersKeyDisplayName = @"displayName";
 }
 
 - (void)callDidConnect:(TVOCall *)call {
+    NSDate *timestamp = [NSDate date];
+    long long timestampMs = [[NSNumber numberWithDouble:[timestamp timeIntervalSince1970]] doubleValue] * 1000;
+    self.callConnectMap[call.uuid.UUIDString] = [NSNumber numberWithLongLong:timestampMs];
+
     [self stopRingback];
 
     [self sendEventWithName:kTwilioVoiceReactNativeScopeCall
@@ -318,10 +322,6 @@ NSString * const kCustomParametersKeyDisplayName = @"displayName";
         self.callKitCompletionCallback(YES);
         self.callKitCompletionCallback = nil;
     }
-    
-    NSDate *timestamp = [NSDate date];
-    long long timestampMs = [[NSNumber numberWithDouble:[timestamp timeIntervalSince1970]] doubleValue] * 1000;
-    self.callConnectMap[call.uuid.UUIDString] = [NSNumber numberWithLongLong:timestampMs];
 }
 
 - (void)call:(TVOCall *)call didDisconnectWithError:(NSError *)error {


### PR DESCRIPTION
## Submission Checklist

 - [ ] Updated the `CHANGELOG.md` to reflect any **feature**, **bug fixes**, or **known issues** made in the source code
 - [ ] Tested code changes and observed expected behavior in the example app
 - [ ] Performed a visual inspection of the `Files changed` tab prior to submitting the pull request for review to ensure proper usage of the style guide

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Description

longlong value for millisecond timestamp (iOS call initial-connected-timestamp)

## Breakdown

- Convert timestamp to longlong value

## Validation

- Ran and printed the longlong (millisecond) value to the log
![IMG_86C5E10E3FF2-1](https://github.com/twilio/twilio-voice-react-native/assets/16326574/299ba651-8e8f-43dd-9075-4e04d0abab8e)
