### PR TITLE
fix: possible notification id race condition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+1.0.0-beta.4 (In Progress)
+==========================
+
+Twilio Voice React Native SDK has now reached milestone `beta.4`. Included in this version are the following.
+
+## Fixes
+
+### Platform Specific Fixes
+
+#### Android
+- Fixed a potential race condition when rejecting a call invite involving null notification IDs.
+
 1.0.0-beta.3 (August 26, 2023)
 ==============================
 

--- a/android/src/main/java/com/twiliovoicereactnative/TwilioVoiceReactNativeModule.java
+++ b/android/src/main/java/com/twiliovoicereactnative/TwilioVoiceReactNativeModule.java
@@ -538,7 +538,7 @@ public class TwilioVoiceReactNativeModule extends ReactContextBaseJavaModule {
 
     WritableMap callInfo = serializeCall(callInviteUuid, call);
 
-    Storage.releaseCallInviteStorage(callInviteUuid, activeCallInvite.getCallSid(), Storage.uuidNotificaionIdMap.get(callInviteUuid), "accept");
+    Storage.releaseCallInviteStorage(callInviteUuid, activeCallInvite.getCallSid(), notificationId, "accept");
 
     promise.resolve(callInfo);
   }

--- a/test/app/src/hook.ts
+++ b/test/app/src/hook.ts
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import {
   AudioDevice,
   Call,
@@ -6,6 +5,8 @@ import {
   CancelledCallInvite,
   Voice,
 } from '@twilio/voice-react-native-sdk';
+import * as React from 'react';
+import { Platform } from 'react-native';
 import type {
   BoundCallInfo,
   BoundCallInvite,
@@ -344,7 +345,10 @@ export function useVoice(token: string) {
     voice.getVersion().then(setSdkVersion);
 
     const bootstrap = async () => {
-      await voice.initializePushRegistry();
+      if (Platform.OS === 'ios') {
+        await voice.initializePushRegistry();
+      }
+
       const calls = await voice.getCalls();
 
       for (const call of calls.values()) {


### PR DESCRIPTION
## Submission Checklist

 - [x] Updated the `CHANGELOG.md` to reflect any **feature**, **bug fixes**, or **known issues** made in the source code
 - [x] Tested code changes and observed expected behavior in the example app
 - [x] Performed a visual inspection of the `Files changed` tab prior to submitting the pull request for review to ensure proper usage of the style guide

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Description

This PR fixes a potential null pointer exception when referencing the notification ID of an incoming call invite.

## Breakdown

- Re-use notification ID variable when rejecting a call invite.

## Validation

- Manual testing.

## Additional Notes

N/A
