### PR TITLE
VBLOCKS-2222 Fire registered and unregistered events when the requests are done

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Twilio Voice React Native SDK has now reached milestone `beta.4`. Included in th
 
 #### iOS
 - Fixed a bug where the call invite results in a rejected event when the call is hung up by the caller.
+- Fixed a bug where the `registered` and `unregistered` events are not fired on iOS.
 
 #### Android
 - Replace frontline notification images with generic phone images

--- a/ios/TwilioVoiceReactNative.m
+++ b/ios/TwilioVoiceReactNative.m
@@ -475,6 +475,8 @@ RCT_EXPORT_METHOD(voice_register:(NSString *)accessToken
                                                                                            kTwilioVoiceReactNativeVoiceErrorKeyMessage: [error localizedDescription]}}];
                     reject(kTwilioVoiceReactNativeVoiceError, errorMessage, nil);
                 } else {
+                    [self sendEventWithName:kTwilioVoiceReactNativeScopeVoice
+                                       body:@{kTwilioVoiceReactNativeVoiceEventType: kTwilioVoiceReactNativeVoiceEventRegistered}];
                     resolve(nil);
                 }
             }];
@@ -540,6 +542,8 @@ RCT_EXPORT_METHOD(voice_unregister:(NSString *)accessToken
                                                                                            kTwilioVoiceReactNativeVoiceErrorKeyMessage: [error localizedDescription]}}];
                     reject(kTwilioVoiceReactNativeVoiceError, errorMessage, nil);
                 } else {
+                    [self sendEventWithName:kTwilioVoiceReactNativeScopeVoice
+                                       body:@{kTwilioVoiceReactNativeVoiceEventType: kTwilioVoiceReactNativeVoiceEventUnregistered}];
                     resolve(nil);
                 }
             }];


### PR DESCRIPTION
## Submission Checklist

 - [ ] Updated the `CHANGELOG.md` to reflect any **feature**, **bug fixes**, or **known issues** made in the source code
 - [ ] Tested code changes and observed expected behavior in the example app
 - [ ] Performed a visual inspection of the `Files changed` tab prior to submitting the pull request for review to ensure proper usage of the style guide

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [ ] I acknowledge that all my contributions will be made under the project's license.

## Description

The iOS native layer is not firing the `registered` and `unregistered` events when the requests are done. Adding the event emitting before resolving the promise.
