### PR TITLE
VBLOCKS-1067: Added  sdk version override

### DIFF
--- a/android/src/main/java/com/twiliovoicereactnative/TwilioVoiceReactNativeModule.java
+++ b/android/src/main/java/com/twiliovoicereactnative/TwilioVoiceReactNativeModule.java
@@ -37,6 +37,7 @@ import java.util.UUID;
 
 import static com.twiliovoicereactnative.AndroidEventEmitter.EVENT_KEY_CALL_INVITE_INFO;
 import static com.twiliovoicereactnative.CommonConstants.ReactNativeVoiceSDK;
+import static com.twiliovoicereactnative.CommonConstants.ReactNativeVoiceSDKVer;
 import static com.twiliovoicereactnative.CommonConstants.VoiceEventType;
 import static com.twiliovoicereactnative.CommonConstants.VoiceErrorKeyError;
 import static com.twiliovoicereactnative.CommonConstants.VoiceErrorKeyCode;
@@ -54,6 +55,7 @@ public class TwilioVoiceReactNativeModule extends ReactContextBaseJavaModule {
   static final String TAG = "TwilioVoiceReactNative";
 
   private static final String GLOBAL_ENV = "com.twilio.voice.env";
+  private static final String SDK_VERSION = "com.twilio.voice.env.sdk.version";
 
   private final ReactApplicationContext reactContext;
   private final AudioSwitchManager audioSwitchManager;
@@ -63,6 +65,7 @@ public class TwilioVoiceReactNativeModule extends ReactContextBaseJavaModule {
     this.reactContext = reactContext;
 
     System.setProperty(GLOBAL_ENV, ReactNativeVoiceSDK);
+    System.setProperty(SDK_VERSION, ReactNativeVoiceSDKVer);
 
     if (BuildConfig.DEBUG) {
       Voice.setLogLevel(LogLevel.DEBUG);

--- a/constants/constants.src
+++ b/constants/constants.src
@@ -1,5 +1,6 @@
 // React Native Voice SDK
 ReactNativeVoiceSDK=react-native
+ReactNativeVoiceSDKVer=1.0.0-dev
 
 // Scope names
 ScopeVoice=scopeVoice

--- a/scripts/constants.js
+++ b/scripts/constants.js
@@ -172,7 +172,7 @@ async function substituteVersion(constantsPath) {
     const packageJsonSource = (await readFile(packageJsonPath)).toString('utf-8');
 
     const json = JSON.parse(packageJsonSource);
-    const version = json['version'];
+    const version = json.version;
 
     const constantsInput = (await readFile(constantsPath)).toString('utf-8');
     const constantsOutput= constantsInput.replace(

--- a/scripts/constants.js
+++ b/scripts/constants.js
@@ -177,7 +177,7 @@ async function substituteVersion(constantsPath) {
   const constantsInput = (await readFile(constantsPath)).toString('utf-8');
   const constantsOutput = constantsInput.replace(
     /(ReactNativeVoiceSDKVer\s*=\s*)(.*)/g,
-    "$1" + version
+    '$1' + version
   );
 
   await writeFile(constantsPath, constantsOutput);

--- a/scripts/constants.js
+++ b/scripts/constants.js
@@ -175,9 +175,9 @@ async function substituteVersion(constantsPath) {
     const version = json.version;
 
     const constantsInput = (await readFile(constantsPath)).toString('utf-8');
-    const constantsOutput= constantsInput.replace(
-	/(ReactNativeVoiceSDKVer\s*=\s*)(.*)/g,
-	"$1" + version
+    const constantsOutput = constantsInput.replace(
+        /(ReactNativeVoiceSDKVer\s*=\s*)(.*)/g,
+        "$1" + version
     );
 
     await writeFile(constantsPath, constantsOutput);

--- a/scripts/constants.js
+++ b/scripts/constants.js
@@ -175,6 +175,9 @@ async function substituteVersion(constantsPath) {
   const version = json.version;
 
   const constantsInput = (await readFile(constantsPath)).toString('utf-8');
+  /**
+   * NOTE(afalls): revisit VBLOCKS-2285
+   */
   const constantsOutput = constantsInput.replace(
     /(ReactNativeVoiceSDKVer\s*=\s*)(.*)/g,
     '$1' + version

--- a/scripts/constants.js
+++ b/scripts/constants.js
@@ -175,7 +175,10 @@ async function substituteVersion(constantsPath) {
     const version = json['version'];
 
     const constantsInput = (await readFile(constantsPath)).toString('utf-8');
-    const constantsOutput= constantsInput.replace(/(ReactNativeVoiceSDKVer\s*=\s*)(.*)/g, "$1" + version);
+    const constantsOutput= constantsInput.replace(
+	/(ReactNativeVoiceSDKVer\s*=\s*)(.*)/g,
+	"$1" + version
+    );
 
     await writeFile(constantsPath, constantsOutput);
 }

--- a/scripts/constants.js
+++ b/scripts/constants.js
@@ -168,19 +168,19 @@ async function transform(constantsPath, templatePath, outputPath) {
 }
 
 async function substituteVersion(constantsPath) {
-    const packageJsonPath = './package.json';
-    const packageJsonSource = (await readFile(packageJsonPath)).toString('utf-8');
+  const packageJsonPath = './package.json';
+  const packageJsonSource = (await readFile(packageJsonPath)).toString('utf-8');
 
-    const json = JSON.parse(packageJsonSource);
-    const version = json.version;
+  const json = JSON.parse(packageJsonSource);
+  const version = json.version;
 
-    const constantsInput = (await readFile(constantsPath)).toString('utf-8');
-    const constantsOutput = constantsInput.replace(
-        /(ReactNativeVoiceSDKVer\s*=\s*)(.*)/g,
-        "$1" + version
-    );
+  const constantsInput = (await readFile(constantsPath)).toString('utf-8');
+  const constantsOutput = constantsInput.replace(
+    /(ReactNativeVoiceSDKVer\s*=\s*)(.*)/g,
+    "$1" + version
+  );
 
-    await writeFile(constantsPath, constantsOutput);
+  await writeFile(constantsPath, constantsOutput);
 }
 
 async function main() {

--- a/scripts/constants.js
+++ b/scripts/constants.js
@@ -167,8 +167,24 @@ async function transform(constantsPath, templatePath, outputPath) {
   await writeFile(outputPath, mergedConstants.join('\n'));
 }
 
+async function substituteVersion(constantsPath) {
+    const packageJsonPath = './package.json';
+    const packageJsonSource = (await readFile(packageJsonPath)).toString('utf-8');
+
+    const json = JSON.parse(packageJsonSource);
+    const version = json['version'];
+
+    const constantsInput = (await readFile(constantsPath)).toString('utf-8');
+    const constantsOutput= constantsInput.replace(/(ReactNativeVoiceSDKVer\s*=\s*)(.*)/g, "$1" + version);
+
+    await writeFile(constantsPath, constantsOutput);
+}
+
 async function main() {
   const constantsPath = './constants/constants.src';
+
+  // Substitute version
+  await substituteVersion(constantsPath);
 
   // Transform TS files
   const tsTemplatePath = './constants/constants.typescript.template';


### PR DESCRIPTION
## Submission Checklist

 - [ ] Updated the `CHANGELOG.md` to reflect any **feature**, **bug fixes**, or **known issues** made in the source code
 - [ ] Tested code changes and observed expected behavior in the example app
 - [ ] Performed a visual inspection of the `Files changed` tab prior to submitting the pull request for review to ensure proper usage of the style guide

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Description

Added the ability to override the SDK version for insights publishing

## Breakdown

- Modified such that version is overridden by package.json
- Made it use Constants.src so that its a platform neutral way.

## Validation

- None
## Additional Notes


