### PR TITLE
VBLOCKS-2093: Improved handling of call invite rejected, one code path now

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ Twilio Voice React Native SDK has now reached milestone `beta.4`. Included in th
 #### Android
 - Replace frontline notification images with generic phone images
 - In call notifications now display when accepting a call from JS application
+- Internal simplification of call accepted/rejected intent message paths
+
 
 1.0.0-beta.3 (August 26, 2023)
 ==============================

--- a/android/src/main/java/com/twiliovoicereactnative/IncomingCallNotificationService.java
+++ b/android/src/main/java/com/twiliovoicereactnative/IncomingCallNotificationService.java
@@ -135,11 +135,14 @@ public class IncomingCallNotificationService extends Service {
   private void rejectCall(CallInvite callInvite, int notificationId, String uuid) {
     endForeground();
     callInvite.reject(getApplicationContext());
-    Storage.releaseCallInviteStorage(uuid, callInvite.getCallSid(), notificationId, "reject");
 
     Intent rejectCallInviteIntent = new Intent(Constants.ACTION_REJECT);
     rejectCallInviteIntent.putExtra(Constants.INCOMING_CALL_INVITE, callInvite);
+    rejectCallInviteIntent.putExtra(Constants.NOTIFICATION_ID, notificationId);
     rejectCallInviteIntent.putExtra(Constants.UUID, uuid);
+
+    // Send the broadcast in case TwilioVoiceReactNative is loaded, it can emit the event
+    Storage.uuidNotificationIdMap.put(uuid, notificationId);
     LocalBroadcastManager.getInstance(this).sendBroadcast(rejectCallInviteIntent);
   }
 

--- a/android/src/main/java/com/twiliovoicereactnative/Storage.java
+++ b/android/src/main/java/com/twiliovoicereactnative/Storage.java
@@ -27,6 +27,7 @@ public class Storage {
   static final Map<String, CancelledCallInvite> cancelledCallInviteMap = new HashMap<>();
   // A map to keep uuid and js promise objects associated
   static final Map<String, Promise> callAcceptedPromiseMap = new HashMap<>();
+  static final Map<String, Promise> callRejectPromiseMap = new HashMap<>();
 
   static void releaseCallInviteStorage(String uuid, String callSid, int notificationId, String action) {
     Log.d(TAG, "Removing items in callInviteMap" +
@@ -38,5 +39,6 @@ public class Storage {
     Storage.callInviteCallSidUuidMap.remove(callSid);
     Storage.uuidNotificationIdMap.remove(uuid);
     Storage.callAcceptedPromiseMap.remove(uuid);
+    Storage.callRejectPromiseMap.remove(uuid);
   }
 }

--- a/android/src/main/java/com/twiliovoicereactnative/TwilioVoiceReactNativeModule.java
+++ b/android/src/main/java/com/twiliovoicereactnative/TwilioVoiceReactNativeModule.java
@@ -538,24 +538,24 @@ public class TwilioVoiceReactNativeModule extends ReactContextBaseJavaModule {
   public void callInvite_reject(String uuid, Promise promise) {
     Log.d(TAG, "callInvite_reject uuid" + uuid);
     try {
-      CallInvite activeCallInvite = Storage.callInviteMap.get(uuid);
+      CallInvite callInvite = Storage.callInviteMap.get(uuid);
 
-      if (activeCallInvite == null) {
+      if (callInvite == null) {
         promise.reject("No such \"callInvite\" object exists with UUID " + uuid);
         return;
       }
 
-      activeCallInvite.reject(getReactApplicationContext());
+      // Store promise for callback
+      Storage.callRejectPromiseMap.put(uuid, promise);
 
-      int notificationId = Storage.uuidNotificationIdMap.get(uuid);
+      // Send Event to service
+      final int notificationId = Storage.uuidNotificationIdMap.get(uuid);
       Intent rejectIntent = new Intent(getReactApplicationContext(), IncomingCallNotificationService.class);
-      rejectIntent.setAction(Constants.ACTION_CANCEL_NOTIFICATION);
+      rejectIntent.setAction(Constants.ACTION_REJECT);
       rejectIntent.putExtra(Constants.NOTIFICATION_ID, notificationId);
       rejectIntent.putExtra(Constants.UUID, uuid);
+      rejectIntent.putExtra(Constants.INCOMING_CALL_INVITE, callInvite);
       getReactApplicationContext().startService(rejectIntent);
-
-      Storage.releaseCallInviteStorage(uuid, activeCallInvite.getCallSid(), Storage.uuidNotificationIdMap.get(uuid), "reject");
-      promise.resolve(uuid);
     } catch (Exception e) {
       promise.reject("Internal Error: " + e.getMessage());
       e.printStackTrace();

--- a/android/src/main/java/com/twiliovoicereactnative/VoiceBroadcastReceiver.java
+++ b/android/src/main/java/com/twiliovoicereactnative/VoiceBroadcastReceiver.java
@@ -158,10 +158,10 @@ public class VoiceBroadcastReceiver extends BroadcastReceiver {
 
         if (Storage.callRejectPromiseMap.containsKey(uuid)) {
           Promise promise = Storage.callRejectPromiseMap.get(uuid);
-          Storage.releaseCallInviteStorage(uuid, callInvite.getCallSid(), Storage.uuidNotificationIdMap.get(uuid), "accept");
+          Storage.releaseCallInviteStorage(uuid, callInvite.getCallSid(), Storage.uuidNotificationIdMap.get(uuid), "reject");
           promise.resolve(uuid);
         } else {
-          Storage.releaseCallInviteStorage(uuid, callInvite.getCallSid(), Storage.uuidNotificationIdMap.get(uuid), "accept");
+          Storage.releaseCallInviteStorage(uuid, callInvite.getCallSid(), Storage.uuidNotificationIdMap.get(uuid), "reject");
         }
         break;
       case Constants.ACTION_CANCEL_CALL:

--- a/android/src/main/java/com/twiliovoicereactnative/VoiceBroadcastReceiver.java
+++ b/android/src/main/java/com/twiliovoicereactnative/VoiceBroadcastReceiver.java
@@ -155,6 +155,14 @@ public class VoiceBroadcastReceiver extends BroadcastReceiver {
         params.putMap(EVENT_KEY_CALL_INVITE_INFO, callInviteInfo);
 
         AndroidEventEmitter.getInstance().sendEvent(ScopeVoice, params);
+
+        if (Storage.callRejectPromiseMap.containsKey(uuid)) {
+          Promise promise = Storage.callRejectPromiseMap.get(uuid);
+          Storage.releaseCallInviteStorage(uuid, callInvite.getCallSid(), Storage.uuidNotificationIdMap.get(uuid), "accept");
+          promise.resolve(uuid);
+        } else {
+          Storage.releaseCallInviteStorage(uuid, callInvite.getCallSid(), Storage.uuidNotificationIdMap.get(uuid), "accept");
+        }
         break;
       case Constants.ACTION_CANCEL_CALL:
         Log.d(TAG, "Successfully received cancel notification");


### PR DESCRIPTION
## Submission Checklist

 - [x] Updated the `CHANGELOG.md` to reflect any **feature**, **bug fixes**, or **known issues** made in the source code
 - [x] Tested code changes and observed expected behavior in the example app
 - [x] Performed a visual inspection of the `Files changed` tab prior to submitting the pull request for review to ensure proper usage of the style guide

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Description

Improved such that there exists one code path for the call-rejected messages and verified that indeed, when the activity is running, an event is fired for call-rejected. _**NOTE: Without redesigning the SDK, there is no way to have the JS layer receive the event when the activity is minimized.**_


## Breakdown

- Cleaned up message flow for call-invite-rejected events. This is similar to what was done for call accepted.
- Verified best possible behavior is available.

## Validation

- Ran both test cases, call invite with application foregrounded, and with application backgrounded.

## Additional Notes

None
