### PR TITLE
[VBLOCKS-2450] fix(ios): do not send explicit null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Twilio Voice React Native SDK has now reached milestone `beta.4`. Included in th
 - Narrowed the `CustomParameters` type to `Record<string, string>` instead of `Record<string, any>`.
 - Fixed inconsistency with `AudioDevice` typings, preferring `undefined` over `null` for optional values.
 - Fixed an issue with `call.isMuted()` and `call.isOnHold()` APIs. They should now always return `boolean | undefined` instead of potentially returning `null`.
+- Fixed an issue with `call.getFrom()`, `call.getTo()`, and `call.getSid()` APIs. They should now always return `string | undefined` instead of potentially returning `null`.
 
 #### iOS
 - Fixed a bug where the call invite results in a rejected event when the call is hung up by the caller.


### PR DESCRIPTION
## Submission Checklist

 - [x] Updated the `CHANGELOG.md` to reflect any **feature**, **bug fixes**, or **known issues** made in the source code
 - [x] Tested code changes and observed expected behavior in the example app
 - [x] Performed a visual inspection of the `Files changed` tab prior to submitting the pull request for review to ensure proper usage of the style guide

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Description

This PR removes potentially null values from the various info messages we send to the JS layer.

## Breakdown

- Parse through the native iOS layer to see where we send events to the JS layer.
- Find potentially null values and gate sending them to the JS layer.

## Validation

- Tested on a real iOS device using the test app.

## Additional Notes

N/A
