### PR TITLE
VBLOCKS-2474: call timestamp now uses rfc-822 datetime format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+1.0.0-beta.5 (In Progress)
+==========================
+
+Twilio Voice React Native SDK has now reached milestone `beta.5`. Included in this version are the following.
+
+## Fixes
+
+### Platform Specific Features
+
+#### Android
+- Call timestamp now in RFC-822 format, not stored as a double from epoch
+
+
 1.0.0-beta.4 (Jan 11, 2024)
 ==========================
 

--- a/android/src/main/java/com/twiliovoicereactnative/ReactNativeArgumentsSerializer.java
+++ b/android/src/main/java/com/twiliovoicereactnative/ReactNativeArgumentsSerializer.java
@@ -30,6 +30,7 @@ import static com.twiliovoicereactnative.CommonConstants.VoiceErrorKeyCode;
 import static com.twiliovoicereactnative.CommonConstants.VoiceErrorKeyMessage;
 import static com.twiliovoicereactnative.JSEventEmitter.constructJSMap;
 
+import 	java.text.SimpleDateFormat;
 import android.util.Pair;
 
 import androidx.annotation.NonNull;
@@ -46,6 +47,8 @@ import com.twilio.audioswitch.AudioDevice;
 import com.twilio.voice.Call;
 import com.twilio.voice.CallInvite;
 
+import java.util.Date;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
@@ -154,12 +157,9 @@ class ReactNativeArgumentsSerializer {
       new Pair<>(CallInfoState, callStateToString(callRecord.getVoiceCall().getState())),
       new Pair<>(CallInfoIsMuted, callRecord.getVoiceCall().isMuted()),
       new Pair<>(CallInfoIsOnHold, callRecord.getVoiceCall().isOnHold()),
-      new Pair<>(CallInviteInfoCustomParameters, serializeCallInviteCustomParameters(callRecord.getCallInvite())));
-    if (callRecord.getTimestamp() != null) {
-      callInfo.putDouble(
-        CallInfoInitialConnectedTimestamp,
-        (double)callRecord.getTimestamp().getTime());
-    }
+      new Pair<>(CallInviteInfoCustomParameters, serializeCallInviteCustomParameters(callRecord.getCallInvite())),
+      new Pair<>(CallInfoInitialConnectedTimestamp, rfc822DateTimeFormat(callRecord.getTimestamp()))
+    );
     return callInfo;
   }
 
@@ -234,5 +234,12 @@ class ReactNativeArgumentsSerializer {
       previousWarningsArray.pushString(warning.toString());
     }
     return previousWarningsArray;
+  }
+
+  private static String rfc822DateTimeFormat(final Date date) {
+    // Pre-Android 24 only ISO-822 is supported (RFC-822)
+    SimpleDateFormat simpleDateFormat =
+      new SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss Z", Locale.US);
+    return (null != date) ? simpleDateFormat.format(date) : null;
   }
 }

--- a/android/src/main/java/com/twiliovoicereactnative/ReactNativeArgumentsSerializer.java
+++ b/android/src/main/java/com/twiliovoicereactnative/ReactNativeArgumentsSerializer.java
@@ -30,7 +30,7 @@ import static com.twiliovoicereactnative.CommonConstants.VoiceErrorKeyCode;
 import static com.twiliovoicereactnative.CommonConstants.VoiceErrorKeyMessage;
 import static com.twiliovoicereactnative.JSEventEmitter.constructJSMap;
 
-import 	java.text.SimpleDateFormat;
+import java.text.SimpleDateFormat;
 import android.util.Pair;
 
 import androidx.annotation.NonNull;


### PR DESCRIPTION
## Submission Checklist

 - [x] Updated the `CHANGELOG.md` to reflect any **feature**, **bug fixes**, or **known issues** made in the source code
 - [ ] Tested code changes and observed expected behavior in the example app
 - [ ] Performed a visual inspection of the `Files changed` tab prior to submitting the pull request for review to ensure proper usage of the style guide

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Description

Updated JS representation of call time to be in RFC-822 format instead of double

## Breakdown

- Changed JS seralizer for call date-time

## Validation

- look above

## Additional Notes
None
