### PR TITLE
[VBLOCKS-2618] Fix docstring references

### DIFF
--- a/src/Call.tsx
+++ b/src/Call.tsx
@@ -845,43 +845,43 @@ export namespace Call {
   export enum Event {
     /**
      * Event string for the `Connected` event.
-     * See {@link (Call:interface).(addListener:2)}.
+     * See {@link (Call:interface).(addListener:1)}.
      */
     'Connected' = 'connected',
 
     /**
      * Event string for the `ConnectedFailure` event.
-     * See {@link (Call:interface).(addListener:3)}.
+     * See {@link (Call:interface).(addListener:2)}.
      */
     'ConnectFailure' = 'connectFailure',
 
     /**
      * Event string for the `Reconnecting` event.
-     * See {@link (Call:interface).(addListener:4)}.
+     * See {@link (Call:interface).(addListener:3)}.
      */
     'Reconnecting' = 'reconnecting',
 
     /**
      * Event string for the `Reconnected` event.
-     * See {@link (Call:interface).(addListener:5)}.
+     * See {@link (Call:interface).(addListener:4)}.
      */
     'Reconnected' = 'reconnected',
 
     /**
      * Event string for the `Disconnected` event.
-     * See {@link (Call:interface).(addListener:6)}.
+     * See {@link (Call:interface).(addListener:5)}.
      */
     'Disconnected' = 'disconnected',
 
     /**
      * Event string for the `Ringing` event.
-     * See {@link (Call:interface).(addListener:7)}.
+     * See {@link (Call:interface).(addListener:6)}.
      */
     'Ringing' = 'ringing',
 
     /**
      * Event string for the `QualityWarningsChanged` event.
-     * See {@link (Call:interface).(addListener:8)}.
+     * See {@link (Call:interface).(addListener:7)}.
      */
     'QualityWarningsChanged' = 'qualityWarningsChanged',
   }
@@ -891,35 +891,46 @@ export namespace Call {
    */
   export enum State {
     /**
-     * Call `Connected` state. Occurs when the `Connected` event is raised.
+     * Call `Connected` state.
+     *
+     * Occurs when the `Connected` and `Reconnected` event is raised.
      *
      * @remarks
-     * See {@link (Call:interface).(addListener:2)}.
+     *
+     * See {@link (Call:interface).(addListener:1)}.
+     *
+     * See {@link (Call:interface).(addListener:4)}.
      */
     'Connected' = Constants.CallStateConnected,
 
     /**
-     * Call `Connecting` state. Occurs when the `Connecting` event is raised.
+     * Call `Connecting` state.
      *
-     * @remarks
-     * See {@link (Call:interface).(addListener:3)}.
+     * The default state of an outgoing call.
      */
     'Connecting' = Constants.CallStateConnecting,
 
     /**
-     * Call `Disconnected` state. Occurs when the `Disconnected` event is
-     * raised.
+     * Call `Disconnected` state.
+     *
+     * Occurs when the `Disconnected` or `ConnectFailure` event is raised.
      *
      * @remarks
-     * See {@link (Call:interface).(addListener:4)}.
+     *
+     * See {@link (Call:interface).(addListener:5)}.
+     *
+     * See {@link (Call:interface).(addListener:2)}.
      */
     'Disconnected' = Constants.CallStateDisconnected,
 
     /**
-     * Call `Reconnecting` state. Occurs when the `Reconnecting` event is raised.
+     * Call `Reconnecting` state.
+     *
+     * Occurs when the `Reconnecting` event is raised.
      *
      * @remarks
-     * See {@link (Call:interface).(addListener:5)}.
+     *
+     * See {@link (Call:interface).(addListener:3)}.
      */
     'Reconnecting' = Constants.CallStateReconnecting,
 
@@ -927,6 +938,7 @@ export namespace Call {
      * Call `Ringing` state. Occurs when the `Ringing` event is raised.
      *
      * @remarks
+     *
      * See {@link (Call:interface).(addListener:6)}.
      */
     'Ringing' = Constants.CallStateRinging,
@@ -1052,21 +1064,12 @@ export namespace Call {
    */
   export namespace Listener {
     /**
-     * Generic event listener. This should be the function signature of any
-     * event listener bound to any call event.
-     *
-     * @remarks
-     * See {@link (Call:interface).(addListener:1)}.
-     */
-    export type Generic = (...args: any[]) => void;
-
-    /**
      * Connected event listener. This should be the function signature of any
      * event listener bound to the {@link (Call:namespace).Event.Connected}
      * event.
      *
      * @remarks
-     * See {@link (Call:interface).(addListener:2)}.
+     * See {@link (Call:interface).(addListener:1)}.
      */
     export type Connected = () => void;
 
@@ -1076,7 +1079,7 @@ export namespace Call {
      * {@link (Call:namespace).Event.ConnectFailure} event.
      *
      * @remarks
-     * See {@link (Call:interface).(addListener:3)}.
+     * See {@link (Call:interface).(addListener:2)}.
      *
      * See {@link TwilioErrors} for all error classes.
      */
@@ -1088,7 +1091,7 @@ export namespace Call {
      * event.
      *
      * @remarks
-     * See {@link (Call:interface).(addListener:4)}.
+     * See {@link (Call:interface).(addListener:3)}.
      *
      * See {@link TwilioErrors} for all error classes.
      */
@@ -1100,7 +1103,7 @@ export namespace Call {
      * event.
      *
      * @remarks
-     * See {@link (Call:interface).(addListener:5)}.
+     * See {@link (Call:interface).(addListener:4)}.
      */
     export type Reconnected = () => void;
 
@@ -1110,7 +1113,7 @@ export namespace Call {
      * event.
      *
      * @remarks
-     * See {@link (Call:interface).(addListener:6)}.
+     * See {@link (Call:interface).(addListener:5)}.
      *
      * See {@link TwilioErrors} for all error classes.
      */
@@ -1121,7 +1124,7 @@ export namespace Call {
      * event listener bound to the {@link (Call:namespace).Event.Ringing} event.
      *
      * @remarks
-     * See {@link (Call:interface).(addListener:7)}.
+     * See {@link (Call:interface).(addListener:6)}.
      */
     export type Ringing = () => void;
 
@@ -1131,11 +1134,20 @@ export namespace Call {
      * {@link (Call:namespace).Event.QualityWarningsChanged} event.
      *
      * @remarks
-     * See {@link (Call:interface).(addListener:8)}.
+     * See {@link (Call:interface).(addListener:7)}.
      */
     export type QualityWarningsChanged = (
       currentQualityWarnings: Call.QualityWarning[],
       previousQualityWarnings: Call.QualityWarning[]
     ) => void;
+
+    /**
+     * Generic event listener. This should be the function signature of any
+     * event listener bound to any call event.
+     *
+     * @remarks
+     * See {@link (Call:interface).(addListener:8)}.
+     */
+    export type Generic = (...args: any[]) => void;
   }
 }

--- a/src/Voice.tsx
+++ b/src/Voice.tsx
@@ -978,61 +978,99 @@ export namespace Voice {
   export enum Event {
     /**
      * Raised when there is a change in available audio devices.
-     * See {@link (Voice:interface).(addListener:2)
+     *
+     * @remarks
+     *
+     * See {@link (Voice:interface).(addListener:1)
      * | Voice.addListener(AudioDevicesUpdated)}.
      */
     'AudioDevicesUpdated' = 'audioDevicesUpdated',
+
     /**
      * Raised when there is an incoming call invite.
-     * See {@link (Voice:interface).(addListener:3)
+     *
+     * @remarks
+     *
+     * See {@link (Voice:interface).(addListener:2)
      * | Voice.addListener(CallInvite)}.
      */
     'CallInvite' = 'callInvite',
+
     /**
      * Raised when an incoming call invite has been accepted.
+     *
      * This event can be raised either through the SDK or outside of the SDK
      * (i.e. through native UI/UX such as push notifications).
-     * See {@link (Voice:interface).(addListener:4)
+     *
+     * @remarks
+     *
+     * See {@link (Voice:interface).(addListener:3)
      * | Voice.addListener(CallInviteAccepted)}.
      */
     'CallInviteAccepted' = 'callInviteAccepted',
+
     /**
      * Raised when the notification for an incoming call invite has been tapped.
+     *
      * This event is raised only from the native layer, through the push
      * notification.
-     * See {@link (Voice:interface).(addListener:5)}
+     *
+     * @remarks
+     *
+     * See {@link (Voice:interface).(addListener:4)}
      */
     'CallInviteNotificationTapped' = 'callInviteNotificationTapped',
+
     /**
      * Raised when an incoming call invite has been rejected.
+     *
      * This event can be raised either through the SDK or outside of the SDK
      * (i.e. through native UI/UX such as push notifications).
-     * See {@link (Voice:interface).(addListener:6)
+     *
+     * @remarks
+     *
+     * See {@link (Voice:interface).(addListener:5)
      * | Voice.addListener(CallInviteRejected)}.
      */
     'CallInviteRejected' = 'callInviteRejected',
+
     /**
      * Raised when an incoming call invite has been cancelled, thus invalidating
      * the associated call invite.
-     * See {@link (Voice:interface).(addListener:7)
+     *
+     * @remarks
+     *
+     * See {@link (Voice:interface).(addListener:6)
      * | Voice.addListener(CancelledCallInvite)}.
      */
     'CancelledCallInvite' = 'cancelledCallInvite',
+
     /**
      * Raised when the SDK encounters an error.
-     * See {@link (Voice:interface).(addListener:8)
+     *
+     * @remarks
+     *
+     * See {@link (Voice:interface).(addListener:7)
      * | Voice.addListener(Error)}.
      */
     'Error' = 'error',
+
     /**
      * Raised when the SDK is registered for incoming calls.
-     * See {@link (Voice:interface).(addListener:9)
+     *
+     * @remarks
+     *
+     * See {@link (Voice:interface).(addListener:8)
      * | Voice.addListener(Registered)}.
      */
     'Registered' = 'registered',
+
     /**
      * Raised when the SDK is unregistered for incoming calls.
-     * See {@link (Voice:interface).(addListener:10)
+     *
+     * @remarks
+     *
+     * See {@link (Voice:interface).(addListener:9)
      * | Voice.addListener(Unregistered)}.
      */
     'Unregistered' = 'unregistered',
@@ -1044,21 +1082,13 @@ export namespace Voice {
    */
   export namespace Listener {
     /**
-     * Generic event listener. This should be the function signature of any
-     * event listener bound to any voice event.
-     *
-     * @remarks
-     * See {@link (Voice:interface).(addListener:1)}.
-     */
-    export type Generic = (...args: any[]) => void;
-
-    /**
      * Audio devices updated event listener. This should be the function
      * signature of an event listener bound to the
      * {@link (Voice:namespace).Event.AudioDevicesUpdated} event.
      *
      * @remarks
-     * See {@link (Voice:interface).(addListener:2)}.
+     *
+     * See {@link (Voice:interface).(addListener:1)}.
      */
     export type AudioDevicesUpdated = (
       audioDevices: AudioDevice[],
@@ -1071,7 +1101,8 @@ export namespace Voice {
      * {@link (Voice:namespace).Event.CallInvite} event.
      *
      * @remarks
-     * See {@link (Voice:interface).(addListener:3)}.
+     *
+     * See {@link (Voice:interface).(addListener:2)}.
      */
     export type CallInvite = (callInvite: CallInvite) => void;
 
@@ -1081,7 +1112,8 @@ export namespace Voice {
      * {@link (Voice:namespace).Event.CallInviteAccepted} event.
      *
      * @remarks
-     * See {@link (Voice:interface).(addListener:4)}.
+     *
+     * See {@link (Voice:interface).(addListener:3)}.
      */
     export type CallInviteAccepted = (
       callInvite: CallInvite,
@@ -1094,7 +1126,8 @@ export namespace Voice {
      * {@link (Voice:namespace).Event.CallInviteNotificationTapped} event.
      *
      * @remarks
-     * See {@link (Voice:interface).(addListener:5)}.
+     *
+     * See {@link (Voice:interface).(addListener:4)}.
      */
     export type CallInviteNotificationTapped = () => void;
 
@@ -1104,7 +1137,8 @@ export namespace Voice {
      * {@link (Voice:namespace).Event.CallInviteRejected} event.
      *
      * @remarks
-     * See {@link (Voice:interface).(addListener:6)}.
+     *
+     * See {@link (Voice:interface).(addListener:5)}.
      */
     export type CallInviteRejected = (callInvite: CallInvite) => void;
 
@@ -1114,7 +1148,8 @@ export namespace Voice {
      * {@link (Voice:namespace).Event.CancelledCallInvite} event.
      *
      * @remarks
-     * See {@link (Voice:interface).(addListener:7)}.
+     *
+     * See {@link (Voice:interface).(addListener:6)}.
      *
      * See {@link TwilioErrors} for all error classes.
      */
@@ -1129,7 +1164,8 @@ export namespace Voice {
      * {@link (Voice:namespace).Event.Error} event.
      *
      * @remarks
-     * See {@link (Voice:interface).(addListener:8)}.
+     *
+     * See {@link (Voice:interface).(addListener:7)}.
      *
      * See {@link TwilioErrors} for all error classes.
      */
@@ -1141,7 +1177,8 @@ export namespace Voice {
      * {@link (Voice:namespace).Event.Registered} event.
      *
      * @remarks
-     * See {@link (Voice:interface).(addListener:9)}.
+     *
+     * See {@link (Voice:interface).(addListener:8)}.
      */
     export type Registered = () => void;
 
@@ -1151,8 +1188,19 @@ export namespace Voice {
      * {@link (Voice:namespace).Event.Unregistered} event.
      *
      * @remarks
-     * See {@link (Voice:interface).(addListener:10)}.
+     *
+     * See {@link (Voice:interface).(addListener:9)}.
      */
     export type Unregistered = () => void;
+
+    /**
+     * Generic event listener. This should be the function signature of any
+     * event listener bound to any voice event.
+     *
+     * @remarks
+     *
+     * See {@link (Voice:interface).(addListener:10)}.
+     */
+    export type Generic = (...args: any[]) => void;
   }
 }


### PR DESCRIPTION
## Submission Checklist

 - [ ] Updated the `CHANGELOG.md` to reflect any **feature**, **bug fixes**, or **known issues** made in the source code
 - [ ] Tested code changes and observed expected behavior in the example app
 - [x] Performed a visual inspection of the `Files changed` tab prior to submitting the pull request for review to ensure proper usage of the style guide

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Description

This PR fixes some docstring formatting and references in the Voice and Call classes.

## Breakdown

- Add newline spacing where necessary.
- Fix numerical references of `Foo.addListener` docstrings.

## Validation

- Check rendered docs locally.

## Additional Notes

N/A
