### PR TITLE
VBLOCKS-2475 RFC-822 formatted date time string for call initial connected timestamp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ Twilio Voice React Native SDK has now reached milestone `beta.5`. Included in th
 #### Android
 - Call timestamp now in RFC-822 format, not stored as a double from epoch
 
+#### iOS
+- The call connected timestamp is now in RFC-822 format.
+
 
 1.0.0-beta.4 (Jan 11, 2024)
 ==========================

--- a/ios/TwilioVoiceReactNative+CallKit.m
+++ b/ios/TwilioVoiceReactNative+CallKit.m
@@ -308,9 +308,7 @@ NSString * const kCustomParametersKeyDisplayName = @"displayName";
 }
 
 - (void)callDidConnect:(TVOCall *)call {
-    NSDate *timestamp = [NSDate date];
-    long long timestampMs = [[NSNumber numberWithDouble:[timestamp timeIntervalSince1970]] doubleValue] * 1000;
-    self.callConnectMap[call.uuid.UUIDString] = [NSNumber numberWithLongLong:timestampMs];
+    self.callConnectMap[call.uuid.UUIDString] = [self getRFC822FormattedTimestamp:[NSDate date]];
 
     [self stopRingback];
 
@@ -484,6 +482,15 @@ previousWarnings:(NSSet<NSNumber *> *)previousWarnings {
         default:
             return @"undefined";
     }
+}
+
+- (NSString *)getRFC822FormattedTimestamp:(NSDate *)date {
+    NSDateFormatter *formatter = [[NSDateFormatter alloc] init];
+    NSLocale *locale = [NSLocale currentLocale];
+    [formatter setLocale:locale];
+    [formatter setDateFormat:@"EEE, dd MMM yyyy HH:mm:ss Z"];
+
+    return [formatter stringFromDate:date];
 }
 
 @end

--- a/ios/TwilioVoiceReactNative.h
+++ b/ios/TwilioVoiceReactNative.h
@@ -24,7 +24,7 @@ FOUNDATION_EXPORT NSString * const kTwilioVoiceReactNativeEventKeyCancelledCallI
 @interface TwilioVoiceReactNative : RCTEventEmitter <RCTBridgeModule>
 
 @property (nonatomic, readonly, strong) NSMutableDictionary<NSString *, TVOCall *> *callMap;
-@property (nonatomic, readonly, strong) NSMutableDictionary<NSString *, NSNumber *> *callConnectMap;
+@property (nonatomic, readonly, strong) NSMutableDictionary<NSString *, NSString *> *callConnectMap;
 @property (nonatomic, readonly, strong) NSMutableDictionary<NSString *, TVOCallInvite *> *callInviteMap;
 @property (nonatomic, readonly, strong) NSMutableDictionary<NSString *, TVOCancelledCallInvite *> *cancelledCallInviteMap;
 

--- a/ios/TwilioVoiceReactNative.m
+++ b/ios/TwilioVoiceReactNative.m
@@ -353,7 +353,7 @@ static TVODefaultAudioDevice *sTwilioAudioDevice;
         callInfo[kTwilioVoiceReactNativeCallInfoTo] = call.to;
     }
 
-    NSNumber *initialConnectedTimestamp = self.callConnectMap[call.uuid.UUIDString];
+    NSString *initialConnectedTimestamp = self.callConnectMap[call.uuid.UUIDString];
     if (initialConnectedTimestamp != nil) {
         callInfo[kTwilioVoiceReactNativeCallInfoInitialConnectedTimestamp] = initialConnectedTimestamp;
     }


### PR DESCRIPTION
## Submission Checklist

 - [x] Updated the `CHANGELOG.md` to reflect any **feature**, **bug fixes**, or **known issues** made in the source code
 - [x] Tested code changes and observed expected behavior in the example app
 - [x] Performed a visual inspection of the `Files changed` tab prior to submitting the pull request for review to ensure proper usage of the style guide

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Description

RFC-822 formatted date time string for call initial connected timestamp

## Validation

- Built and ran test app locally. Formatted string `Mon, 29 Jan 2024 14:01:52 -0800`
