### PR TITLE
[VBLOCKS-2479] fix(js): use common constants for keying quality warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ Twilio Voice React Native SDK has now reached milestone `beta.5`. Included in th
 
 - Fixed and improved the docstrings for the `Voice` and `Call` listeners. The descriptions of the events and listeners should now point to the correct docstrings.
 - Call quality warning events should now properly pass arguments to listener functions.
+
+## Changes
+
 - The API for `call.getInitialConnectedTimestamp()` has now changed.
   Please see the API documentation [here](https://github.com/twilio/twilio-voice-react-native/blob/latest/docs/api/voice-react-native-sdk.call_class.getinitialconnectedtimestamp_method.md) for details.
   The method `call.getInitialConnectedTimestamp()` now returns a `Date` object.
@@ -16,13 +19,13 @@ Twilio Voice React Native SDK has now reached milestone `beta.5`. Included in th
   const millisecondsSinceEpoch = date.getTime();
   ```
 
-### Platform Specific Fixes
+### Platform Specific Changes
 
 #### Android
-- Call timestamp now in RFC-822 format, not stored as a double from epoch
+- Call timestamp now in simplified ISO-8601 format, not stored as a double from epoch
 
 #### iOS
-- The call connected timestamp is now in RFC-822 format.
+- The call connected timestamp is now in simplified ISO-8601 format.
 
 1.0.0-beta.4 (Jan 11, 2024)
 ===========================

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,12 +3,9 @@
 
 Twilio Voice React Native SDK has now reached milestone `beta.5`. Included in this version are the following.
 
-## Changes
-
-- Fixed and improved the docstrings for the `Voice` and `Call` listeners. The descriptions of the events and listeners should now point to the correct docstrings.
-
 ## Fixes
 
+- Fixed and improved the docstrings for the `Voice` and `Call` listeners. The descriptions of the events and listeners should now point to the correct docstrings.
 - Call quality warning events should now properly pass arguments to listener functions.
 
 1.0.0-beta.4 (Jan 11, 2024)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ Twilio Voice React Native SDK has now reached milestone `beta.5`. Included in th
 ### Platform Specific Changes
 
 #### Android
-- Call timestamp now in simplified ISO-8601 format, not stored as a double from epoch
+- Call timestamp now in simplified ISO-8601 format, not stored as a double from epoch.
 
 #### iOS
 - The call connected timestamp is now in simplified ISO-8601 format.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ Twilio Voice React Native SDK has now reached milestone `beta.5`. Included in th
 
 - Fixed and improved the docstrings for the `Voice` and `Call` listeners. The descriptions of the events and listeners should now point to the correct docstrings.
 
+## Fixes
+
+- Call quality warning events should now properly pass arguments to listener functions.
+
 1.0.0-beta.4 (Jan 11, 2024)
 ===========================
 

--- a/src/Call.tsx
+++ b/src/Call.tsx
@@ -606,7 +606,9 @@ export class Call extends EventEmitter {
 
     this._update(nativeCallEvent);
 
-    const { currentWarnings, previousWarnings } = nativeCallEvent;
+    const currentWarnings = nativeCallEvent[Constants.CallEventCurrentWarnings];
+    const previousWarnings =
+      nativeCallEvent[Constants.CallEventPreviousWarnings];
 
     this.emit(
       Call.Event.QualityWarningsChanged,

--- a/src/__mocks__/Call.ts
+++ b/src/__mocks__/Call.ts
@@ -81,10 +81,10 @@ export const mockCallNativeEvents = {
     nativeEvent: {
       type: Constants.CallEventQualityWarningsChanged,
       call: createNativeCallInfo(),
-      currentWarnings: [
+      [Constants.CallEventCurrentWarnings]: [
         'mock-callqualitywarningschangedevent-nativeevent-currentwarnings',
       ],
-      previousWarnings: [
+      [Constants.CallEventPreviousWarnings]: [
         'mock-callqualitywarningschangedevent-nativeevent-previouswarnings',
       ],
     },

--- a/src/type/Call.ts
+++ b/src/type/Call.ts
@@ -53,8 +53,8 @@ export type NativeCallQualityWarnings = string[];
 export interface NativeCallQualityWarningsEvent {
   type: Constants.CallEventQualityWarningsChanged;
   call: NativeCallInfo;
-  currentWarnings: NativeCallQualityWarnings;
-  previousWarnings: NativeCallQualityWarnings;
+  [Constants.CallEventCurrentWarnings]: NativeCallQualityWarnings;
+  [Constants.CallEventPreviousWarnings]: NativeCallQualityWarnings;
 }
 
 export type NativeCallEvent =

--- a/test/app/e2e/call.test.ts
+++ b/test/app/e2e/call.test.ts
@@ -47,19 +47,49 @@ describe('call', () => {
   }
 
   if (device.getPlatform() === 'android') {
-    it('should make an outgoing call and then disconnect', async () => {
-      await element(by.text('CONNECT')).tap();
-      await waitFor(element(by.text('Call State: connected')))
-        .toBeVisible()
-        .withTimeout(DEFAULT_TIMEOUT);
+    describe('outgoing call', () => {
+      it('should make an outgoing call and then disconnect', async () => {
+        await element(by.text('CONNECT')).tap();
+        await waitFor(element(by.text('Call State: connected')))
+          .toBeVisible()
+          .withTimeout(DEFAULT_TIMEOUT);
 
-      // Let the call go for 5 seconds
-      await new Promise((r) => setTimeout(r, 5000));
+        // Let the call go for 5 seconds
+        await new Promise((r) => setTimeout(r, 5000));
 
-      await element(by.text('DISCONNECT')).tap();
-      await waitFor(element(by.text('Call State: disconnected')))
-        .toBeVisible()
-        .withTimeout(DEFAULT_TIMEOUT);
+        await element(by.text('DISCONNECT')).tap();
+        await waitFor(element(by.text('Call State: disconnected')))
+          .toBeVisible()
+          .withTimeout(DEFAULT_TIMEOUT);
+      });
+
+      it('should log a constant-audio-input-level quality warning', async () => {
+        await element(by.text('CONNECT')).tap();
+        await waitFor(element(by.text('Call State: connected')))
+          .toBeVisible()
+          .withTimeout(DEFAULT_TIMEOUT);
+
+        // Let the call go for 15 seconds
+        await new Promise((r) => setTimeout(r, 15000));
+
+        const eventLogAttr = await element(by.id('event_log')).getAttributes();
+        if (!('label' in eventLogAttr) || !eventLogAttr.label) {
+          throw new Error('cannot parse event log label');
+        }
+        const searchString =
+          'qualityWarningsChanged\n' +
+          JSON.stringify(
+            [['constant-audio-input-level'], []],
+            null,
+            2
+          );
+        expect(eventLogAttr.label.includes(searchString)).toBeTruthy();
+
+        await element(by.text('DISCONNECT')).tap();
+        await waitFor(element(by.text('Call State: disconnected')))
+          .toBeVisible()
+          .withTimeout(DEFAULT_TIMEOUT);
+      });
     });
 
     it('should receive an incoming call and then disconnect', async () => {

--- a/test/app/e2e/call.test.ts
+++ b/test/app/e2e/call.test.ts
@@ -1,5 +1,6 @@
 import { device, element, by, waitFor } from 'detox';
 import twilio from 'twilio';
+import { expect as jestExpect } from 'expect';
 
 const DEFAULT_TIMEOUT = 10000;
 
@@ -83,7 +84,7 @@ describe('call', () => {
             null,
             2
           );
-        expect(eventLogAttr.label.includes(searchString)).toBeTruthy();
+        jestExpect(eventLogAttr.label.includes(searchString)).toBeTruthy();
 
         await element(by.text('DISCONNECT')).tap();
         await waitFor(element(by.text('Call State: disconnected')))

--- a/test/app/src/App.tsx
+++ b/test/app/src/App.tsx
@@ -133,7 +133,11 @@ export default function App() {
       <View style={composedStyles.events}>
         <Text>Events</Text>
         <View style={composedStyles.eventsList}>
-          <FlatList data={events} renderItem={eventLogItemRender} />
+          <FlatList
+            testID="event_log"
+            data={events}
+            renderItem={eventLogItemRender}
+          />
         </View>
       </View>
       <View style={styles.padded}>


### PR DESCRIPTION
## Submission Checklist

 - [x] Updated the `CHANGELOG.md` to reflect any **feature**, **bug fixes**, or **known issues** made in the source code
 - [x] Tested code changes and observed expected behavior in the example app
 - [x] Performed a visual inspection of the `Files changed` tab prior to submitting the pull request for review to ensure proper usage of the style guide

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Description

This PR fixes missing call quality events by properly using the common constants to key the native info objects that are passed to the JS layer.

## Breakdown

- Use common constants to key the native info objects.

## Validation

- Manually tested with the test app.

## Additional Notes

N/A