### PR TITLE
VBLOCKS-2328 iOS CallKit caller name update API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Twilio Voice React Native SDK has now reached milestone `beta.5`. Included in th
 
 #### iOS
 - The call connected timestamp is now in RFC-822 format.
+- A new method `CallInvite.updateCallerHandle()` has been added. Use this method to update the caller's name displayed in the iOS system incoming call UI. This method is specific to iOS and unavailable in Android.
 
 1.0.0-beta.4 (Jan 11, 2024)
 ===========================

--- a/ios/TwilioVoiceReactNative+CallKit.m
+++ b/ios/TwilioVoiceReactNative+CallKit.m
@@ -202,13 +202,16 @@ NSString * const kCustomParametersKeyDisplayName = @"displayName";
     CXHandle *callHandle = [[CXHandle alloc] initWithType:CXHandleTypeGeneric value:handle];
     CXCallUpdate *callUpdate = [[CXCallUpdate alloc] init];
     callUpdate.remoteHandle = callHandle;
+    callUpdate.localizedCallerName = handle;
     callUpdate.supportsDTMF = YES;
     callUpdate.supportsHolding = YES;
     callUpdate.supportsGrouping = NO;
     callUpdate.supportsUngrouping = NO;
     callUpdate.hasVideo = NO;
 
-    [self.callKitProvider reportCallWithUUID:[[NSUUID alloc] initWithUUIDString:uuid] updated:callUpdate];
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [self.callKitProvider reportCallWithUUID:[[NSUUID alloc] initWithUUIDString:uuid] updated:callUpdate];
+    });
 }
 
 #pragma mark - CXProviderDelegate

--- a/ios/TwilioVoiceReactNative+CallKit.m
+++ b/ios/TwilioVoiceReactNative+CallKit.m
@@ -198,6 +198,19 @@ NSString * const kCustomParametersKeyDisplayName = @"displayName";
                               kTwilioVoiceReactNativeEventKeyCallInvite: [self callInviteInfo:callInvite]}];
 }
 
+- (void)updateCall:(NSString *)uuid callerHandle:(NSString *)handle {
+    CXHandle *callHandle = [[CXHandle alloc] initWithType:CXHandleTypeGeneric value:handle];
+    CXCallUpdate *callUpdate = [[CXCallUpdate alloc] init];
+    callUpdate.remoteHandle = callHandle;
+    callUpdate.supportsDTMF = YES;
+    callUpdate.supportsHolding = YES;
+    callUpdate.supportsGrouping = NO;
+    callUpdate.supportsUngrouping = NO;
+    callUpdate.hasVideo = NO;
+
+    [self.callKitProvider reportCallWithUUID:[[NSUUID alloc] initWithUUIDString:uuid] updated:callUpdate];
+}
+
 #pragma mark - CXProviderDelegate
 
 - (void)providerDidReset:(CXProvider *)provider {

--- a/ios/TwilioVoiceReactNative.h
+++ b/ios/TwilioVoiceReactNative.h
@@ -64,6 +64,7 @@ FOUNDATION_EXPORT NSString * const kTwilioVoiceReactNativeEventKeyCancelledCallI
 /* Initiate the answering from the app UI */
 - (void)answerCallInvite:(NSUUID *)uuid
               completion:(void(^)(BOOL success))completionHandler;
+- (void)updateCall:(NSString *)uuid callerHandle:(NSString *)handle;
 
 /* Utility */
 - (NSDictionary *)callInfo:(TVOCall *)call;

--- a/ios/TwilioVoiceReactNative.m
+++ b/ios/TwilioVoiceReactNative.m
@@ -841,87 +841,100 @@ RCT_EXPORT_METHOD(callInvite_accept:(NSString *)callInviteUuid
     }];
 }
 
-RCT_EXPORT_METHOD(callInvite_reject:(NSString *)callInviteUuiid
+RCT_EXPORT_METHOD(callInvite_reject:(NSString *)callInviteUuid
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject)
 {
-    [self endCallWithUuid:[[NSUUID alloc] initWithUUIDString:callInviteUuiid]];
+    [self endCallWithUuid:[[NSUUID alloc] initWithUUIDString:callInviteUuid]];
     resolve(nil);
 }
 
-RCT_EXPORT_METHOD(callInvite_isValid:(NSString *)callInviteUuiid
+RCT_EXPORT_METHOD(callInvite_isValid:(NSString *)callInviteUuid
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject)
 {
     resolve(@(YES));
 }
 
-RCT_EXPORT_METHOD(callInvite_getCallSid:(NSString *)callInviteUuiid
+RCT_EXPORT_METHOD(callInvite_getCallSid:(NSString *)callInviteUuid
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject)
 {
-    if (self.callInviteMap[callInviteUuiid]) {
-        TVOCallInvite *callInvite = self.callInviteMap[callInviteUuiid];
+    if (self.callInviteMap[callInviteUuid]) {
+        TVOCallInvite *callInvite = self.callInviteMap[callInviteUuid];
         resolve(callInvite.callSid);
     } else {
         reject(kTwilioVoiceReactNativeVoiceError, @"No matching call invite", nil);
     }
 }
 
-RCT_EXPORT_METHOD(callInvite_getFrom:(NSString *)callInviteUuiid
+RCT_EXPORT_METHOD(callInvite_getFrom:(NSString *)callInviteUuid
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject)
 {
-    if (self.callInviteMap[callInviteUuiid]) {
-        TVOCallInvite *callInvite = self.callInviteMap[callInviteUuiid];
+    if (self.callInviteMap[callInviteUuid]) {
+        TVOCallInvite *callInvite = self.callInviteMap[callInviteUuid];
         resolve(callInvite.from);
     } else {
         reject(kTwilioVoiceReactNativeVoiceError, @"No matching call invite", nil);
     }
 }
 
-RCT_EXPORT_METHOD(callInvite_getTo:(NSString *)callInviteUuiid
+RCT_EXPORT_METHOD(callInvite_getTo:(NSString *)callInviteUuid
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject)
 {
-    if (self.callInviteMap[callInviteUuiid]) {
-        TVOCallInvite *callInvite = self.callInviteMap[callInviteUuiid];
+    if (self.callInviteMap[callInviteUuid]) {
+        TVOCallInvite *callInvite = self.callInviteMap[callInviteUuid];
         resolve(callInvite.to);
     } else {
         reject(kTwilioVoiceReactNativeVoiceError, @"No matching call invite", nil);
     }
 }
 
-RCT_EXPORT_METHOD(cancelledCallInvite_getCallSid:(NSString *)cancelledCallInviteUuiid
+RCT_EXPORT_METHOD(callInvite_updateCallerHandle:(NSString *)callInviteUuid
+                  handle:(NSString *)handle
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject)
 {
-    if (self.cancelledCallInviteMap[cancelledCallInviteUuiid]) {
-        TVOCancelledCallInvite *cancelledCallInvite = self.cancelledCallInviteMap[cancelledCallInviteUuiid];
+    if (self.callInviteMap[callInviteUuid]) {
+        [self updateCall:callInviteUuid callerHandle:handle];
+        resolve(nil);
+    } else {
+        reject(kTwilioVoiceReactNativeVoiceError, @"No matching call invite", nil);
+    }
+}
+
+RCT_EXPORT_METHOD(cancelledCallInvite_getCallSid:(NSString *)cancelledCallInviteUuid
+                  resolver:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject)
+{
+    if (self.cancelledCallInviteMap[cancelledCallInviteUuid]) {
+        TVOCancelledCallInvite *cancelledCallInvite = self.cancelledCallInviteMap[cancelledCallInviteUuid];
         resolve(cancelledCallInvite.callSid);
     } else {
         reject(kTwilioVoiceReactNativeVoiceError, @"No matching cancelled call invite", nil);
     }
 }
 
-RCT_EXPORT_METHOD(cancelledCallInvite_getFrom:(NSString *)cancelledCallInviteUuiid
+RCT_EXPORT_METHOD(cancelledCallInvite_getFrom:(NSString *)cancelledCallInviteUuid
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject)
 {
-    if (self.cancelledCallInviteMap[cancelledCallInviteUuiid]) {
-        TVOCancelledCallInvite *cancelledCallInvite = self.cancelledCallInviteMap[cancelledCallInviteUuiid];
+    if (self.cancelledCallInviteMap[cancelledCallInviteUuid]) {
+        TVOCancelledCallInvite *cancelledCallInvite = self.cancelledCallInviteMap[cancelledCallInviteUuid];
         resolve(cancelledCallInvite.from);
     } else {
         reject(kTwilioVoiceReactNativeVoiceError, @"No matching cancelled call invite", nil);
     }
 }
 
-RCT_EXPORT_METHOD(cancelledCallInvite_getTo:(NSString *)cancelledCallInviteUuiid
+RCT_EXPORT_METHOD(cancelledCallInvite_getTo:(NSString *)cancelledCallInviteUuid
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject)
 {
-    if (self.cancelledCallInviteMap[cancelledCallInviteUuiid]) {
-        TVOCancelledCallInvite *cancelledCallInvite = self.cancelledCallInviteMap[cancelledCallInviteUuiid];
+    if (self.cancelledCallInviteMap[cancelledCallInviteUuid]) {
+        TVOCancelledCallInvite *cancelledCallInvite = self.cancelledCallInviteMap[cancelledCallInviteUuid];
         resolve(cancelledCallInvite.to);
     } else {
         reject(kTwilioVoiceReactNativeVoiceError, @"No matching cancelled call invite", nil);

--- a/src/CallInvite.tsx
+++ b/src/CallInvite.tsx
@@ -183,6 +183,31 @@ export class CallInvite {
   getTo(): string {
     return this._to;
   }
+
+  /**
+   * Update the caller name displayed in the iOS system incoming call screen.
+   * 
+   * @param newHandle - The new value of the caller's name.
+   * 
+   * @remarks
+   * Unsupported platforms:
+   * - Android
+   *
+   * This API is specific to iOS and unavailable in Android.
+   * 
+   * @returns
+   *  - Resolves when the caller name has been updated.
+   */
+  updateCallerHandle(newHandle: string): Promise<void> {
+    switch (Platform.OS) {
+      case 'ios':
+        return return NativeModule.callInvite_updateCallerHandle(this._uuid, newHandle);
+      default:
+        throw new UnsupportedPlatformError(
+          `Unsupported platform "${Platform.OS}". This method is only supported on iOS.`
+        );
+    }
+  }
 }
 
 /**

--- a/src/CallInvite.tsx
+++ b/src/CallInvite.tsx
@@ -201,7 +201,7 @@ export class CallInvite {
   updateCallerHandle(newHandle: string): Promise<void> {
     switch (Platform.OS) {
       case 'ios':
-        return return NativeModule.callInvite_updateCallerHandle(this._uuid, newHandle);
+        return NativeModule.callInvite_updateCallerHandle(this._uuid, newHandle);
       default:
         throw new UnsupportedPlatformError(
           `Unsupported platform "${Platform.OS}". This method is only supported on iOS.`


### PR DESCRIPTION
## Submission Checklist

 - [x] Updated the `CHANGELOG.md` to reflect any **feature**, **bug fixes**, or **known issues** made in the source code
 - [x] Tested code changes and observed expected behavior in the example app
 - [x] Performed a visual inspection of the `Files changed` tab prior to submitting the pull request for review to ensure proper usage of the style guide

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Description

New API `CallInvite.updateCallerHandle()` added for updating the iOS CallKit incoming caller name displayed in the iOS system call UI.

## Breakdown

- New method in `CallInvite`
- iOS native module implementation
- Changelog

## Validation

- Built and ran locally
