### PR TITLE
[VBLOCKS-2763] fix(android): npe on foregrounding app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ Twilio Voice React Native SDK has now reached milestone `beta.5`. Included in th
 - Fixed and improved the docstrings for the `Voice` and `Call` listeners. The descriptions of the events and listeners should now point to the correct docstrings.
 - Call quality warning events should now properly pass arguments to listener functions.
 
+### Platform Specific Fixes
+
+#### Android
+
+- Receiving an incoming call while your app is backgrounded will no longer crash your application.
+
 ## Changes
 
 - The API for `call.getInitialConnectedTimestamp()` has now changed.

--- a/android/src/main/java/com/twiliovoicereactnative/JSEventEmitter.java
+++ b/android/src/main/java/com/twiliovoicereactnative/JSEventEmitter.java
@@ -25,16 +25,24 @@ class JSEventEmitter {
   public void sendEvent(String eventName, @Nullable WritableMap params) {
     logger.debug("sendEvent " + eventName + " params " + params);
 
-    if ((null != context.get() && context.get().hasActiveReactInstance())) {
-      context.get()
-        .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)
-        .emit(eventName, params);
-    } else {
-      logger.warning(
-        String.format(
-          "attempt to sendEvent without context {%s} or Catalyst instance not active",
-          context.get()));
+    if (null == context) {
+      logger.warning("context is null");
+      return;
     }
+
+    if (null == context.get()) {
+      logger.warning(String.format("weak dereference of context is null"));
+      return;
+    }
+
+    if (!context.get().hasActiveReactInstance()) {
+      logger.warning("no active react instance on context weak dereference");
+      return;
+    }
+
+    context.get()
+      .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)
+      .emit(eventName, params);
   }
   public static WritableArray constructJSArray(@NonNull Object...entries) {
     WritableArray params = Arguments.createArray();


### PR DESCRIPTION
## Submission Checklist

 - [x] Updated the `CHANGELOG.md` to reflect any **feature**, **bug fixes**, or **known issues** made in the source code
 - [x] Tested code changes and observed expected behavior in the example app
 - [x] Performed a visual inspection of the `Files changed` tab prior to submitting the pull request for review to ensure proper usage of the style guide

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Description

Fix null pointer exception when the app receives an incoming call while backgrounded.

## Breakdown

- Check that weak reference to context is null before trying to dereference.

## Validation

- Manually tested.

## Additional Notes

N/A