### PR TITLE
[VBLOCKS-2787] fix: add mic privacy usage string

### DIFF
--- a/test/app/ios/TwilioVoiceReactNativeExample/Info.plist
+++ b/test/app/ios/TwilioVoiceReactNativeExample/Info.plist
@@ -37,6 +37,8 @@
 	</dict>
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string></string>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>foobar</string>
 	<key>UIBackgroundModes</key>
 	<array>
 		<string>audio</string>


### PR DESCRIPTION
## Submission Checklist

 - [x] ~Updated the `CHANGELOG.md` to reflect any **feature**, **bug fixes**, or **known issues** made in the source code~
 - [x] Tested code changes and observed expected behavior in the example app
 - [x] Performed a visual inspection of the `Files changed` tab prior to submitting the pull request for review to ensure proper usage of the style guide

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Description

This PR adds the new privacy microphone usage string that newer versions of iOS mandate.

## Breakdown

- Add usage string to Info in XCode.

## Validation

- N/A

## Additional Notes

I was personally unable to test since my iOS device is on an older version of iOS that does not need this fix. However, consulting @kpchoy about this, this is exactly what his device needed to function.