### PR TITLE
fix: add extra wait time to constant audio input level test

### DIFF
--- a/android/src/main/java/com/twiliovoicereactnative/JSEventEmitter.java
+++ b/android/src/main/java/com/twiliovoicereactnative/JSEventEmitter.java
@@ -23,7 +23,7 @@ class JSEventEmitter {
     this.context = new WeakReference<>(context);
   }
   public void sendEvent(String eventName, @Nullable WritableMap params) {
-    logger.debug("sendEvent " + eventName + " params " + params);
+    logger.log("sendEvent " + eventName + " params " + params);
     if ((null != context.get()) &&
         context.get().hasActiveReactInstance()) {
       context.get()

--- a/test/app/e2e/call.test.ts
+++ b/test/app/e2e/call.test.ts
@@ -70,8 +70,8 @@ describe('call', () => {
           .toBeVisible()
           .withTimeout(DEFAULT_TIMEOUT);
 
-        // Let the call go for 15 seconds
-        await new Promise((r) => setTimeout(r, 30000));
+        // Let the call go for 3 minutes
+        await new Promise((r) => setTimeout(r, 1000 * 60 * 3));
 
         const eventLogAttr = await element(by.id('event_log')).getAttributes();
         if (!('label' in eventLogAttr) || !eventLogAttr.label) {

--- a/test/app/e2e/call.test.ts
+++ b/test/app/e2e/call.test.ts
@@ -1,6 +1,5 @@
 import { device, element, by, waitFor } from 'detox';
 import twilio from 'twilio';
-import { expect as jestExpect } from 'expect';
 
 const DEFAULT_TIMEOUT = 10000;
 

--- a/test/app/e2e/call.test.ts
+++ b/test/app/e2e/call.test.ts
@@ -70,13 +70,16 @@ describe('call', () => {
           .withTimeout(DEFAULT_TIMEOUT);
 
         const createTimer =
-          async () => await new Promise((r) => setTimeout(r, 30000));
+          async () => await new Promise((r) => setTimeout(r, 10000));
 
         const checkForQualityWarning = async () => {
+          await element(by.id('event_log')).swipe('up');
+
           const eventLogAttr = await element(by.id('event_log')).getAttributes();
           if (!('label' in eventLogAttr) || !eventLogAttr.label) {
             throw new Error('cannot parse event log label');
           }
+
           const searchString =
             'qualityWarningsChanged\n' +
             JSON.stringify(
@@ -84,16 +87,18 @@ describe('call', () => {
               null,
               2
             );
+
           console.log('attempting to find the search string within the log', {
             searchString,
             log: eventLogAttr.label,
           });
+
           return eventLogAttr.label.includes(searchString);
         };
 
         // try for a total of 3 minutes
         let didSucceed = false;
-        for (let i = 0; i < 6; i++) {
+        for (let i = 0; i < 18; i++) {
           await createTimer();
           didSucceed = await checkForQualityWarning();
           if (didSucceed) {

--- a/test/app/e2e/call.test.ts
+++ b/test/app/e2e/call.test.ts
@@ -71,7 +71,7 @@ describe('call', () => {
           .withTimeout(DEFAULT_TIMEOUT);
 
         // Let the call go for 15 seconds
-        await new Promise((r) => setTimeout(r, 15000));
+        await new Promise((r) => setTimeout(r, 30000));
 
         const eventLogAttr = await element(by.id('event_log')).getAttributes();
         if (!('label' in eventLogAttr) || !eventLogAttr.label) {

--- a/test/app/e2e/call.test.ts
+++ b/test/app/e2e/call.test.ts
@@ -84,6 +84,10 @@ describe('call', () => {
             null,
             2
           );
+        console.log('attempting to find the search string within the log', {
+          searchString,
+          log: eventLogAttr.label,
+        });
         jestExpect(eventLogAttr.label.includes(searchString)).toBeTruthy();
 
         await element(by.text('DISCONNECT')).tap();

--- a/test/app/e2e/jest.config.js
+++ b/test/app/e2e/jest.config.js
@@ -2,7 +2,7 @@
 module.exports = {
   rootDir: '..',
   testMatch: ['<rootDir>/e2e/**/*.test.ts'],
-  testTimeout: 120000,
+  testTimeout: 1000 * 60 * 10,
   maxWorkers: 1,
   globalSetup: 'detox/runners/jest/globalSetup',
   globalTeardown: 'detox/runners/jest/globalTeardown',


### PR DESCRIPTION
## Submission Checklist

 - [x] ~Updated the `CHANGELOG.md` to reflect any **feature**, **bug fixes**, or **known issues** made in the source code~
 - [x] Tested code changes and observed expected behavior in the example app
 - [x] Performed a visual inspection of the `Files changed` tab prior to submitting the pull request for review to ensure proper usage of the style guide

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Description

This PR increases the wait time of the call quality warning test.

## Breakdown

- Increase wait time of the call quality warning test.

## Validation

- Manually ran Detox pipeline locally.

## Additional Notes

N/A
