### PR TITLE
[VBLOCKS-2830] Remove custom twiml parameter displayName functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,21 +62,25 @@ call.addListener(Call.Event.MessageReceived, (message: CallMessage) => {
   Please see the `CallInvite` class API documentation [here](https://github.com/twilio/twilio-voice-react-native/blob/latest/docs/api/voice-react-native-sdk.callinvite_class.md) for details.
 
 - Call Notifications can be customized on Android.
-  
+
   The following features regarding a call notificaiton can now be modified
   - incoming/outgoing/answered call notification tray icon
   - name of caller/or recipient
-  
+
   The incoming/outgoing/answered call notification tray icon can be changed by adding a drawable resources with the following id to your application
   - `incoming_call_small_icon` for incoming call notifications
   - `answered_call_small_icon` for answered call notifications
   - `outgoing_call_small_icon` for outgoing call notifications
-  
+
   The name of the caller/or recipient of a call in the notification can be set by adding the following string resources with the following ids to your application.
   - `incoming_call_caller_name_text` for incoming call notifications
   - `outgoing_call_caller_name_text` for outgoing call notifications
   - `answered_call_caller_name_text` for answered call notifications
   NOTE: For `incoming_call_caller_name_text` & `answered_call_caller_name_text`, the substring `${from}` will be replaced with the caller and for `outgoing_call_caller_name_text`, the substring `${to}` will be replaced with the recipient of the call (if available, defaulting to "unknown").
+
+- Custom functionality around the `displayName` TwiML parameter has been removed.
+
+  In previous versions of the SDK, passing a custom TwiML parameter `displayName` would override the notification on Android platforms. Now, this functionality has been removed and notification customization is handled with the above features.
 
 ### Platform Specific Changes
 

--- a/android/src/main/java/com/twiliovoicereactnative/Constants.java
+++ b/android/src/main/java/com/twiliovoicereactnative/Constants.java
@@ -18,5 +18,4 @@ class Constants {
   public static final String JS_EVENT_KEY_CALL_INFO = "call";
   public static final String JS_EVENT_KEY_CALL_INVITE_INFO = "callInvite";
   public static final String JS_EVENT_KEY_CANCELLED_CALL_INVITE_INFO = "cancelledCallInvite";
-  public static final String DISPLAY_NAME = "displayName";
 }

--- a/android/src/main/java/com/twiliovoicereactnative/NotificationUtility.java
+++ b/android/src/main/java/com/twiliovoicereactnative/NotificationUtility.java
@@ -1,6 +1,5 @@
 package com.twiliovoicereactnative;
 
-import java.net.URLDecoder;
 import java.security.SecureRandom;
 import java.util.Map;
 import java.util.Objects;
@@ -65,13 +64,7 @@ class NotificationUtility {
     }
     private static String getDisplayName(@NonNull CallInvite callInvite) {
       final String title = callInvite.getFrom();
-      Map<String, String> customParameters = callInvite.getCustomParameters();
-      // If "displayName" is passed as a custom parameter in the TwiML application,
-      // it will be used as the caller name.
-      if (customParameters.get(Constants.DISPLAY_NAME) != null) {
-        return URLDecoder.decode(customParameters.get(Constants.DISPLAY_NAME)
-          .replaceAll("\\+", "%20"));
-      } else if (title.startsWith("client:")) {
+      if (title.startsWith("client:")) {
         return title.replaceFirst("client:", "");
       }
       return title;

--- a/ios/TwilioVoiceReactNative+CallKit.m
+++ b/ios/TwilioVoiceReactNative+CallKit.m
@@ -12,7 +12,6 @@
 #import "TwilioVoiceReactNativeConstants.h"
 
 NSString * const kDefaultCallKitConfigurationName = @"Twilio Voice React Native";
-NSString * const kCustomParametersKeyDisplayName = @"displayName";
 
 @interface TwilioVoiceReactNative (CallKit) <CXProviderDelegate, TVOCallDelegate, AVAudioPlayerDelegate>
 
@@ -68,15 +67,7 @@ NSString * const kCustomParametersKeyDisplayName = @"displayName";
 }
 
 - (void)reportNewIncomingCall:(TVOCallInvite *)callInvite {
-    // If "displayName" is passed as a custom parameter in the TwiML application,
-    // it will be used as the caller name.
     NSString *handleName = callInvite.from;
-    NSDictionary *customParams = callInvite.customParameters;
-    if (customParams[kCustomParametersKeyDisplayName]) {
-        NSString *callerDisplayName = customParams[kCustomParametersKeyDisplayName];
-        callerDisplayName = [callerDisplayName stringByReplacingOccurrencesOfString:@"+" withString:@" "];
-        handleName = callerDisplayName;
-    }
     
     CXHandle *callHandle = [[CXHandle alloc] initWithType:CXHandleTypeGeneric value:handleName];
 

--- a/ios/TwilioVoiceReactNative+CallKit.m
+++ b/ios/TwilioVoiceReactNative+CallKit.m
@@ -68,6 +68,9 @@ NSString * const kDefaultCallKitConfigurationName = @"Twilio Voice React Native"
 
 - (void)reportNewIncomingCall:(TVOCallInvite *)callInvite {
     NSString *handleName = callInvite.from;
+    if (handleName == nil) {
+        handleName = @"Unknown Caller";
+    }
     
     CXHandle *callHandle = [[CXHandle alloc] initWithType:CXHandleTypeGeneric value:handleName];
 


### PR DESCRIPTION
## Submission Checklist

 - [x] Updated the `CHANGELOG.md` to reflect any **feature**, **bug fixes**, or **known issues** made in the source code
 - [x] Tested code changes and observed expected behavior in the example app
 - [x] Performed a visual inspection of the `Files changed` tab prior to submitting the pull request for review to ensure proper usage of the style guide

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Description

This PR removes the custom display name TwiML parameter functionality, such that passing "displayName" as a TwiML parameter will override the notification.

## Breakdown

- Remove the functionality.

## Validation

- Tested manually with the test app.

The following scenarios were tested using the test app:
```
[x] android
  [x] incoming call with twiml param
    [x] native accept
      [x] local disconnect
      [x] remote disconnect
    [x] native reject
    [x] js accept
      [x] local disconnect
      [x] remote disconnect
    [x] js reject
    [x] cancel
  [x] incoming call without twiml param
    [x] native accept
      [x] local disconnect
      [x] remote disconnect
    [x] native reject
    [x] js accept
      [x] local disconnect
      [x] remote disconnect
    [x] js reject
    [x] cancel
  [x] outgoing call
    [x] accept
      [x] local disconnect
      [x] remote disconnect
    [x] reject
    [x] cancel

[x] ios
  [x] incoming call with twiml param
    [] native accept
      [x] local disconnect
      [x] remote disconnect
    [x] native reject
    [x] js accept
      [x] local disconnect
      [x] remote disconnect
    [x] js reject
    [x] cancel
  [x] incoming call without twiml param
    [x] native accept
      [x] local disconnect
      [x] remote disconnect
    [x] native reject
    [x] js accept
      [x] local disconnect
      [x] remote disconnect
    [x] js reject
    [x] cancel
  [x] outgoing call
    [x] accept
      [x] local disconnect
      [x] remote disconnect
    [x] reject
    [x] cancel
```

## Additional Notes

We can't write automated tests for this at the moment because Detox has no way of interacting with the native notification UI/UX.
