### PR TITLE
FM-499: fix audio device switch on Android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 #### Android
 - Added support for Android 34
+- Fix audio device switch
 
 
 1.0.0 (Mar 25, 2024)

--- a/android/src/main/java/com/twiliovoicereactnative/TwilioVoiceReactNativeModule.java
+++ b/android/src/main/java/com/twiliovoicereactnative/TwilioVoiceReactNativeModule.java
@@ -303,7 +303,9 @@ public class TwilioVoiceReactNativeModule extends ReactContextBaseJavaModule {
       return;
     }
 
-    audioSwitchManager.getAudioSwitch().selectDevice(audioDevice);
+    AudioSwitch audioSwitch = audioSwitchManager.getAudioSwitch();
+    audioSwitch.selectDevice(audioDevice);
+    audioSwitch.activate();
 
     promise.resolve(null);
   }

--- a/android/src/main/java/com/twiliovoicereactnative/TwilioVoiceReactNativeModule.java
+++ b/android/src/main/java/com/twiliovoicereactnative/TwilioVoiceReactNativeModule.java
@@ -15,6 +15,7 @@ import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.module.annotations.ReactModule;
 import com.google.firebase.messaging.FirebaseMessaging;
 import com.twilio.audioswitch.AudioDevice;
+import com.twilio.audioswitch.AudioSwitch;
 import com.twilio.voice.Call;
 import com.twilio.voice.CallMessage;
 import com.twilio.voice.ConnectOptions;


### PR DESCRIPTION
## Submission Checklist

 - [x] Updated the `CHANGELOG.md` to reflect any **feature**, **bug fixes**, or **known issues** made in the source code
 - [x] Tested code changes and observed expected behavior in the example app
 - [x] Performed a visual inspection of the `Files changed` tab prior to submitting the pull request for review to ensure proper usage of the style guide

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Description
[AudioSwitch library requires](https://github.com/twilio/audioswitch?tab=readme-ov-file#activate-a-device) calling `.select` and `.activate` functions to be called in order to switch between audio devices (like speakerphone to earpiece). As far as I see there is no existing way to call activate by using react native functions. I propose modifying `voice_selectAudioDevice` function so that it will immediately activate the device after selecting it. 

## Breakdown

- [Bulleted summary of changes]
- [eg. Updated documentation]
- [eg. Added audio device feature]

## Validation

- Manually tested with app

## Additional Notes

[Any additional comments, notes, or information relevant to reviewers.]
