### PR TITLE
[VBLOCKS-3113] Catch and emit missing permissions android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@
 
 - Added support for Android 34
 
+- Missing Android microphone permissions will now be gracefully handled.
+
+  When using the JS API, `callInvite.accept()` and `voice.connect()` will now reject the returned Promise with error `31401`.
+
+  When accepting an incoming call through the native notification, the analogous `31401` error can be caught by attaching a listener to `voice.on(Voice.Event.Error, ...)`. See the following example:
+  ```ts
+  voice.on(Voice.Event.Error, (error) => {
+    // handle error
+    if (error.code === 31401) {
+      // show the end-user that they did not give the app the proper permissions
+    }
+  });
+  ```
+
 ## Fixes
 
 ### Platform Specific Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,14 @@ call.sendMessage(new CallMessage({
   | 31210 | Raised when a Call Message is sent with an invalid message type. |
   | 31211 | Raised when a Call Message is sent when the call is not yet ready to send messages. This can typically happen when the Call/CallInvite is not yet in a ringing state. |
 
+### Platform Specific Changes
+
+#### Android
+
+- When permissions are not available, the SDK will now raise a new
+  `PermissionsError` with code `31401` when attempting to make an outgoing call
+  or when trying to accept an incoming call.
+
 1.0.0 (Mar 25, 2024)
 ====================
 

--- a/android/src/main/java/com/twiliovoicereactnative/ReactNativeArgumentsSerializer.java
+++ b/android/src/main/java/com/twiliovoicereactnative/ReactNativeArgumentsSerializer.java
@@ -16,6 +16,8 @@ import static com.twiliovoicereactnative.CommonConstants.CallInfoIsOnHold;
 import static com.twiliovoicereactnative.CommonConstants.CallMessageContent;
 import static com.twiliovoicereactnative.CommonConstants.CallMessageContentType;
 import static com.twiliovoicereactnative.CommonConstants.CallMessageMessageType;
+import static com.twiliovoicereactnative.CommonConstants.ScopeVoice;
+import static com.twiliovoicereactnative.CommonConstants.VoiceEventError;
 import static com.twiliovoicereactnative.CommonConstants.VoiceEventSid;
 import static com.twiliovoicereactnative.CommonConstants.CallStateConnected;
 import static com.twiliovoicereactnative.CommonConstants.CallStateConnecting;
@@ -32,6 +34,7 @@ import static com.twiliovoicereactnative.CommonConstants.CancelledCallInviteInfo
 import static com.twiliovoicereactnative.CommonConstants.CancelledCallInviteInfoTo;
 import static com.twiliovoicereactnative.CommonConstants.VoiceErrorKeyCode;
 import static com.twiliovoicereactnative.CommonConstants.VoiceErrorKeyMessage;
+import static com.twiliovoicereactnative.CommonConstants.VoiceEventType;
 import static com.twiliovoicereactnative.JSEventEmitter.constructJSMap;
 
 import java.text.SimpleDateFormat;
@@ -231,6 +234,16 @@ class ReactNativeArgumentsSerializer {
     return (null != callRecord.getCallException())
       ? serializeVoiceException(callRecord.getCallException())
       : null;
+  }
+
+  public static WritableMap serializeError(int code, String message) {
+    if (null != message) {
+      return constructJSMap(
+        new Pair<>(VoiceErrorKeyCode, code),
+        new Pair<>(VoiceErrorKeyMessage, message)
+      );
+    }
+    return null;
   }
 
   public static WritableArray serializeCallQualityWarnings(@NonNull Set<Call.CallQualityWarning> warnings) {

--- a/android/src/main/java/com/twiliovoicereactnative/TwilioVoiceReactNativeModule.java
+++ b/android/src/main/java/com/twiliovoicereactnative/TwilioVoiceReactNativeModule.java
@@ -219,7 +219,7 @@ public class TwilioVoiceReactNativeModule extends ReactContextBaseJavaModule {
       // notify JS layer
       promise.resolve(serializeCall(callRecord));
     } catch (SecurityException e) {
-      promise.reject(e);
+      promise.reject(e, serializeError(31401, e.getMessage()));
     }
   }
 

--- a/android/src/main/java/com/twiliovoicereactnative/TwilioVoiceReactNativeModule.java
+++ b/android/src/main/java/com/twiliovoicereactnative/TwilioVoiceReactNativeModule.java
@@ -493,7 +493,7 @@ public class TwilioVoiceReactNativeModule extends ReactContextBaseJavaModule {
       try {
         getVoiceServiceApi().acceptCall(callRecord);
       } catch (SecurityException e) {
-        promise.reject(e);
+        promise.reject(e, serializeError(31401, e.getMessage()));
       }
     }
   }

--- a/android/src/main/java/com/twiliovoicereactnative/VoiceService.java
+++ b/android/src/main/java/com/twiliovoicereactnative/VoiceService.java
@@ -348,7 +348,7 @@ public class VoiceService extends Service {
     final int errorCode = 31401;
     getJSEventEmitter().sendEvent(ScopeVoice, constructJSMap(
       new Pair<>(VoiceEventType, VoiceEventError),
-      new Pair<>(VoiceEventError, serializeError(errorCode, errorMessage))
+      new Pair<>(VoiceErrorKeyError, serializeError(errorCode, errorMessage))
     ));
   }
 }

--- a/android/src/main/java/com/twiliovoicereactnative/VoiceService.java
+++ b/android/src/main/java/com/twiliovoicereactnative/VoiceService.java
@@ -345,7 +345,7 @@ public class VoiceService extends Service {
   }
   private static void sendPermissionsError() {
     final String errorMessage = "Missing permissions.";
-    final int errorCode = 31208;
+    final int errorCode = 31401;
     getJSEventEmitter().sendEvent(ScopeVoice, constructJSMap(
       new Pair<>(VoiceEventType, VoiceEventError),
       new Pair<>(VoiceEventError, serializeError(errorCode, errorMessage))

--- a/api/voice-react-native-sdk.api.md
+++ b/api/voice-react-native-sdk.api.md
@@ -927,7 +927,8 @@ declare namespace TwilioErrors {
         ServerErrors,
         SignalingErrors,
         SIPServerErrors,
-        TwiMLErrors
+        TwiMLErrors,
+        UserMediaErrors
     }
 }
 export { TwilioErrors }
@@ -951,6 +952,18 @@ class UnsupportedPlatformError extends TwilioError {
     description: string;
     // (undocumented)
     explanation: string;
+}
+
+// @public
+namespace UserMediaErrors {
+    class PermissionDeniedError extends TwilioError {
+        constructor(message: string);
+        causes: string[];
+        description: string;
+        explanation: string;
+        name: string;
+        solutions: string[];
+    }
 }
 
 // @public

--- a/package.json
+++ b/package.json
@@ -150,7 +150,7 @@
     ]
   },
   "dependencies": {
-    "@twilio/voice-errors": "1.6.0",
+    "@twilio/voice-errors": "1.8.0",
     "eventemitter3": "^4.0.7"
   }
 }

--- a/scripts/errors.js
+++ b/scripts/errors.js
@@ -108,6 +108,11 @@ const ERRORS = [
   'MediaErrors.NoSupportedCodec', // 53404
   'MediaErrors.ConnectionError', // 53405
   'MediaErrors.MediaDtlsTransportFailedError', // 53407
+
+  /**
+   * UserMediaErrors
+   */
+  'UserMediaErrors.PermissionDeniedError', // 31401
 ];
 
 module.exports = {

--- a/src/CallInvite.tsx
+++ b/src/CallInvite.tsx
@@ -446,11 +446,24 @@ export class CallInvite extends EventEmitter {
       );
     }
 
-    const callInfo = await NativeModule.callInvite_accept(this._uuid, options);
+    const acceptResult = await NativeModule.callInvite_accept(
+      this._uuid,
+      options
+    )
+      .then((callInfo) => {
+        return { type: 'ok', callInfo } as const;
+      })
+      .catch((error) => {
+        const code = error.userInfo.code;
+        const message = error.userInfo.message;
+        return { type: 'err', message, code } as const;
+      });
 
-    const call = new Call(callInfo);
+    if (acceptResult.type === 'err') {
+      throw constructTwilioError(acceptResult.message, acceptResult.code);
+    }
 
-    return call;
+    return new Call(acceptResult.callInfo);
   }
 
   /**

--- a/src/__tests__/CallInvite.test.ts
+++ b/src/__tests__/CallInvite.test.ts
@@ -270,7 +270,7 @@ describe('CallInvite class', () => {
       await new CallInvite(
         createNativeCallInviteInfo(),
         CallInvite.State.Pending
-      ).accept();
+      ).accept(acceptOptions);
       expect(MockCall.mock.instances).toHaveLength(1);
       expect(MockCall.mock.calls).toEqual([[createNativeCallInfo()]]);
     });
@@ -279,8 +279,27 @@ describe('CallInvite class', () => {
       const callPromise = new CallInvite(
         createNativeCallInviteInfo(),
         CallInvite.State.Pending
-      ).accept();
+      ).accept(acceptOptions);
       await expect(callPromise).resolves.toBeInstanceOf(MockCall);
+    });
+
+    it('rejects when the native module rejects', async () => {
+      const callPromise = new CallInvite(
+        createNativeCallInviteInfo(),
+        CallInvite.State.Pending
+      );
+
+      jest.mocked(NativeModule.callInvite_accept).mockRejectedValueOnce({
+        userInfo: {
+          code: 31401,
+          message: 'Missing permissions.',
+        },
+      });
+
+      expect.assertions(1);
+      await callPromise.accept(acceptOptions).catch((error) => {
+        expect(error).toBeInstanceOf(TwilioError);
+      });
     });
 
     (
@@ -372,7 +391,7 @@ describe('CallInvite class', () => {
     });
   });
 
-  describe('isValid()', () => {
+  describe('.isValid()', () => {
     it('invokes the native module', async () => {
       await new CallInvite(
         createNativeCallInviteInfo(),

--- a/src/__tests__/Voice.test.ts
+++ b/src/__tests__/Voice.test.ts
@@ -224,7 +224,7 @@ describe('Voice class', () => {
         expect(typeof error).toBe('object');
       });
 
-      describe('constructs an error', () => {
+      it('constructs an error', () => {
         new Voice(); // eslint-disable-line no-new
 
         const errorEvent = {
@@ -421,13 +421,22 @@ describe('Voice class', () => {
 
         it('rejects when the native layer rejects', async () => {
           const someMockErrorMessage = 'some mock error message';
-          const someMockError = new Error(someMockErrorMessage);
+          const someMockErrorCode = 31401;
+          const someMockError = {
+            userInfo: {
+              code: someMockErrorCode,
+              message: someMockErrorMessage,
+            },
+          };
+
           jest
             .mocked(MockNativeModule.voice_connect_android)
             .mockRejectedValueOnce(someMockError);
-          await expect(() => new Voice().connect(token)).rejects.toThrow(
-            someMockErrorMessage
-          );
+
+          expect.assertions(1);
+          await new Voice().connect(token).catch((error) => {
+            expect(error).toBeInstanceOf(MockTwilioError);
+          });
         });
 
         it('defaults params to "{}" when not passed', async () => {

--- a/src/error/generated.ts
+++ b/src/error/generated.ts
@@ -1732,6 +1732,63 @@ export namespace RegistrationErrors {
 
 /**
  * @public
+ * UserMedia errors.
+ */
+export namespace UserMediaErrors {
+  /**
+   * @public
+   * UserMediaErrors.PermissionDeniedError error.
+   * Error code `31401`.
+   */
+  export class PermissionDeniedError extends TwilioError {
+    /**
+     * The user denied the getUserMedia request.
+     * The browser denied the getUserMedia request.
+     * The application has not been configured with the proper permissions.
+     */
+    causes: string[] = [
+      'The user denied the getUserMedia request.',
+      'The browser denied the getUserMedia request.',
+      'The application has not been configured with the proper permissions.',
+    ];
+    /**
+     * UserMedia Permission Denied Error
+     */
+    description: string = 'UserMedia Permission Denied Error';
+    /**
+     * The browser or end-user denied permissions to user media. Therefore we were unable to acquire input audio.
+     */
+    explanation: string = 'The browser or end-user denied permissions to user media. Therefore we were unable to acquire input audio.';
+    /**
+     * PermissionDeniedError
+     */
+    name: string = 'PermissionDeniedError';
+    /**
+     * The user should accept the request next time prompted. If the browser saved the deny, the user should change that permission in their browser.
+     * The user should to verify that the browser has permission to access the microphone at this address.
+     * The user should ensure that the proper permissions have been granted in the mobile device OS.
+     */
+    solutions: string[] = [
+      'The user should accept the request next time prompted. If the browser saved the deny, the user should change that permission in their browser.',
+      'The user should to verify that the browser has permission to access the microphone at this address.',
+      'The user should ensure that the proper permissions have been granted in the mobile device OS.',
+    ];
+
+    constructor(message: string) {
+      super(message, 31401);
+      Object.setPrototypeOf(this, UserMediaErrors.PermissionDeniedError.prototype);
+
+      const msg: string = typeof message === 'string'
+        ? message
+        : this.explanation;
+
+      this.message = `${this.name} (${this.code}): ${msg}`;
+    }
+  }
+}
+
+/**
+ * @public
  * Signaling errors.
  */
 export namespace SignalingErrors {
@@ -2142,6 +2199,7 @@ export const errorsByCode: ReadonlyMap<number, typeof TwilioError> = new Map([
   [31301, RegistrationErrors.RegistrationError],
   [31302, RegistrationErrors.UnsupportedCancelMessageError],
   [31400, ClientErrors.BadRequest],
+  [31401, UserMediaErrors.PermissionDeniedError],
   [31403, ClientErrors.Forbidden],
   [31404, ClientErrors.NotFound],
   [31408, ClientErrors.RequestTimeout],

--- a/src/error/index.ts
+++ b/src/error/index.ts
@@ -14,4 +14,5 @@ export {
   SignalingErrors,
   SIPServerErrors,
   TwiMLErrors,
+  UserMediaErrors,
 } from './generated';

--- a/test/app/src/hook.ts
+++ b/test/app/src/hook.ts
@@ -373,8 +373,11 @@ export function useVoice(token: string) {
         });
         callHandler(call);
       } catch (err) {
-        console.log(err.userInfo);
-        logEvent(`connect rejected: ${err.userInfo}`);
+        const message = err.message;
+        const code = err.code;
+        logEvent(
+          `connect rejected: ${JSON.stringify({ message, code }, null, 2)}`
+        );
       }
     },
     [callHandler, token, voice, logEvent]

--- a/test/app/src/hook.ts
+++ b/test/app/src/hook.ts
@@ -257,7 +257,15 @@ export function useCallInvites(
         {
           accept: async () => {
             removeCallInvite(callInvite.getCallSid());
-            await callInvite.accept();
+            try {
+              await callInvite.accept();
+            } catch (err) {
+              const message = err.message;
+              const code = err.code;
+              logEvent(
+                `accept rejected: ${JSON.stringify({ message, code }, null, 2)}`
+              );
+            }
           },
           callSid,
           customParameters: callInvite.getCustomParameters(),

--- a/test/app/src/hook.ts
+++ b/test/app/src/hook.ts
@@ -363,17 +363,21 @@ export function useVoice(token: string) {
 
   const connectHandler = React.useCallback(
     async (to: string) => {
-      const call = await voice.connect(token, {
-        params: {
-          answerOnBridge: 'true',
-          recipientType: 'client',
-          to,
-        },
-      });
-
-      callHandler(call);
+      try {
+        const call = await voice.connect(token, {
+          params: {
+            answerOnBridge: 'true',
+            recipientType: 'client',
+            to,
+          },
+        });
+        callHandler(call);
+      } catch (err) {
+        console.log(err.userInfo);
+        logEvent(`connect rejected: ${err.userInfo}`);
+      }
     },
-    [callHandler, token, voice]
+    [callHandler, token, voice, logEvent]
   );
 
   const registerHandler = React.useCallback(() => {

--- a/test/app/src/hook.ts
+++ b/test/app/src/hook.ts
@@ -355,7 +355,7 @@ export function useVoice(token: string) {
         message: error.message,
         name: error.name,
         solutions: error.solutions,
-      }
+      };
       logEvent(JSON.stringify(msg, null, 2));
     },
     [logEvent]
@@ -486,7 +486,13 @@ export function useVoice(token: string) {
       voice.off(Voice.Event.AudioDevicesUpdated, audioDevicesUpdateHandler);
       voice.off(Voice.Event.Error, logVoiceErrorHandler);
     };
-  }, [audioDevicesUpdateHandler, callHandler, callInviteHandler, voice]);
+  }, [
+    audioDevicesUpdateHandler,
+    callHandler,
+    callInviteHandler,
+    logVoiceErrorHandler,
+    voice,
+  ]);
 
   return {
     registered,

--- a/test/app/src/hook.ts
+++ b/test/app/src/hook.ts
@@ -345,6 +345,22 @@ export function useVoice(token: string) {
     callHandler
   );
 
+  const logVoiceErrorHandler = React.useCallback<Voice.Listener.Error>(
+    (error) => {
+      const msg = {
+        causes: error.causes,
+        code: error.code,
+        description: error.description,
+        explanation: error.explanation,
+        message: error.message,
+        name: error.name,
+        solutions: error.solutions,
+      }
+      logEvent(JSON.stringify(msg, null, 2));
+    },
+    [logEvent]
+  );
+
   const connectHandler = React.useCallback(
     async (to: string) => {
       const call = await voice.connect(token, {
@@ -463,10 +479,12 @@ export function useVoice(token: string) {
 
     voice.on(Voice.Event.CallInvite, callInviteHandler);
     voice.on(Voice.Event.AudioDevicesUpdated, audioDevicesUpdateHandler);
+    voice.on(Voice.Event.Error, logVoiceErrorHandler);
 
     return () => {
       voice.off(Voice.Event.CallInvite, callInviteHandler);
       voice.off(Voice.Event.AudioDevicesUpdated, audioDevicesUpdateHandler);
+      voice.off(Voice.Event.Error, logVoiceErrorHandler);
     };
   }, [audioDevicesUpdateHandler, callHandler, callInviteHandler, voice]);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3129,10 +3129,10 @@
   dependencies:
     "@sinonjs/commons" "^1.7.0"
 
-"@twilio/voice-errors@1.6.0":
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/@twilio/voice-errors/-/voice-errors-1.6.0.tgz#5711a9e12dbe1653a078fdc229e54ff9348b36d1"
-  integrity sha512-T1Fbllo27UPRYWUqBXGwYz8PQgSTbL2wcMKpyNXj7aloQBtA4hxIiEnZ0+oDc3CLz8RlHdYtQktUg9Ezo9huiA==
+"@twilio/voice-errors@1.8.0":
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/@twilio/voice-errors/-/voice-errors-1.8.0.tgz#ab13ae8ee9bd53dc62acffa9631be4f391b8c695"
+  integrity sha512-Mh3CCCNOZ+OCFNv90ibml1VrsXiJy/1+/FP6382tUQuqZztndp41eqnJhsnM44UBkMAtlvVUSd1HuK8iCdHM/A==
 
 "@types/argparse@1.0.38":
   version "1.0.38"


### PR DESCRIPTION
## Submission Checklist

 - [x] Updated the `CHANGELOG.md` to reflect any **feature**, **bug fixes**, or **known issues** made in the source code
 - [x] Tested code changes and observed expected behavior in the example app
 - [x] Performed a visual inspection of the `Files changed` tab prior to submitting the pull request for review to ensure proper usage of the style guide

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Description

This PR implements a missing permissions error on Android platforms. As well as catching said error on the JS layer.

## Breakdown

- Emit the missing permissions error in the Android layer.
- Catch the error on the JS layer.
- Add test app code path to catch and verify error.

## Validation

- Manual testing with test app.

## Additional Notes

N/A
