### PR TITLE
[VBLOCKS-3325] Added support for disabling embedded firebase messaging service

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -8,6 +8,7 @@
   <uses-permission android:name="android.permission.WAKE_LOCK" />
   <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
   <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MICROPHONE"/>
+  <uses-permission android:name="android.permission.RECORD_AUDIO" />
 
   <application>
     <service

--- a/android/src/main/java/com/twiliovoicereactnative/ConfigurationProperties.java
+++ b/android/src/main/java/com/twiliovoicereactnative/ConfigurationProperties.java
@@ -1,0 +1,6 @@
+package com.twiliovoicereactnative;
+
+class ConfigurationProperties {
+  public static String ENABLE_FIREBASE_MESSAGING_SERVICE =
+    "com.twiliovoicereactnative.firebasemessagingserivce.enable";
+}

--- a/android/src/main/java/com/twiliovoicereactnative/VoiceApplicationProxy.java
+++ b/android/src/main/java/com/twiliovoicereactnative/VoiceApplicationProxy.java
@@ -2,8 +2,10 @@ package com.twiliovoicereactnative;
 
 import static com.twiliovoicereactnative.CallRecordDatabase.CallRecord;
 
+import java.io.IOException;
 import java.util.List;
 import java.util.Objects;
+import java.util.Properties;
 
 import android.app.Application;
 import android.content.ComponentName;
@@ -35,6 +37,7 @@ public class VoiceApplicationProxy {
       voiceServiceApi = null;
     }
   };
+
   public abstract static class VoiceReactNativeHost extends ReactNativeHost {
     public VoiceReactNativeHost(Application application) {
       super(application);
@@ -55,6 +58,7 @@ public class VoiceApplicationProxy {
     instance = this;
     context = reactNativeHost.getAssociatedApplication();
   }
+
   public void onCreate() {
     logger.debug("onCreate(..) invoked");
     // construct JS event engine
@@ -71,6 +75,7 @@ public class VoiceApplicationProxy {
     mediaPlayerManager = new MediaPlayerManager(context);
     audioSwitchManager.start();
   }
+
   public void onTerminate() {
     logger.debug("onTerminate(..) invoked");
     // shutdown notificaiton channels
@@ -87,21 +92,40 @@ public class VoiceApplicationProxy {
     }
     callRecordDatabase.clear();
   }
+
   static CallRecordDatabase getCallRecordDatabase() {
     return VoiceApplicationProxy.instance.callRecordDatabase;
   }
+
   static AudioSwitchManager getAudioSwitchManager() {
     return VoiceApplicationProxy.instance.audioSwitchManager;
   }
+
   static MediaPlayerManager getMediaPlayerManager() {
     return VoiceApplicationProxy.instance.mediaPlayerManager;
   }
+
   static JSEventEmitter getJSEventEmitter() {
     return VoiceApplicationProxy.instance.jsEventEmitter;
   }
 
   static Context getApplicationContext() {
     return VoiceApplicationProxy.instance.context;
+  }
+
+  static Properties getApplicationConfiguration() {
+    Properties config = new Properties();
+    try {
+      config.load(
+        getApplicationContext().getAssets().open("config.properties"));
+    } catch (IOException exception) {
+      logger.warning("Failed to load properties file");
+      // set defaults
+      config.setProperty(
+        ConfigurationProperties.ENABLE_FIREBASE_MESSAGING_SERVICE,
+        String.valueOf(true));
+    }
+    return config;
   }
 
   static Class<?> getMainActivityClass() {

--- a/android/src/main/java/com/twiliovoicereactnative/VoiceFirebaseMessagingService.java
+++ b/android/src/main/java/com/twiliovoicereactnative/VoiceFirebaseMessagingService.java
@@ -18,10 +18,42 @@ import com.twilio.voice.MessageListener;
 import com.twilio.voice.Voice;
 
 import java.util.Objects;
+import java.util.Properties;
 import java.util.UUID;
 
-public class VoiceFirebaseMessagingService extends FirebaseMessagingService implements MessageListener {
+public class VoiceFirebaseMessagingService extends FirebaseMessagingService {
   private static final SDKLog logger = new SDKLog(VoiceFirebaseMessagingService.class);
+
+  public static class MessageHandler implements MessageListener  {
+    @Override
+    public void onCallInvite(@NonNull CallInvite callInvite) {
+      final CallRecord callRecord = new CallRecord(UUID.randomUUID(), callInvite);
+
+      getCallRecordDatabase().add(callRecord);
+      getVoiceServiceApi().incomingCall(callRecord);
+    }
+
+    @Override
+    public void onCancelledCallInvite(@NonNull CancelledCallInvite cancelledCallInvite,
+                                      @Nullable CallException callException) {
+      CallRecord callRecord = Objects.requireNonNull(
+        getCallRecordDatabase().remove(new CallRecord(cancelledCallInvite.getCallSid())));
+
+      callRecord.setCancelledCallInvite(cancelledCallInvite);
+      callRecord.setCallException(callException);
+      getVoiceServiceApi().cancelCall(callRecord);
+    }
+  }
+
+  @Override
+  public void onCreate() {
+    // disable service if configured to use external firebase messaging system
+    Properties config = VoiceApplicationProxy.getApplicationConfiguration();
+    if (!Boolean.parseBoolean(
+      config.getProperty(ConfigurationProperties.ENABLE_FIREBASE_MESSAGING_SERVICE))) {
+      stopSelf();
+    }
+  }
 
   @Override
   public void onNewToken(@NonNull String token) {
@@ -50,29 +82,14 @@ public class VoiceFirebaseMessagingService extends FirebaseMessagingService impl
 
     // Check if message contains a data payload.
     if (!remoteMessage.getData().isEmpty()) {
-      if (!Voice.handleMessage(this, remoteMessage.getData(), this, new CallMessageListenerProxy())) {
+      if (!Voice.handleMessage(
+        this,
+        remoteMessage.getData(),
+        new MessageHandler(),
+        new CallMessageListenerProxy())) {
         logger.error("The message was not a valid Twilio Voice SDK payload: " +
           remoteMessage.getData());
       }
     }
-  }
-
-  @Override
-  public void onCallInvite(@NonNull CallInvite callInvite) {
-    final CallRecord callRecord = new CallRecord(UUID.randomUUID(), callInvite);
-
-    getCallRecordDatabase().add(callRecord);
-    getVoiceServiceApi().incomingCall(callRecord);
-  }
-
-  @Override
-  public void onCancelledCallInvite(@NonNull CancelledCallInvite cancelledCallInvite,
-                                    @Nullable CallException callException) {
-    CallRecord callRecord = Objects.requireNonNull(
-      getCallRecordDatabase().remove(new CallRecord(cancelledCallInvite.getCallSid())));
-
-    callRecord.setCancelledCallInvite(cancelledCallInvite);
-    callRecord.setCallException(callException);
-    getVoiceServiceApi().cancelCall(callRecord);
   }
 }

--- a/android/src/main/res/values/strings.xml
+++ b/android/src/main/res/values/strings.xml
@@ -21,4 +21,5 @@
   <string name="incoming_call_caller_name_text">${from}</string>
   <string name="outgoing_call_caller_name_text">${to}</string>
   <string name="answered_call_caller_name_text">${from}</string>
+  <string name="method_invocation_invalid">Method invocation invalid</string>
 </resources>


### PR DESCRIPTION
## Submission Checklist

 - [x] Updated the `CHANGELOG.md` to reflect any **feature**, **bug fixes**, or **known issues** made in the source code
 - [ ] Tested code changes and observed expected behavior in the example app
 - [ ] Performed a visual inspection of the `Files changed` tab prior to submitting the pull request for review to ensure proper usage of the style guide

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Description

This change allows the user of the sdk to disable the embedded firebase messaging serviced by adding `config.properties` to their assets directory containing the property value `com.twiliovoicereactnative.firebasemessagingserivce.enable=false`. This also enables an API called handleEvent which will process incoming messages from other firebase modules.

## Breakdown

- Exposed HandleEvent
- Enabled the disabling of the embedded firebase module

## Validation

- Ran, can't test without JS development

## Additional Notes

None
