### PR TITLE
[VBLOCKS-2978] fix: missing android rtc byte stats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,10 @@
 
 - Fixed Call Messages not being built with the passed `contentType` or `messageType`.
 
+#### Android
+
+- Fixed some RTCStats members not available on Android. Specifically, `mos`, `bytesSent`, and `bytesReceived`.
+
 ## Changes
 
 ### Call Message Events (Beta)

--- a/android/src/main/java/com/twiliovoicereactnative/JSEventEmitter.java
+++ b/android/src/main/java/com/twiliovoicereactnative/JSEventEmitter.java
@@ -56,6 +56,10 @@ class JSEventEmitter {
         params.pushDouble((Double) entry);
       } else if (entry instanceof Long) {
         params.pushDouble((Long) entry);
+      } else if (entry == null) {
+        logger.debug("constructJSArray: filtering null value");
+      } else {
+        logger.debug(String.format("constructJSArray: unexpected type %s", entry.getClass()));
       }
     }
     return params;
@@ -80,6 +84,13 @@ class JSEventEmitter {
         params.putDouble(entry.first, (Double) entry.second);
       } else if (entry.second instanceof Long) {
         params.putDouble(entry.first, (Long) entry.second);
+      } else if (entry.second == null) {
+        logger.debug("constructJSMap: filtering null value");
+      } else {
+        logger.debug(String.format(
+          "constructJSMap: unexpected type %s",
+          entry.second.getClass()
+        ));
       }
     }
     return params;

--- a/android/src/main/java/com/twiliovoicereactnative/JSEventEmitter.java
+++ b/android/src/main/java/com/twiliovoicereactnative/JSEventEmitter.java
@@ -56,13 +56,6 @@ class JSEventEmitter {
         params.pushDouble((Double) entry);
       } else if (entry instanceof Long) {
         params.pushDouble((Long) entry);
-      } else {
-        logger.warning(
-          String.format(
-            "constructJSArray: found unexpected type {%s}",
-            entry.getClass()
-          )
-        );
       }
     }
     return params;
@@ -87,15 +80,6 @@ class JSEventEmitter {
         params.putDouble(entry.first, (Double) entry.second);
       } else if (entry.second instanceof Long) {
         params.putDouble(entry.first, (Long) entry.second);
-      } else {
-        logger.warning(
-          String.format(
-            "constructJSMap: found unexpected type {%s}",
-            entry.second != null
-              ? entry.second.getClass()
-              : "null"
-          )
-        );
       }
     }
     return params;

--- a/android/src/main/java/com/twiliovoicereactnative/JSEventEmitter.java
+++ b/android/src/main/java/com/twiliovoicereactnative/JSEventEmitter.java
@@ -54,6 +54,15 @@ class JSEventEmitter {
         params.pushDouble((Float) entry);
       } else if (entry instanceof Double) {
         params.pushDouble((Double) entry);
+      } else if (entry instanceof Long) {
+        params.pushDouble((Long) entry);
+      } else {
+        logger.warning(
+          String.format(
+            "constructJSArray: found unexpected type {%s}",
+            entry.getClass()
+          )
+        );
       }
     }
     return params;
@@ -76,6 +85,17 @@ class JSEventEmitter {
         params.putDouble(entry.first, (Float) entry.second);
       } else if (entry.second instanceof Double) {
         params.putDouble(entry.first, (Double) entry.second);
+      } else if (entry.second instanceof Long) {
+        params.putDouble(entry.first, (Long) entry.second);
+      } else {
+        logger.warning(
+          String.format(
+            "constructJSMap: found unexpected type {%s}",
+            entry.second != null
+              ? entry.second.getClass()
+              : "null"
+          )
+        );
       }
     }
     return params;

--- a/test/app/e2e/common/logParser.ts
+++ b/test/app/e2e/common/logParser.ts
@@ -1,0 +1,42 @@
+import type { EventLogItem } from '../../src/type';
+
+export const getLog = async (): Promise<Array<EventLogItem>> => {
+  const eventLogAttr = await element(by.id('event_log')).getAttributes();
+  if (!('label' in eventLogAttr) || !eventLogAttr.label) {
+    throw new Error('cannot parse event log label');
+  }
+
+  const log: string = eventLogAttr.label;
+
+  return JSON.parse(log);
+};
+
+export const pollValidateLog = async (
+  validator: (log: Array<EventLogItem>) => boolean,
+  loops: number = 5,
+) => {
+  let wasValid = false;
+  for (let i = 0; i < loops; i++) {
+    const log = await getLog();
+    if (validator(log)) {
+      wasValid = true;
+      break;
+    } else {
+      await new Promise((resolve) => setTimeout(resolve, 5000));
+    }
+  }
+  return wasValid;
+};
+
+export const getRegExpMatch = async (regExp: RegExp) => {
+  let log = await getLog();
+  let regExpMatchGroup;
+  for (const entry of [...log].reverse()) {
+    const m = entry.content.match(regExp);
+    if (m) {
+      regExpMatchGroup = m[1];
+      break;
+    }
+  }
+  return regExpMatchGroup;
+};

--- a/test/app/e2e/common/rtcStatsValidators.ts
+++ b/test/app/e2e/common/rtcStatsValidators.ts
@@ -1,0 +1,154 @@
+import { expect as jestExpect } from 'expect';
+
+export class RecordValidator {
+  private _record: Record<any, any>;
+  private _validators: Array<Function> = [];
+  private _validatedKeys: Array<string> = [];
+
+  constructor(record: Record<any, any>) {
+    this._record = record;
+  }
+
+  expect(
+    key: string,
+    expectedValueType: 'boolean' | 'number' | 'string' | 'object' | 'array'
+  ) {
+    this._validators.push(() => {
+      const value = this._record[key];
+      const actualValueType = typeof value;
+
+      if (expectedValueType === 'array') {
+        jestExpect(actualValueType).toStrictEqual('object');
+        jestExpect(Array.isArray(value)).toStrictEqual(true);
+      } else {
+        jestExpect(actualValueType).toStrictEqual(expectedValueType);
+      }
+
+      this._validatedKeys.push(key);
+    });
+
+    return this;
+  }
+
+  exhaustive() {
+    this.run();
+
+    const validatedKeys = this._validatedKeys.sort();
+    const allKeys = Object.keys(this._record).sort();
+
+    jestExpect(validatedKeys).toStrictEqual(allKeys);
+  }
+
+  run() {
+    this._validators.forEach((validator) => {
+      validator();
+    });
+  }
+}
+
+const iceCandidatePairStatValidator = (iceCandidatePairStat: any) => {
+  new RecordValidator(iceCandidatePairStat)
+    .expect('writeable', 'boolean')
+    .expect('transportId', 'string')
+    .expect('state', 'string')
+    .expect('responsesSent', 'number')
+    .expect('responsesReceived', 'number')
+    .expect('activeCandidatePair', 'boolean')
+    .expect('requestsReceived', 'number')
+    .expect('readable', 'boolean')
+    .expect('remoteCandidateIp', 'string')
+    .expect('localCandidateIp', 'string')
+    .expect('totalRoundTripTime', 'number')
+    .expect('bytesSent', 'number')
+    .expect('remoteCandidateId', 'string')
+    .expect('localCandidateId', 'string')
+    .expect('currentRoundTripTime', 'number')
+    .expect('retransmissionsReceived', 'number')
+    .expect('priority', 'number')
+    .expect('consentResponsesReceived', 'number')
+    .expect('consentRequestsSent', 'number')
+    .expect('nominated', 'boolean')
+    .expect('retransmissionsSent', 'number')
+    .expect('consentRequestsReceived', 'number')
+    .expect('bytesReceived', 'number')
+    .expect('consentResponsesSent', 'number')
+    .expect('availableIncomingBitrate', 'number')
+    .expect('availableOutgoingBitrate', 'number')
+    .expect('requestsSent', 'number')
+    .expect('relayProtocol', 'string')
+    .exhaustive();
+};
+
+const remoteAudioTrackStatValidator = (remoteAudioTrackStat: any) => {
+  new RecordValidator(remoteAudioTrackStat)
+    .expect('jitter', 'number')
+    .expect('audioLevel', 'number')
+    .expect('packetsReceived', 'number')
+    .expect('bytesReceived', 'number')
+    .expect('timestamp', 'number')
+    .expect('packetsLost', 'number')
+    .expect('trackId', 'string')
+    .expect('mos', 'number')
+    .expect('ssrc', 'string')
+    .expect('codec', 'string')
+    .exhaustive();
+};
+
+const iceCandidateStatValidator = (iceCandidateStat: any) => {
+  new RecordValidator(iceCandidateStat)
+    .expect('url', 'string')
+    .expect('transportId', 'string')
+    .expect('priority', 'number')
+    .expect('protocol', 'string')
+    .expect('ip', 'string')
+    .expect('candidateType', 'string')
+    .expect('isRemote', 'boolean')
+    .expect('deleted', 'boolean')
+    .expect('port', 'number')
+    .exhaustive();
+};
+
+const localAudioTrackStatValidator = (localAudioTrackStat: any) => {
+  new RecordValidator(localAudioTrackStat)
+    .expect('jitter', 'number')
+    .expect('audioLevel', 'number')
+    .expect('roundTripTime', 'number')
+    .expect('bytesSent', 'number')
+    .expect('timestamp', 'number')
+    .expect('packetsLost', 'number')
+    .expect('trackId', 'string')
+    .expect('packetsSent', 'number')
+    .expect('ssrc', 'string')
+    .expect('codec', 'string')
+    .exhaustive();
+};
+
+const rtcStatValidator = (rtcStat: any) => {
+  new RecordValidator(rtcStat)
+    .expect('iceCandidatePairStats', 'array')
+    .expect('remoteAudioTrackStats', 'array')
+    .expect('iceCandidateStats', 'array')
+    .expect('localAudioTrackStats', 'array')
+    .expect('peerConnectionId', 'string')
+    .exhaustive();
+};
+
+export const validateRtcStats = (rtcStats: any) => {
+  jestExpect(Array.isArray(rtcStats)).toBeTruthy();
+
+  for (const rtcStat of rtcStats) {
+    rtcStatValidator(rtcStat);
+
+    const {
+      iceCandidatePairStats,
+      remoteAudioTrackStats,
+      iceCandidateStats,
+      localAudioTrackStats,
+    } = rtcStat;
+
+    iceCandidatePairStats.forEach((iceCandidatePairStatValidator));
+    remoteAudioTrackStats.forEach(remoteAudioTrackStatValidator);
+    iceCandidateStats.forEach(iceCandidateStatValidator);
+    localAudioTrackStats.forEach(localAudioTrackStatValidator);
+  }
+};

--- a/test/app/e2e/suites/callMessage.test.ts
+++ b/test/app/e2e/suites/callMessage.test.ts
@@ -2,8 +2,8 @@ import axios from 'axios';
 import { device, element, by, waitFor } from 'detox';
 import { expect as jestExpect } from 'expect';
 import type twilio from 'twilio';
-import type { EventLogItem } from '../../src/type';
 import { bootstrapTwilioClient } from '../common/twilioClient';
+import { pollValidateLog, getRegExpMatch } from '../common/logParser';
 
 const DEFAULT_TIMEOUT = 10000;
 const RELAY_SERVER_URL = 'http://localhost:4040'
@@ -63,47 +63,6 @@ describe('call', () => {
 
   const toggleLogFormat = async () => {
     await tapButton('TOGGLE LOG FORMAT');
-  };
-
-  const getLog = async (): Promise<Array<EventLogItem>> => {
-    const eventLogAttr = await element(by.id('event_log')).getAttributes();
-    if (!('label' in eventLogAttr) || !eventLogAttr.label) {
-      throw new Error('cannot parse event log label');
-    }
-
-    const log: string = eventLogAttr.label;
-
-    return JSON.parse(log);
-  };
-
-  const pollValidateLog = async (
-    validator: (log: Array<EventLogItem>) => boolean,
-    loops: number = 5,
-  ) => {
-    let wasValid = false;
-    for (let i = 0; i < loops; i++) {
-      const log = await getLog();
-      if (validator(log)) {
-        wasValid = true;
-        break;
-      } else {
-        await new Promise((resolve) => setTimeout(resolve, 5000));
-      }
-    }
-    return wasValid;
-  };
-
-  const getRegExpMatch = async (regExp: RegExp) => {
-    let log = await getLog();
-    let regExpMatchGroup;
-    for (const entry of [...log].reverse()) {
-      const m = entry.content.match(regExp);
-      if (m) {
-        regExpMatchGroup = m[1];
-        break;
-      }
-    }
-    return regExpMatchGroup;
   };
 
   const sendValidMessageTest = async () => {


### PR DESCRIPTION
## Submission Checklist

 - [x] Updated the `CHANGELOG.md` to reflect any **feature**, **bug fixes**, or **known issues** made in the source code
 - [x] Tested code changes and observed expected behavior in the example app
 - [x] Performed a visual inspection of the `Files changed` tab prior to submitting the pull request for review to ensure proper usage of the style guide

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Description

This PR implements e2e tests for RTC Stats. It also fixes some missing values that are reported from the native layer as `long` values.

## Breakdown

- Add e2e tests for RTC Stats.
- Fix `long` typed values being ignored when raised by the native layer to the JS layer on Android.

## Validation

- New e2e test.
- Manual testing.

## Additional Notes

N/A
