### PR TITLE
[VBLOCKS-3421] fixed api 34 notification issue when app is backgrounded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+1.1.1 (In Progress)
+====================
+
+## Fixes
+
+### Platform Specific Fixes
+
+#### Android
+
+- Fixed crash issue on API 34 when activity is not running in background or foreground and an incoming call is received.
+
 1.1.0 (Aug 20, 2024)
 ====================
 

--- a/android/src/main/java/com/twiliovoicereactnative/CallListenerProxy.java
+++ b/android/src/main/java/com/twiliovoicereactnative/CallListenerProxy.java
@@ -60,7 +60,7 @@ class CallListenerProxy implements Call.Listener {
     CallRecord callRecord = Objects.requireNonNull(getCallRecordDatabase().remove(new CallRecord(uuid)));
 
     // take down notification
-    getVoiceServiceApi().cancelNotification(callRecord);
+    getVoiceServiceApi().cancelActiveCallNotification(callRecord);
 
     // serialize and notify JS
     sendJSEvent(
@@ -148,7 +148,7 @@ class CallListenerProxy implements Call.Listener {
     getMediaPlayerManager().stop();
     getMediaPlayerManager().play(MediaPlayerManager.SoundTable.DISCONNECT);
     getAudioSwitchManager().getAudioSwitch().deactivate();
-    getVoiceServiceApi().cancelNotification(callRecord);
+    getVoiceServiceApi().cancelActiveCallNotification(callRecord);
 
     // notify JS layer
     sendJSEvent(

--- a/android/src/main/java/com/twiliovoicereactnative/Constants.java
+++ b/android/src/main/java/com/twiliovoicereactnative/Constants.java
@@ -7,7 +7,7 @@ class Constants {
   public static final String VOICE_CHANNEL_DEFAULT_IMPORTANCE = "notification-channel-normal-importance";
   public static final String ACTION_ACCEPT_CALL = "ACTION_ACCEPT_CALL";
   public static final String ACTION_REJECT_CALL = "ACTION_REJECT_CALL";
-  public static final String ACTION_CANCEL_NOTIFICATION = "ACTION_CANCEL_NOTIFICATION";
+  public static final String ACTION_CANCEL_ACTIVE_CALL_NOTIFICATION = "ACTION_CANCEL_ACTIVE_CALL_NOTIFICATION";
   public static final String ACTION_INCOMING_CALL = "ACTION_INCOMING_CALL";
   public static final String ACTION_CANCEL_CALL = "ACTION_CANCEL_CALL";
   public static final String ACTION_CALL_DISCONNECT = "ACTION_CALL_DISCONNECT";


### PR DESCRIPTION
## Submission Checklist

 - [x] Updated the `CHANGELOG.md` to reflect any **feature**, **bug fixes**, or **known issues** made in the source code
 - [x] Tested code changes and observed expected behavior in the example app
 - [ ] Performed a visual inspection of the `Files changed` tab prior to submitting the pull request for review to ensure proper usage of the style guide

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Description

Fixed API 34 notification crash when activity is not running in foreground or background.

## Breakdown

- Now the incoming call notification does not cause foregrounding of the call service.

## Validation

- Tested handling incoming calls when app is foregrounded and backgrounded.

## Additional Notes

None
