### PR TITLE
Bump min sdk version and cancel notification for disconnected calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 1.1.1 (In Progress)
 ====================
 
+## Changes
+
+### Platform Specific Changes
+
+#### Android
+
+- Bumped `minSdkVersion` to `23` to match the latest versions of React Native.
+
 ## Fixes
 
 ### Platform Specific Fixes

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -32,7 +32,7 @@ android {
   namespace 'com.twiliovoicereactnative'
   compileSdk safeExtGet('TwilioVoiceReactNative_compileSdkVersion', 34)
   defaultConfig {
-    minSdkVersion safeExtGet('TwilioVoiceReactNative_minSdkVersion', 21)
+    minSdkVersion safeExtGet('TwilioVoiceReactNative_minSdkVersion', 23)
     targetSdkVersion safeExtGet('TwilioVoiceReactNative_targetSdkVersion', 34)
     versionCode 1
     versionName "1.0"

--- a/android/src/main/java/com/twiliovoicereactnative/VoiceService.java
+++ b/android/src/main/java/com/twiliovoicereactnative/VoiceService.java
@@ -339,7 +339,7 @@ public class VoiceService extends Service {
     // only take down notification & stop any active sounds if one is active
     if (null != callRecord) {
       VoiceApplicationProxy.getMediaPlayerManager().stop();
-      removeForegroundNotification();
+      removeForegroundNotification(callRecord.getNotificationId());
     }
   }
   private void createOrReplaceNotification(final int notificationId,
@@ -358,11 +358,14 @@ public class VoiceService extends Service {
     }
   }
   private void removeNotification(final int notificationId) {
+    logger.debug("removeNotification");
     NotificationManager mNotificationManager =
       (NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE);
     mNotificationManager.cancel(notificationId);
   }
-  private void removeForegroundNotification() {
+  private void removeForegroundNotification(final int notificationId) {
+    logger.debug("removeForegroundNotification");
+    removeNotification(notificationId);
     ServiceCompat.stopForeground(this, ServiceCompat.STOP_FOREGROUND_REMOVE);
   }
   private void foregroundNotification(int id, Notification notification) {

--- a/android/src/main/java/com/twiliovoicereactnative/VoiceService.java
+++ b/android/src/main/java/com/twiliovoicereactnative/VoiceService.java
@@ -312,7 +312,7 @@ public class VoiceService extends Service {
       NotificationUtility.createOutgoingCallNotificationWithLowImportance(
         VoiceService.this,
         callRecord);
-    createOrReplaceNotification(callRecord.getNotificationId(), notification);
+    createOrReplaceForegroundNotification(callRecord.getNotificationId(), notification);
   }
   private void foregroundAndDeprioritizeIncomingCallNotification(final CallRecordDatabase.CallRecord callRecord) {
     logger.debug("foregroundAndDeprioritizeIncomingCallNotification: " + callRecord.getUuid());
@@ -339,7 +339,7 @@ public class VoiceService extends Service {
     // only take down notification & stop any active sounds if one is active
     if (null != callRecord) {
       VoiceApplicationProxy.getMediaPlayerManager().stop();
-      removeForegroundNotification(callRecord.getNotificationId());
+      removeForegroundNotification();
     }
   }
   private void createOrReplaceNotification(final int notificationId,
@@ -363,9 +363,8 @@ public class VoiceService extends Service {
       (NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE);
     mNotificationManager.cancel(notificationId);
   }
-  private void removeForegroundNotification(final int notificationId) {
+  private void removeForegroundNotification() {
     logger.debug("removeForegroundNotification");
-    removeNotification(notificationId);
     ServiceCompat.stopForeground(this, ServiceCompat.STOP_FOREGROUND_REMOVE);
   }
   private void foregroundNotification(int id, Notification notification) {

--- a/test/app/android/build.gradle
+++ b/test/app/android/build.gradle
@@ -3,7 +3,7 @@
 buildscript {
     ext {
         buildToolsVersion = "33.0.0"
-        minSdkVersion = 21
+        minSdkVersion = 23
         compileSdkVersion = 34
         targetSdkVersion = 34
         kotlinVersion = "1.8.0"


### PR DESCRIPTION
## Submission Checklist

 - [x] Updated the `CHANGELOG.md` to reflect any **feature**, **bug fixes**, or **known issues** made in the source code
 - [x] Tested code changes and observed expected behavior in the example app
 - [x] Performed a visual inspection of the `Files changed` tab prior to submitting the pull request for review to ensure proper usage of the style guide

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Description

This PR bumps the `minSdkVersion` to `23` to match latest RN requirements. This PR also implements a fix for cancelling active call notifications when a call is disconnected.

## Breakdown

- Bump `minSdkVersion` to `23`.
- Cancel call notification for disconnected calls.

## Validation

- Manual testing with example app.
```
device running android api 34
outgoing call
  accepted
    [x] disconnected by remote
    [x] disconnected by local js
    [x] disconnected by local native
  [x] rejected by remote
  cancelled by local
    [x] js
    [x] native
incoming call
  closed
    [x] tap on notification body
    accepted by local native
      [x] disconnected by local js
      [x] disconnected by local native
    [x] rejected by local native
    [x] cancelled by remote
  background
    [x] tap on notification body
    accepted by local native
      [x] disconnected by local js
      [x] disconnected by local native
    [x] rejected by local native
    [x] cancelled by remote
  foreground
    accepted by local
      native
        [x] disconnected by local native
        [x] disconnected by local js
        [x] disconnected by remote
      js
        [x] disconnected by local native
        [x] disconnected by local js
        [x] disconnected by remote
    rejected by local
      [x] native
      [x] js
    [x] cancelled by remote
```

## Additional Notes

N/A
