### PR TITLE
[VBLOCKS-3468] Conditional stringify of call message content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ The Call Message Events feature in the Twilio Voice React Native SDK, previously
 
 - **(Breaking)** The error code for attempting to send a call message with a payload size exceeding maximum limits has changed from `31209` to `31212`.
 
+- **(Breaking)** The behavior of `call.sendMessage` has now changed. When sending a message such that the value of `content` is type `string`, the content will no longer be processed through `JSON.stringify` before being sent to Twilio. If the value of `content` is any type other than `string`, it will behave as original.
+
 ### Platform Specific Changes
 
 #### Android

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ The Call Message Events feature in the Twilio Voice React Native SDK, previously
 
 - **(Breaking)** The error code for attempting to send a call message with a payload size exceeding maximum limits has changed from `31209` to `31212`.
 
-- **(Breaking)** The behavior of `call.sendMessage` has now changed. When sending a message such that the value of `content` is type `string`, the content will no longer be processed through `JSON.stringify` before being sent to Twilio. If the value of `content` is any type other than `string`, it will behave as original.
+- The behavior of `call.sendMessage` has been changed to support future `contentType`s.
+  Please see the [API Docs](https://github.com/twilio/twilio-voice-react-native/blob/latest/docs/api/voice-react-native-sdk.callmessage_interface.md) for more information.
 
 ### Platform Specific Changes
 

--- a/src/Call.tsx
+++ b/src/Call.tsx
@@ -906,18 +906,15 @@ export class Call extends EventEmitter {
   async sendMessage(message: CallMessage): Promise<OutgoingCallMessage> {
     const { content, contentType, messageType } = validateCallMessage(message);
 
-    const contentStr =
-      typeof content === 'string' ? content : JSON.stringify(content);
-
     const voiceEventSid = await NativeModule.call_sendMessage(
       this._uuid,
-      contentStr,
+      content,
       contentType,
       messageType
     );
 
     const outgoingCallMessage = new OutgoingCallMessage({
-      content: contentStr,
+      content,
       contentType,
       messageType,
       voiceEventSid,

--- a/src/Call.tsx
+++ b/src/Call.tsx
@@ -905,15 +905,18 @@ export class Call extends EventEmitter {
   async sendMessage(message: CallMessage): Promise<OutgoingCallMessage> {
     const { content, contentType, messageType } = validateCallMessage(message);
 
+    const contentStr =
+      typeof content === 'string' ? content : JSON.stringify(content);
+
     const voiceEventSid = await NativeModule.call_sendMessage(
       this._uuid,
-      JSON.stringify(content),
+      contentStr,
       contentType,
       messageType
     );
 
     const outgoingCallMessage = new OutgoingCallMessage({
-      content,
+      content: contentStr,
       contentType,
       messageType,
       voiceEventSid,

--- a/src/Call.tsx
+++ b/src/Call.tsx
@@ -876,12 +876,10 @@ export class Call extends EventEmitter {
    * @example
    * To send a user-defined-message
    * ```typescript
-   * const outgoingCallMessage: OutgoingCallMessage = await call.sendMessage(
-   *   new CallMessage({
-   *     content: { key1: 'This is a messsage from the parent call' },
-   *     contentType: 'application/json',
-   *     messageType: 'user-defined-message'
-   *   })
+   * const outgoingCallMessage: OutgoingCallMessage = await call.sendMessage({
+   *   content: { key1: 'This is a messsage from the parent call' },
+   *   contentType: 'application/json',
+   *   messageType: 'user-defined-message'
    * });
    *
    * outgoingCallMessage.addListener(OutgoingCallMessage.Event.Failure, (error) => {
@@ -894,9 +892,6 @@ export class Call extends EventEmitter {
    * ```
    *
    * @param message The call message to send.
-   * Note that if `message.content` is of type `string`, it will be sent
-   * directly to Twilio as-is. If `message.content` is any other type, it will
-   * be processed using `JSON.stringify` before being sent to Twilio.
    *
    * @returns
    *  A `Promise` that

--- a/src/Call.tsx
+++ b/src/Call.tsx
@@ -871,8 +871,6 @@ export class Call extends EventEmitter {
   }
 
   /**
-   * CallMessage API is in beta.
-   *
    * Send a CallMessage.
    *
    * @example
@@ -896,6 +894,9 @@ export class Call extends EventEmitter {
    * ```
    *
    * @param message The call message to send.
+   * Note that if `message.content` is of type `string`, it will be sent
+   * directly to Twilio as-is. If `message.content` is any other type, it will
+   * be processed using `JSON.stringify` before being sent to Twilio.
    *
    * @returns
    *  A `Promise` that
@@ -1005,8 +1006,6 @@ export namespace Call {
     'QualityWarningsChanged' = 'qualityWarningsChanged',
 
     /**
-     * CallMessage API is in beta.
-     *
      * Event string for the `MessageReceived` event.
      * See {@link (Call:interface).(addListener:8)}
      */
@@ -1269,8 +1268,6 @@ export namespace Call {
     ) => void;
 
     /**
-     * CallMessage API is in beta.
-     *
      * CallMessage received event listener. This should be the function signature of
      * any event listener bound to the {@link (Call:namespace).Event.MessageReceived} event.
      *

--- a/src/CallInvite.tsx
+++ b/src/CallInvite.tsx
@@ -542,19 +542,15 @@ export class CallInvite extends EventEmitter {
   }
 
   /**
-   * CallMessage API is in beta.
-   *
    * Send a CallMessage.
    *
    * @example
    * To send a user-defined-message
    * ```typescript
-   * const outgoingCallMessage: OutgoingCallMessage = await callInvite.sendMessage(
-   *   new CallMessage({
-   *     content: { key1: 'This is a messsage from the parent call invite' },
-   *     contentType: 'application/json',
-   *     messageType: 'user-defined-message'
-   *   })
+   * const outgoingCallMessage: OutgoingCallMessage = await callInvite.sendMessage({
+   *   content: { key1: 'This is a messsage from the parent call invite' },
+   *   contentType: 'application/json',
+   *   messageType: 'user-defined-message'
    * });
    *
    * outgoingCallMessage.addListener(OutgoingCallMessage.Event.Failure, (error) => {
@@ -696,8 +692,6 @@ export namespace CallInvite {
     NotificationTapped = 'notificationTapped',
 
     /**
-     * CallMessage API is in beta.
-     *
      * Event string for the `MessageReceived` event.
      * See {@link (CallInvite:interface).(addListener:5)}
      */
@@ -750,8 +744,6 @@ export namespace CallInvite {
     export type NotificationTapped = () => void;
 
     /**
-     * CallMessage API is in beta.
-     *
      * CallInviteMessage received event listener. This should be the function signature of
      * any event listener bound to the {@link (CallInvite:namespace).Event.MessageReceived} event.
      *

--- a/src/CallInvite.tsx
+++ b/src/CallInvite.tsx
@@ -578,7 +578,7 @@ export class CallInvite extends EventEmitter {
 
     const voiceEventSid = await NativeModule.call_sendMessage(
       this._uuid,
-      JSON.stringify(content),
+      content,
       contentType,
       messageType
     );

--- a/src/CallMessage/CallMessage.ts
+++ b/src/CallMessage/CallMessage.ts
@@ -29,6 +29,9 @@ export interface CallMessage {
    *
    * If no value is defined, then the default value of "application/json" will
    * be used.
+   *
+   * If the `contentType` of the message is "application/json", the content
+   * of the message may be a JS object.
    */
   contentType?: string;
 

--- a/src/CallMessage/CallMessage.ts
+++ b/src/CallMessage/CallMessage.ts
@@ -73,5 +73,8 @@ export function validateCallMessage(message: CallMessage) {
     throw new InvalidArgumentError('"content" must be defined and not "null".');
   }
 
-  return { content, contentType, messageType };
+  const contentStr =
+    typeof content === 'string' ? content : JSON.stringify(content);
+
+  return { content: contentStr, contentType, messageType };
 }

--- a/src/__tests__/Call.test.ts
+++ b/src/__tests__/Call.test.ts
@@ -1,5 +1,4 @@
 import { IncomingCallMessage } from '../CallMessage/IncomingCallMessage';
-import { OutgoingCallMessage } from '../CallMessage/OutgoingCallMessage';
 import { createNativeCallInfo, mockCallNativeEvents } from '../__mocks__/Call';
 import type { NativeEventEmitter as MockNativeEventEmitterType } from '../__mocks__/common';
 import { createNativeErrorInfo } from '../__mocks__/Error';
@@ -14,6 +13,7 @@ const MockNativeEventEmitter =
 const MockNativeModule = jest.mocked(NativeModule);
 let MockTwilioError: jest.Mock;
 let mockConstructTwilioError: jest.Mock;
+let MockOutgoingCallMessage: jest.Mock;
 
 jest.mock('../common');
 jest.mock('../error/utility', () => {
@@ -23,6 +23,11 @@ jest.mock('../error/utility', () => {
   });
   return {
     constructTwilioError: mockConstructTwilioError,
+  };
+});
+jest.mock('../CallMessage/OutgoingCallMessage', () => {
+  return {
+    OutgoingCallMessage: (MockOutgoingCallMessage = jest.fn()),
   };
 });
 
@@ -558,7 +563,7 @@ describe('Call class', () => {
       const contentType = 'application/json';
       const messageType = 'user-defined-message';
 
-      it('invokes the native module', async () => {
+      it('stringifys content that is not a string', async () => {
         const message = {
           content,
           contentType,
@@ -579,6 +584,22 @@ describe('Call class', () => {
         ]);
       });
 
+      it('does not stringifys content that is a string', async () => {
+        const message = {
+          content: 'foo',
+          contentType,
+          messageType,
+        };
+
+        await new Call(createNativeCallInfo()).sendMessage(message);
+
+        expect(
+          jest.mocked(MockNativeModule.call_sendMessage).mock.calls
+        ).toEqual([
+          ['mock-nativecallinfo-uuid', 'foo', contentType, messageType],
+        ]);
+      });
+
       it('returns a Promise<OutgoingCallMessage>', async () => {
         const message = {
           content,
@@ -589,14 +610,30 @@ describe('Call class', () => {
         const sendMessagePromise = new Call(createNativeCallInfo()).sendMessage(
           message
         );
-        const mockResult: OutgoingCallMessage = new OutgoingCallMessage({
-          content,
-          contentType,
-          messageType,
-          voiceEventSid: 'mock-nativemodule-tracking-id',
-        });
+        expect(sendMessagePromise instanceof Promise).toStrictEqual(true);
+
         const result = await sendMessagePromise;
-        expect(JSON.stringify(result)).toEqual(JSON.stringify(mockResult));
+        expect(result instanceof MockOutgoingCallMessage).toStrictEqual(true);
+      });
+
+      it('constructs an outgoing call message with the raw string content', async () => {
+        await new Call(createNativeCallInfo()).sendMessage({
+          content: 'foo',
+          messageType: 'user-defined-message',
+        });
+
+        const [[processedContent]] = MockOutgoingCallMessage.mock.calls;
+        expect(processedContent.content).toStrictEqual('foo');
+      });
+
+      it('constructs an outgoing call message with the processed content', async () => {
+        await new Call(createNativeCallInfo()).sendMessage({
+          content,
+          messageType: 'user-defined-message',
+        });
+
+        const [[processedContent]] = MockOutgoingCallMessage.mock.calls;
+        expect(processedContent.content).toStrictEqual(JSON.stringify(content));
       });
     });
   });

--- a/src/__tests__/Call.test.ts
+++ b/src/__tests__/Call.test.ts
@@ -584,7 +584,7 @@ describe('Call class', () => {
         ]);
       });
 
-      it('does not stringifys content that is a string', async () => {
+      it('does not stringify content that is a string', async () => {
         const message = {
           content: 'foo',
           contentType,

--- a/src/__tests__/Call.test.ts
+++ b/src/__tests__/Call.test.ts
@@ -563,41 +563,39 @@ describe('Call class', () => {
       const contentType = 'application/json';
       const messageType = 'user-defined-message';
 
-      it('stringifys content that is not a string', async () => {
-        const message = {
-          content,
-          contentType,
-          messageType,
-        };
-
-        await new Call(createNativeCallInfo()).sendMessage(message);
-
-        expect(
-          jest.mocked(MockNativeModule.call_sendMessage).mock.calls
-        ).toEqual([
-          [
-            'mock-nativecallinfo-uuid',
-            JSON.stringify(content),
+      describe('when invoking the native module', () => {
+        it('stringifys content that is not a string', async () => {
+          await new Call(createNativeCallInfo()).sendMessage({
+            content,
             contentType,
             messageType,
-          ],
-        ]);
-      });
+          });
 
-      it('does not stringify content that is a string', async () => {
-        const message = {
-          content: 'foo',
-          contentType,
-          messageType,
-        };
+          expect(
+            jest.mocked(MockNativeModule.call_sendMessage).mock.calls
+          ).toEqual([
+            [
+              'mock-nativecallinfo-uuid',
+              JSON.stringify(content),
+              contentType,
+              messageType,
+            ],
+          ]);
+        });
 
-        await new Call(createNativeCallInfo()).sendMessage(message);
+        it('does not stringify content that is a string', async () => {
+          await new Call(createNativeCallInfo()).sendMessage({
+            content: 'foo',
+            contentType,
+            messageType,
+          });
 
-        expect(
-          jest.mocked(MockNativeModule.call_sendMessage).mock.calls
-        ).toEqual([
-          ['mock-nativecallinfo-uuid', 'foo', contentType, messageType],
-        ]);
+          expect(
+            jest.mocked(MockNativeModule.call_sendMessage).mock.calls
+          ).toEqual([
+            ['mock-nativecallinfo-uuid', 'foo', contentType, messageType],
+          ]);
+        });
       });
 
       it('returns a Promise<OutgoingCallMessage>', async () => {
@@ -616,24 +614,28 @@ describe('Call class', () => {
         expect(result instanceof MockOutgoingCallMessage).toStrictEqual(true);
       });
 
-      it('constructs an outgoing call message with the raw string content', async () => {
-        await new Call(createNativeCallInfo()).sendMessage({
-          content: 'foo',
-          messageType: 'user-defined-message',
+      describe('constructs an outgoing call message', () => {
+        it('with the raw string content', async () => {
+          await new Call(createNativeCallInfo()).sendMessage({
+            content: 'foo',
+            messageType: 'user-defined-message',
+          });
+
+          const [[processedContent]] = MockOutgoingCallMessage.mock.calls;
+          expect(processedContent.content).toStrictEqual('foo');
         });
 
-        const [[processedContent]] = MockOutgoingCallMessage.mock.calls;
-        expect(processedContent.content).toStrictEqual('foo');
-      });
+        it('with the processed content', async () => {
+          await new Call(createNativeCallInfo()).sendMessage({
+            content,
+            messageType: 'user-defined-message',
+          });
 
-      it('constructs an outgoing call message with the processed content', async () => {
-        await new Call(createNativeCallInfo()).sendMessage({
-          content,
-          messageType: 'user-defined-message',
+          const [[processedContent]] = MockOutgoingCallMessage.mock.calls;
+          expect(processedContent.content).toStrictEqual(
+            JSON.stringify(content)
+          );
         });
-
-        const [[processedContent]] = MockOutgoingCallMessage.mock.calls;
-        expect(processedContent.content).toStrictEqual(JSON.stringify(content));
       });
     });
   });

--- a/src/__tests__/CallMessage/CallMessage.test.ts
+++ b/src/__tests__/CallMessage/CallMessage.test.ts
@@ -8,7 +8,7 @@ describe('validateCallMessage', () => {
       messageType: 'user-defined-message',
     });
     expect(result).toStrictEqual({
-      content: { foo: 'bar' },
+      content: '{"foo":"bar"}',
       contentType: 'application/json',
       messageType: 'user-defined-message',
     });
@@ -46,6 +46,7 @@ describe('validateCallMessage', () => {
 
   it('should throw an error if the messageType is not a string', () => {
     const invalidMessageTypes = [undefined, 10, null, {}, true];
+    expect.assertions(invalidMessageTypes.length);
 
     const testMessageType = (messageType: any) => {
       const invalidMessage = {
@@ -76,5 +77,31 @@ describe('validateCallMessage', () => {
     };
 
     invalidContentTypes.forEach(testContentType);
+  });
+
+  it('should stringify content that is not a string', () => {
+    const nonStringContent = [
+      [{ foo: 'bar' }, '{"foo":"bar"}'],
+      [10, '10'],
+      [true, 'true'],
+    ];
+    expect.assertions(nonStringContent.length);
+
+    for (const [inputContent, expectedContent] of nonStringContent) {
+      const { content: validatedContent } = validateCallMessage({
+        content: inputContent,
+        messageType: 'foobar',
+      });
+
+      expect(validatedContent).toStrictEqual(expectedContent);
+    }
+  });
+
+  it('should not stringify content that is a string', () => {
+    const { content } = validateCallMessage({
+      content: 'foobar',
+      messageType: 'foobar',
+    });
+    expect(content).toStrictEqual('foobar');
   });
 });

--- a/src/__tests__/CallMessage/IncomingCallMessage.test.ts
+++ b/src/__tests__/CallMessage/IncomingCallMessage.test.ts
@@ -30,16 +30,28 @@ describe('IncomingCallMessage class', () => {
       const incomingCallMessage = new IncomingCallMessage(
         createNativeCallMessageInfo()
       );
-      expect({
-        // eslint-disable-next-line dot-notation
-        content: incomingCallMessage['_content'],
-        // eslint-disable-next-line dot-notation
-        contentType: incomingCallMessage['_contentType'],
-        // eslint-disable-next-line dot-notation
-        messageType: incomingCallMessage['_messageType'],
-        // eslint-disable-next-line dot-notation
-        voiceEventSid: incomingCallMessage['_voiceEventSid'],
-      }).toEqual(createNativeCallMessageInfo());
+
+      const callMessageInfo = createNativeCallMessageInfo();
+
+      // eslint-disable-next-line dot-notation
+      expect(incomingCallMessage['_content']).toStrictEqual(
+        JSON.stringify(callMessageInfo.content)
+      );
+
+      // eslint-disable-next-line dot-notation
+      expect(incomingCallMessage['_contentType']).toStrictEqual(
+        callMessageInfo.contentType
+      );
+
+      // eslint-disable-next-line dot-notation
+      expect(incomingCallMessage['_messageType']).toStrictEqual(
+        callMessageInfo.messageType
+      );
+
+      // eslint-disable-next-line dot-notation
+      expect(incomingCallMessage['_voiceEventSid']).toStrictEqual(
+        callMessageInfo.voiceEventSid
+      );
     });
 
     const content = { key1: 'hello world' };
@@ -102,7 +114,9 @@ describe('IncomingCallMessage class', () => {
       const content = new IncomingCallMessage(
         createNativeCallMessageInfo()
       ).getContent();
-      expect(content).toEqual(createNativeCallMessageInfo().content);
+      expect(content).toEqual(
+        JSON.stringify(createNativeCallMessageInfo().content)
+      );
     });
   });
 

--- a/src/__tests__/CallMessage/OutgoingCallMessage.test.ts
+++ b/src/__tests__/CallMessage/OutgoingCallMessage.test.ts
@@ -36,16 +36,28 @@ describe('OutgoingCallMessage class', () => {
       const outgoingCallMessage = new OutgoingCallMessage(
         createNativeCallMessageInfo()
       );
-      expect({
-        // eslint-disable-next-line dot-notation
-        content: outgoingCallMessage['_content'],
-        // eslint-disable-next-line dot-notation
-        contentType: outgoingCallMessage['_contentType'],
-        // eslint-disable-next-line dot-notation
-        messageType: outgoingCallMessage['_messageType'],
-        // eslint-disable-next-line dot-notation
-        voiceEventSid: outgoingCallMessage['_voiceEventSid'],
-      }).toEqual(createNativeCallMessageInfo());
+
+      const callMessageInfo = createNativeCallMessageInfo();
+
+      // eslint-disable-next-line dot-notation
+      expect(outgoingCallMessage['_content']).toStrictEqual(
+        JSON.stringify(callMessageInfo.content)
+      );
+
+      // eslint-disable-next-line dot-notation
+      expect(outgoingCallMessage['_contentType']).toStrictEqual(
+        callMessageInfo.contentType
+      );
+
+      // eslint-disable-next-line dot-notation
+      expect(outgoingCallMessage['_messageType']).toStrictEqual(
+        callMessageInfo.messageType
+      );
+
+      // eslint-disable-next-line dot-notation
+      expect(outgoingCallMessage['_voiceEventSid']).toStrictEqual(
+        callMessageInfo.voiceEventSid
+      );
     });
 
     it('contains an entry for every outgoingCallMessage event', () => {
@@ -78,7 +90,9 @@ describe('OutgoingCallMessage class', () => {
       const content = new OutgoingCallMessage(
         createNativeCallMessageInfo()
       ).getContent();
-      expect(content).toEqual(createNativeCallMessageInfo().content);
+      expect(content).toEqual(
+        JSON.stringify(createNativeCallMessageInfo().content)
+      );
     });
   });
 


### PR DESCRIPTION
## Submission Checklist

 - [x] Updated the `CHANGELOG.md` to reflect any **feature**, **bug fixes**, or **known issues** made in the source code
 - [x] Tested code changes and observed expected behavior in the example app
 - [x] Performed a visual inspection of the `Files changed` tab prior to submitting the pull request for review to ensure proper usage of the style guide

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Description

This PR conditionally stringifys the content of outgoing call messages.

## Breakdown

- Conditionally stringify content.
- Add unit tests.

## Validation

- Manually tested with test app.
- Unit tests.
- Call message e2e tests are green.

## Additional Notes

N/A
