### PR TITLE
[VBLOCKS-3603] protect against case where intent is NULL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+1.2.1 (In Progress)
+====================
+
+### Bug Fixes
+
+#### Android
+
+- Fixed crash issue where system restarts service without an Intent (intent == null).
+
+
 1.2.0 (Sep 16, 2024)
 ====================
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 1.2.1 (In Progress)
 ====================
 
-### Bug Fixes
+## Bug Fixes
 
 #### Android
 

--- a/android/src/main/java/com/twiliovoicereactnative/VoiceService.java
+++ b/android/src/main/java/com/twiliovoicereactnative/VoiceService.java
@@ -100,43 +100,47 @@ public class VoiceService extends Service {
 
   @Override
   public int onStartCommand(Intent intent, int flags, int startId) {
-    switch (Objects.requireNonNull(intent.getAction())) {
-      case ACTION_INCOMING_CALL:
-        incomingCall(getCallRecord(Objects.requireNonNull(getMessageUUID(intent))));
-        break;
-      case ACTION_ACCEPT_CALL:
-        try {
-          acceptCall(getCallRecord(Objects.requireNonNull(getMessageUUID(intent))));
-        } catch (SecurityException e) {
-          sendPermissionsError();
-          logger.warning(e, "Cannot accept call, lacking necessary permissions");
-        }
-        break;
-      case ACTION_REJECT_CALL:
-        rejectCall(getCallRecord(Objects.requireNonNull(getMessageUUID(intent))));
-        break;
-      case ACTION_CANCEL_CALL:
-        cancelCall(getCallRecord(Objects.requireNonNull(getMessageUUID(intent))));
-        break;
-      case ACTION_CALL_DISCONNECT:
-        disconnect(getCallRecord(Objects.requireNonNull(getMessageUUID(intent))));
-        break;
-      case ACTION_RAISE_OUTGOING_CALL_NOTIFICATION:
-        raiseOutgoingCallNotification(getCallRecord(Objects.requireNonNull(getMessageUUID(intent))));
-        break;
-      case ACTION_CANCEL_ACTIVE_CALL_NOTIFICATION:
-        cancelActiveCallNotification(getCallRecord(Objects.requireNonNull(getMessageUUID(intent))));
-        break;
-      case ACTION_FOREGROUND_AND_DEPRIORITIZE_INCOMING_CALL_NOTIFICATION:
-        foregroundAndDeprioritizeIncomingCallNotification(
-          getCallRecord(Objects.requireNonNull(getMessageUUID(intent))));
-        break;
-      case ACTION_PUSH_APP_TO_FOREGROUND:
-        logger.warning("VoiceService received foreground request, ignoring");
-        break;
-      default:
-        logger.log("Unknown notification, ignoring");
-        break;
+    // apparently the system can recreate the service without sending it an intent so protect
+    // against that case (GH-430).
+    if (null != intent) {
+      switch (Objects.requireNonNull(intent.getAction())) {
+        case ACTION_INCOMING_CALL:
+          incomingCall(getCallRecord(Objects.requireNonNull(getMessageUUID(intent))));
+          break;
+        case ACTION_ACCEPT_CALL:
+          try {
+            acceptCall(getCallRecord(Objects.requireNonNull(getMessageUUID(intent))));
+          } catch (SecurityException e) {
+            sendPermissionsError();
+            logger.warning(e, "Cannot accept call, lacking necessary permissions");
+          }
+          break;
+        case ACTION_REJECT_CALL:
+          rejectCall(getCallRecord(Objects.requireNonNull(getMessageUUID(intent))));
+          break;
+        case ACTION_CANCEL_CALL:
+          cancelCall(getCallRecord(Objects.requireNonNull(getMessageUUID(intent))));
+          break;
+        case ACTION_CALL_DISCONNECT:
+          disconnect(getCallRecord(Objects.requireNonNull(getMessageUUID(intent))));
+          break;
+        case ACTION_RAISE_OUTGOING_CALL_NOTIFICATION:
+          raiseOutgoingCallNotification(getCallRecord(Objects.requireNonNull(getMessageUUID(intent))));
+          break;
+        case ACTION_CANCEL_ACTIVE_CALL_NOTIFICATION:
+          cancelActiveCallNotification(getCallRecord(Objects.requireNonNull(getMessageUUID(intent))));
+          break;
+        case ACTION_FOREGROUND_AND_DEPRIORITIZE_INCOMING_CALL_NOTIFICATION:
+          foregroundAndDeprioritizeIncomingCallNotification(
+            getCallRecord(Objects.requireNonNull(getMessageUUID(intent))));
+          break;
+        case ACTION_PUSH_APP_TO_FOREGROUND:
+          logger.warning("VoiceService received foreground request, ignoring");
+          break;
+        default:
+          logger.log("Unknown notification, ignoring");
+          break;
+      }
     }
     return START_NOT_STICKY;
   }


### PR DESCRIPTION
## Submission Checklist

 - [x] Updated the `CHANGELOG.md` to reflect any **feature**, **bug fixes**, or **known issues** made in the source code
 - [x] Tested code changes and observed expected behavior in the example app
 - [ ] Performed a visual inspection of the `Files changed` tab prior to submitting the pull request for review to ensure proper usage of the style guide

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Description

Protected against case where the system recreates the service without sending it an intent. PLEASE NOTE: Could not reproduce the issue, just added a protection to prevent crashes.

## Breakdown

- NONE

## Validation

- Checks for null intent

## Additional Notes

None
