### PR TITLE
[QSDK-10180] Add QE tests CCI trigger to run RC validation job after releasing new version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -334,6 +334,25 @@ jobs:
           when: always
           path: ./test/app/detox_artifacts
 
+  trigger-qe-tests:
+    executor:
+      name: default
+    steps:
+      - run:
+          name: Trigger standard QE tests 
+          command: |
+            curl --fail --write-out "\nHTTP Response Code: %{http_code}\n" \
+            -u "$CIRCLECI_PERSONAL_API_TOKEN": -X POST --header "Content-Type: application/json" \
+            -d '{"branch":"main","parameters":{"rc-version":"'$CIRCLE_TAG'","rc-testing":true}}' \
+            $SDKS_QE_CIRCLECI_VOICE_REACT_SLAVE_PIPELINE_ENDPOINT
+      - run:
+          name: Trigger custom android messaging QE tests 
+          command: |
+            curl --fail --write-out "\nHTTP Response Code: %{http_code}\n" \
+            -u "$CIRCLECI_PERSONAL_API_TOKEN": -X POST --header "Content-Type: application/json" \
+            -d '{"branch":"custom-android-messaging","parameters":{"rc-version":"'$CIRCLE_TAG'","rc-testing":true}}' \
+            $SDKS_QE_CIRCLECI_VOICE_REACT_SLAVE_PIPELINE_ENDPOINT
+      
 
 ###
 # Workflows
@@ -407,3 +426,13 @@ workflows:
           dry-run: false
           requires:
             - Release approval
+      - trigger-qe-tests:
+          context: sdks-qe
+          filters:
+            tags:
+              only:
+              - /^\d+\.\d+\.\d+-rc\d+$/
+              - /^\d+\.\d+\.\d+-preview\d+-rc\d+$/
+              - /^\d+\.\d+\.\d+-beta\d+-rc\d+$/
+            branches:
+              ignore: /.*/


### PR DESCRIPTION
## Submission Checklist

 - [ ] Updated the `CHANGELOG.md` to reflect any **feature**, **bug fixes**, or **known issues** made in the source code
 - [ ] Tested code changes and observed expected behavior in the example app
 - [x] Performed a visual inspection of the `Files changed` tab prior to submitting the pull request for review to ensure proper usage of the style guide

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Description

This PR uses adds QE Voice React RC tests trigger to the CCI config

## Breakdown

- Added `trigger-qe-tests` job, that will trigger two workflows in `sdks-qe-voice-react-native-slave` with default setting and custom android messaging
- Run `trigger-qe-tests` job in `build-test-release` workflow

## Validation

N/A

## Additional Notes

N/A
