### PR TITLE
fix: resolve thread safety issue in CallRecordDatabase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,13 @@
 
 - Updated the Twilio Voice iOS SDK dependency to `6.12.1`.
 
+## Fixes
+
+### Platform Specific Fixes
+
+#### Android
+
+- Fix thread safety issue in the `CallRecordDatabase`
 
 1.3.0 (Dec 10, 2024)
 ====================

--- a/android/src/main/java/com/twiliovoicereactnative/CallRecordDatabase.java
+++ b/android/src/main/java/com/twiliovoicereactnative/CallRecordDatabase.java
@@ -157,14 +157,18 @@ class CallRecordDatabase  {
 
   public CallRecord get(final CallRecord record) {
     try {
-      return callRecordList.get(callRecordList.indexOf(record));
+      synchronized (callRecordList) {
+        return callRecordList.get(callRecordList.indexOf(record));
+      }
     } catch (IndexOutOfBoundsException e) {
       return null;
     }
   }
   public CallRecord remove(final CallRecord record) {
     try {
-      return callRecordList.remove(callRecordList.indexOf(record));
+      synchronized (callRecordList) {
+        return callRecordList.remove(callRecordList.indexOf(record));
+      }
     } catch (IndexOutOfBoundsException e) {
       return null;
     }


### PR DESCRIPTION
Fix #474

## Submission Checklist

 - [x] Updated the `CHANGELOG.md` to reflect any **feature**, **bug fixes**, or **known issues** made in the source code
 - [x] Tested code changes and observed expected behavior in the example app
 - [x] Performed a visual inspection of the `Files changed` tab prior to submitting the pull request for review to ensure proper usage of the style guide

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Description

Add proper synchronization to the `remove` and `get` methods of the `CallRecordDatabase` in the Android native code.

## Breakdown

- synchronized `get` method
- synchronized `remove` method

## Validation

- Manually tested with app
