### PR TITLE
[VBLOCKS-4100] fix: invoke voice service api from main thread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+1.5.0 (In Progress)
+===================
+
+## Fixes
+
+### Platform Specific Fixes
+
+#### Android
+
+- Updated the RNModule methods to invoke all Voice Service API methods from only
+  the main thread.
+
+
 1.4.0 (Feb 11, 2025)
 ====================
 

--- a/android/src/main/java/com/twiliovoicereactnative/TwilioVoiceReactNativeModule.java
+++ b/android/src/main/java/com/twiliovoicereactnative/TwilioVoiceReactNativeModule.java
@@ -302,26 +302,40 @@ public class TwilioVoiceReactNativeModule extends ReactContextBaseJavaModule {
 
   @ReactMethod
   public void voice_getCalls(Promise promise) {
-    WritableArray callInfos = Arguments.createArray();
-    for (CallRecord callRecord : getCallRecordDatabase().getCollection()) {
-      // incoming calls that have not been acted on do not have call-objects
-      if (null != callRecord.getVoiceCall()) {
-        callInfos.pushMap(serializeCall(callRecord));
+    logger.debug(".voice_getCalls()");
+
+    mainHandler.post(() -> {
+      logger.debug(".voice_getCalls() > runnable");
+
+      WritableArray callInfos = Arguments.createArray();
+      for (CallRecord callRecord : getCallRecordDatabase().getCollection()) {
+        // incoming calls that have not been acted on do not have call-objects
+        if (null != callRecord.getVoiceCall()) {
+          callInfos.pushMap(serializeCall(callRecord));
+        }
       }
-    }
-    promise.resolve(callInfos);
+
+      promise.resolve(callInfos);
+    });
   }
 
   @ReactMethod
   public void voice_getCallInvites(Promise promise) {
-    WritableArray callInviteInfos = Arguments.createArray();
-    for (CallRecord callRecord : getCallRecordDatabase().getCollection()) {
-      if (null != callRecord.getCallInvite() &&
+    logger.debug(".voice_getCallInvites()");
+
+    mainHandler.post(() -> {
+      logger.debug(".voice_getCallInvites() > runnable");
+
+      WritableArray callInviteInfos = Arguments.createArray();
+      for (CallRecord callRecord : getCallRecordDatabase().getCollection()) {
+        if (null != callRecord.getCallInvite() &&
           CallRecord.CallInviteState.ACTIVE == callRecord.getCallInviteState()) {
-        callInviteInfos.pushMap(serializeCallInvite(callRecord));
+          callInviteInfos.pushMap(serializeCallInvite(callRecord));
+        }
       }
-    }
-    promise.resolve(callInviteInfos);
+
+      promise.resolve(callInviteInfos);
+    });
   }
 
   @ReactMethod
@@ -364,29 +378,47 @@ public class TwilioVoiceReactNativeModule extends ReactContextBaseJavaModule {
 
   @ReactMethod
   public void call_getState(String uuid, Promise promise) {
-    final CallRecord callRecord = validateCallRecord(UUID.fromString(uuid), promise);
+    logger.debug(".call_getState()");
 
-    if (null != callRecord) {
-      promise.resolve(callRecord.getVoiceCall().getState().toString().toLowerCase());
-    }
+    mainHandler.post(() -> {
+      logger.debug(".call_getState() > runnable");
+
+      final CallRecord callRecord = validateCallRecord(UUID.fromString(uuid), promise);
+
+      if (null != callRecord) {
+        promise.resolve(callRecord.getVoiceCall().getState().toString().toLowerCase());
+      }
+    });
   }
 
   @ReactMethod
   public void call_isMuted(String uuid, Promise promise) {
-    final CallRecord callRecord = validateCallRecord(UUID.fromString(uuid), promise);
+    logger.debug(".call_isMuted()");
 
-    if (null != callRecord) {
-      promise.resolve(callRecord.getVoiceCall().isMuted());
-    }
+    mainHandler.post(() -> {
+      logger.debug(".call_isMuted() > runnable");
+
+      final CallRecord callRecord = validateCallRecord(UUID.fromString(uuid), promise);
+
+      if (null != callRecord) {
+        promise.resolve(callRecord.getVoiceCall().isMuted());
+      }
+    });
   }
 
   @ReactMethod
   public void call_isOnHold(String uuid, Promise promise) {
-    final CallRecord callRecord = validateCallRecord(UUID.fromString(uuid), promise);
+    logger.debug(".call_isOnHold()");
 
-    if (null != callRecord) {
-      promise.resolve(callRecord.getVoiceCall().isOnHold());
-    }
+    mainHandler.post(() -> {
+      logger.debug(".call_isOnHold() > runnable");
+
+      final CallRecord callRecord = validateCallRecord(UUID.fromString(uuid), promise);
+
+      if (null != callRecord) {
+        promise.resolve(callRecord.getVoiceCall().isOnHold());
+      }
+    });
   }
 
   @ReactMethod


### PR DESCRIPTION
## Submission Checklist

 - [x] Updated the `CHANGELOG.md` to reflect any **feature**, **bug fixes**, or **known issues** made in the source code
 - [x] Tested code changes and observed expected behavior in the example app
 - [x] ~Performed a visual inspection of the `Files changed` tab prior to submitting the pull request for review to ensure proper usage of the style guide~

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Description

This PR changes the way that the RN Module invokes any Voice Service API, issuing invocations on the main thread to avoid race conditions. Note that the Voice Android SDK contract necessitates all invocations occur from the main thread, so this PR is necessary to adhere to Voice Android SDK standards.

## Breakdown

- Create a main thread handler and runnable for all applicable RNModule methods.

## Validation

- Manually tested with the test app locally.
- Integration tests pass.

## Additional Notes

N/A
