### PR TITLE
[VBLOCKS-4464] Full screen notification handling

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     'androidGradlePlugin': '7.4.2',
     'googleServices'     : '4.3.10',
     'voiceAndroid'       : '6.7.1',
-    'androidxCore'       : '1.10.1',
+    'androidxCore'       : '1.12.0',
     'androidxLifecycle'  : '2.2.0',
     'audioSwitch'        : '1.1.8',
     'firebaseMessaging'  : '23.4.0'

--- a/android/src/main/java/com/twiliovoicereactnative/ConfigurationProperties.java
+++ b/android/src/main/java/com/twiliovoicereactnative/ConfigurationProperties.java
@@ -23,4 +23,15 @@ class ConfigurationProperties {
     return context.getResources()
       .getBoolean(R.bool.twiliovoicereactnative_firebasemessagingservice_enabled);
   }
+
+  /**
+   * Get configuration boolean, used to determine if full screen notifications are enabled
+   * or not.
+   * @param context the application context
+   * @return a boolean read from the application resources
+   */
+  public static boolean isFullScreenNotificationEnabled(Context context) {
+    return context.getResources()
+      .getBoolean(R.bool.twiliovoicereactnative_fullscreennotification_enabled);
+  }
 }

--- a/android/src/main/java/com/twiliovoicereactnative/NotificationUtility.java
+++ b/android/src/main/java/com/twiliovoicereactnative/NotificationUtility.java
@@ -24,6 +24,7 @@ import androidx.core.app.Person;
 
 import com.twilio.voice.CallInvite;
 
+import static com.twiliovoicereactnative.ConfigurationProperties.isFullScreenNotificationEnabled;
 import static com.twiliovoicereactnative.Constants.VOICE_CHANNEL_DEFAULT_IMPORTANCE;
 import static com.twiliovoicereactnative.Constants.VOICE_CHANNEL_HIGH_IMPORTANCE;
 import static com.twiliovoicereactnative.Constants.VOICE_CHANNEL_LOW_IMPORTANCE;
@@ -165,16 +166,18 @@ class NotificationUtility {
       callRecord.getUuid());
     PendingIntent piAcceptIntent = constructPendingIntentForActivity(context, acceptIntent);
 
-    return constructNotificationBuilder(context, channelImportance)
+    NotificationCompat.Builder builder = constructNotificationBuilder(context, channelImportance)
       .setSmallIcon(notificationResource.getSmallIconId())
       .setCategory(Notification.CATEGORY_CALL)
       .setAutoCancel(true)
       .setContentIntent(piForegroundIntent)
-      .setFullScreenIntent(piForegroundIntent, true)
       .addPerson(incomingCaller)
       .setStyle(NotificationCompat.CallStyle.forIncomingCall(
-        incomingCaller, piRejectIntent, piAcceptIntent))
-      .build();
+        incomingCaller, piRejectIntent, piAcceptIntent));
+    if (isFullscreenIntentEnabled(context)) {
+      builder.setFullScreenIntent(piForegroundIntent, true);
+    }
+    return builder.build();
   }
 
   public static Notification createCallAnsweredNotificationWithLowImportance(@NonNull Context context,
@@ -202,16 +205,18 @@ class NotificationUtility {
       callRecord.getUuid());
     PendingIntent piEndCallIntent = constructPendingIntentForService(context, endCallIntent);
 
-    return constructNotificationBuilder(context, Constants.VOICE_CHANNEL_LOW_IMPORTANCE)
+    NotificationCompat.Builder builder = constructNotificationBuilder(context, Constants.VOICE_CHANNEL_LOW_IMPORTANCE)
       .setSmallIcon(notificationResource.getSmallIconId())
       .setCategory(Notification.CATEGORY_CALL)
       .setAutoCancel(false)
       .setContentIntent(piForegroundIntent)
-      .setFullScreenIntent(piForegroundIntent, true)
       .setOngoing(true)
       .addPerson(activeCaller)
-      .setStyle(NotificationCompat.CallStyle.forOngoingCall(activeCaller, piEndCallIntent))
-      .build();
+      .setStyle(NotificationCompat.CallStyle.forOngoingCall(activeCaller, piEndCallIntent));
+    if (isFullscreenIntentEnabled(context)) {
+      builder.setFullScreenIntent(piForegroundIntent, true);
+    }
+    return builder.build();
   }
 
   public static Notification createOutgoingCallNotificationWithLowImportance(@NonNull Context context,
@@ -239,7 +244,7 @@ class NotificationUtility {
       callRecord.getUuid());
     PendingIntent piEndCallIntent = constructPendingIntentForService(context, endCallIntent);
 
-    return constructNotificationBuilder(context, Constants.VOICE_CHANNEL_LOW_IMPORTANCE)
+    NotificationCompat.Builder builder =  constructNotificationBuilder(context, Constants.VOICE_CHANNEL_LOW_IMPORTANCE)
       .setSmallIcon(notificationResource.getSmallIconId())
       .setCategory(Notification.CATEGORY_CALL)
       .setAutoCancel(false)
@@ -247,8 +252,11 @@ class NotificationUtility {
       .setFullScreenIntent(piForegroundIntent, true)
       .setOngoing(true)
       .addPerson(activeCaller)
-      .setStyle(NotificationCompat.CallStyle.forOngoingCall(activeCaller, piEndCallIntent))
-      .build();
+      .setStyle(NotificationCompat.CallStyle.forOngoingCall(activeCaller, piEndCallIntent));
+    if (isFullscreenIntentEnabled(context)) {
+      builder.setFullScreenIntent(piForegroundIntent, true);
+    }
+    return builder.build();
   }
 
   public static void createNotificationChannels(@NonNull Context context) {
@@ -270,6 +278,11 @@ class NotificationUtility {
   public static void destroyNotificationChannels(@NonNull Context context) {
     NotificationManagerCompat notificationManager = NotificationManagerCompat.from(context);
     notificationManager.deleteNotificationChannelGroup(Constants.VOICE_CHANNEL_GROUP);
+  }
+
+  public static boolean isFullscreenIntentEnabled(Context context) {
+    return isFullScreenNotificationEnabled(context) &&
+      NotificationManagerCompat.from(context).canUseFullScreenIntent();
   }
 
   private static NotificationChannelCompat createNotificationChannel(@NonNull Context context,

--- a/android/src/main/java/com/twiliovoicereactnative/VoiceActivityProxy.java
+++ b/android/src/main/java/com/twiliovoicereactnative/VoiceActivityProxy.java
@@ -1,5 +1,7 @@
 package com.twiliovoicereactnative;
 
+import static com.twiliovoicereactnative.ConfigurationProperties.isFullScreenNotificationEnabled;
+
 import java.util.List;
 import java.util.Vector;
 
@@ -7,13 +9,16 @@ import android.Manifest;
 import android.app.Activity;
 import android.content.Intent;
 import android.content.pm.PackageManager;
+import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
+import android.provider.Settings;
 import android.view.Window;
 import android.view.WindowManager;
 
 import androidx.annotation.NonNull;
 import androidx.core.app.ActivityCompat;
+import androidx.core.app.NotificationManagerCompat;
 import androidx.core.content.ContextCompat;
 
 public class VoiceActivityProxy {
@@ -37,6 +42,10 @@ public class VoiceActivityProxy {
     // Ensure the microphone permission is enabled
     if (!checkPermissions()) {
       requestPermissions();
+    }
+    // Ensure necessary requests for full screen intents are activated (API 34+)
+    if (checkFullScreenIntentsEnabled()) {
+      requestFullScreenIntentPermission();
     }
     // These flags ensure that the activity can be launched when the screen is locked.
     Window window = context.getWindow();
@@ -74,6 +83,19 @@ public class VoiceActivityProxy {
       }
     }
     return true;
+  }
+
+  private void requestFullScreenIntentPermission() {
+    if (Build.VERSION.SDK_INT > Build.VERSION_CODES.TIRAMISU) {
+      Intent intent = new Intent(
+        Settings.ACTION_MANAGE_APP_USE_FULL_SCREEN_INTENT,
+        Uri.parse("package:" + context.getPackageName()));
+      context.startActivity(intent);
+    }
+  }
+  private boolean checkFullScreenIntentsEnabled() {
+    return isFullScreenNotificationEnabled(context) &&
+      !NotificationManagerCompat.from(context).canUseFullScreenIntent();
   }
   private void handleIntent(Intent intent) {
     String action = intent.getAction();

--- a/android/src/main/res/values/config.xml
+++ b/android/src/main/res/values/config.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
   <bool name="twiliovoicereactnative_firebasemessagingservice_enabled">true</bool>
+  <bool name="twiliovoicereactnative_fullscreennotification_enabled">true</bool>
 </resources>

--- a/docs/disable-fullscree-notifications.md
+++ b/docs/disable-fullscree-notifications.md
@@ -1,0 +1,25 @@
+The functionality detailed in this document was added in `1.5.1` of the
+`@twilio/voice-react-native-sdk`.
+
+# Using Full Screen Notifications on Android
+The `@twilio/voice-react-native-sdk` Starting with Android 14 (API 34), 
+full screen intents are only available for alarm and phone calling 
+applications and require user approval to enable. This is a departure 
+from previous versions of Android.
+
+This document provides details on how to disable the use of full screen
+notifications if desired.
+
+## Disabling Full Screen Notifications on Android
+To disable full screen notifications, you can add a `config.xml` file 
+in the `src/main/res/values/` folder within your `android/app/` 
+folder. Including the following content within this file will disable 
+the use of full screen notifications.
+```
+<bool name="twiliovoicereactnative_fullscreennotification_enabled">false</bool>
+```
+See [this file](/android/src/main/res/values/config.xml) for more details.
+
+With full screen notifications disabled, the SDK will not ask for user
+permissions for enabling it and it will not use full screen 
+notifications for incoming phone calls.


### PR DESCRIPTION
## Submission Checklist

 - [x] Updated the `CHANGELOG.md` to reflect any **feature**, **bug fixes**, or **known issues** made in the source code
 - [x] Tested code changes and observed expected behavior in the example app
 - [ x Performed a visual inspection of the `Files changed` tab prior to submitting the pull request for review to ensure proper usage of the style guide

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [ ] I acknowledge that all my contributions will be made under the project's license.

## Description

This enables two things...
 1) On API 34, the user must approve full screen notifications, this launches the settings app when needed.
 2) It allows for the developer to disable full screen notifications, if so desired.

## Breakdown

- Now checks if it should request the user for full screen notifications if needed in the ActivityProxy class (needed in API 34+)
- When creating notifications, now full screen intents are conditionally added
- Added a mechanism to allow for the developer to disable full screen intents if desired.

## Validation

- Ran test app and verified 


## Additional Notes

None
