### PR TITLE
[VBLOCKS-3981] fix: add missing detox scripts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,7 @@ executors:
     working_directory: ~/project
   ios-executor:
     macos:
-      xcode: "14.3.1"
+      xcode: 16.2.0
       resource_class: macos.m1.medium.gen1
 
 ###

--- a/package.json
+++ b/package.json
@@ -129,10 +129,9 @@
   "eslintIgnore": [
     "node_modules/",
     "lib/",
-    "test/app/e2e/",
+    "test/app/",
     "src/error/generated.ts",
-    "coverage/",
-    "test/TwilioVoiceExampleNewArch"
+    "coverage/"
   ],
   "prettier": {
     "quoteProps": "consistent",

--- a/test/app/.detoxrc.js
+++ b/test/app/.detoxrc.js
@@ -12,13 +12,13 @@ module.exports = {
   apps: {
     'ios.debug': {
       type: 'ios.app',
-      binaryPath: 'ios/build/Build/Products/Debug-iphonesimulator/TwilioVoiceReactNativeExample.app',
-      build: 'xcodebuild -workspace ios/TwilioVoiceReactNativeExample.xcworkspace -scheme TwilioVoiceReactNativeExample -configuration Debug -sdk iphonesimulator -derivedDataPath ios/build'
+      binaryPath: 'ios/build/Build/Products/Debug-iphonesimulator/TwilioVoiceExampleNewArch.app',
+      build: 'xcodebuild -workspace ios/TwilioVoiceExampleNewArch.xcworkspace -scheme TwilioVoiceExampleNewArch -configuration Debug -sdk iphonesimulator -derivedDataPath ios/build'
     },
     'ios.release': {
       type: 'ios.app',
-      binaryPath: 'ios/build/Build/Products/Release-iphonesimulator/TwilioVoiceReactNativeExample.app',
-      build: 'xcodebuild -workspace ios/TwilioVoiceReactNativeExample.xcworkspace -scheme TwilioVoiceReactNativeExample -configuration Release -sdk iphonesimulator -derivedDataPath ios/build'
+      binaryPath: 'ios/build/Build/Products/Release-iphonesimulator/TwilioVoiceExampleNewArch.app',
+      build: 'xcodebuild -workspace ios/TwilioVoiceExampleNewArch.xcworkspace -scheme TwilioVoiceExampleNewArch -configuration Release -sdk iphonesimulator -derivedDataPath ios/build'
     },
     'android.debug': {
       type: 'android.apk',

--- a/test/app/.detoxrc.js
+++ b/test/app/.detoxrc.js
@@ -38,7 +38,7 @@ module.exports = {
     simulator: {
       type: 'ios.simulator',
       device: {
-        type: 'iPhone 14'
+        type: 'iPhone 16'
       }
     },
     attached: {

--- a/test/app/package.json
+++ b/test/app/package.json
@@ -7,7 +7,10 @@
     "ios": "react-native run-ios",
     "lint": "eslint .",
     "start": "react-native start",
-    "test": "jest"
+    "test": "jest",
+    "detox:build": "detox build",
+    "detox:test": "detox test",
+    "detox:relay-server": "node ./e2e/relay/server.js"
   },
   "dependencies": {
     "@twilio/voice-react-native-sdk": "link:../../",


### PR DESCRIPTION
## Submission Checklist

 - [x] ~Updated the `CHANGELOG.md` to reflect any **feature**, **bug fixes**, or **known issues** made in the source code~
 - [x] Tested code changes and observed expected behavior in the example app
 - [x] Performed a visual inspection of the `Files changed` tab prior to submitting the pull request for review to ensure proper usage of the style guide

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Description

This PR fixes the package manifests for the SDK and the test app to work in CircleCI.

## Breakdown

- Remove SDK eslint from analyzing the test app src folder.
- Add missing detox scripts to the test app.

## Validation

- CircleCI runs and succeeds.

## Additional Notes

N/A
