### PR TITLE
[VBLOCKS-4518] Task/save contact handle to preferences

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 1.7.0 (In Progress)
 ===================
 
+## Fixes
+
+- The call contact handle template feature now caches the set value. This fixes an issue where the handle template value would be `null` when an incoming call was received and the React Native JS runtime was not initialized or was restarted by the OS.
+
 ## Features
 
 ### Platform Specific Features

--- a/android/src/main/java/com/twiliovoicereactnative/ConfigurationProperties.java
+++ b/android/src/main/java/com/twiliovoicereactnative/ConfigurationProperties.java
@@ -1,16 +1,20 @@
 package com.twiliovoicereactnative;
 
 import android.content.Context;
+import android.content.SharedPreferences;
 
 class ConfigurationProperties {
-  private static String incomingCallContactHandleTemplate = null;
-
-  public static void setIncomingCallContactHandleTemplate(String template) {
-    ConfigurationProperties.incomingCallContactHandleTemplate = template;
+  public static void setIncomingCallContactHandleTemplate(Context ctx, String template) {
+    SharedPreferences sharedPreferences = ctx.getSharedPreferences(Constants.PREFERENCES_FILE, Context.MODE_PRIVATE);
+    sharedPreferences
+      .edit()
+      .putString(Constants.INCOMING_CALL_CONTACT_HANDLE_TEMPLATE_PREFERENCES_KEY, template)
+      .apply();
   }
 
-  public static String getIncomingCallContactHandleTemplate() {
-    return ConfigurationProperties.incomingCallContactHandleTemplate;
+  public static String getIncomingCallContactHandleTemplate(Context ctx) {
+    SharedPreferences sharedPreferences = ctx.getSharedPreferences(Constants.PREFERENCES_FILE, Context.MODE_PRIVATE);
+    return sharedPreferences.getString(Constants.INCOMING_CALL_CONTACT_HANDLE_TEMPLATE_PREFERENCES_KEY, null);
   }
 
   /**

--- a/android/src/main/java/com/twiliovoicereactnative/Constants.java
+++ b/android/src/main/java/com/twiliovoicereactnative/Constants.java
@@ -18,4 +18,6 @@ class Constants {
   public static final String JS_EVENT_KEY_CALL_INFO = "call";
   public static final String JS_EVENT_KEY_CALL_INVITE_INFO = "callInvite";
   public static final String JS_EVENT_KEY_CANCELLED_CALL_INVITE_INFO = "cancelledCallInvite";
+  public static final String PREFERENCES_FILE = "com.twilio.twiliovoicereactnative.preferences";
+  public static final String INCOMING_CALL_CONTACT_HANDLE_TEMPLATE_PREFERENCES_KEY = "incomingCallContactHandleTemplatePreferenceKey";
 }

--- a/android/src/main/java/com/twiliovoicereactnative/NotificationUtility.java
+++ b/android/src/main/java/com/twiliovoicereactnative/NotificationUtility.java
@@ -72,7 +72,7 @@ class NotificationUtility {
 
     public String getName() {
       if (this.callRecord.getDirection() == CallRecord.Direction.INCOMING) {
-        final String template = ConfigurationProperties.getIncomingCallContactHandleTemplate();
+        final String template = ConfigurationProperties.getIncomingCallContactHandleTemplate(ctx);
         if (template != null) {
           final String processedTemplate =
             templateDisplayName(template, this.callRecord.getCustomParameters());

--- a/android/src/main/java/com/twiliovoicereactnative/TwilioVoiceReactNativeModule.java
+++ b/android/src/main/java/com/twiliovoicereactnative/TwilioVoiceReactNativeModule.java
@@ -313,7 +313,7 @@ public class TwilioVoiceReactNativeModule extends ReactContextBaseJavaModule {
 
   @ReactMethod
   public void voice_setIncomingCallContactHandleTemplate(String template, Promise promise) {
-    ConfigurationProperties.setIncomingCallContactHandleTemplate(template);
+    ConfigurationProperties.setIncomingCallContactHandleTemplate(reactContext, template);
     promise.resolve(null);
   }
 

--- a/ios/TwilioVoiceReactNative+CallKit.m
+++ b/ios/TwilioVoiceReactNative+CallKit.m
@@ -82,8 +82,14 @@ NSString * const kDefaultCallKitConfigurationName = @"Twilio Voice React Native"
     if (handleName == nil) {
         handleName = @"Unknown Caller";
     }
-    if (self.incomingCallContactHandleTemplate != NULL && [self.incomingCallContactHandleTemplate length] > 0) {
-        handleName = [self getDisplayName:self.incomingCallContactHandleTemplate customParameters:[callInvite customParameters]];
+
+    NSUserDefaults *preferences = [NSUserDefaults standardUserDefaults];
+    NSString *preferenceKey = @"incomingCallContactHandleTemplate";
+    if ([preferences objectForKey:preferenceKey] != nil) {
+        const NSString *preferenceVal = [preferences stringForKey:preferenceKey];
+        if ([preferenceVal length] > 0) {
+            handleName = [self getDisplayName:preferenceVal customParameters:[callInvite customParameters]];
+        }
     }
 
     CXHandle *callHandle = [[CXHandle alloc] initWithType:CXHandleTypeGeneric value:handleName];

--- a/ios/TwilioVoiceReactNative.h
+++ b/ios/TwilioVoiceReactNative.h
@@ -43,8 +43,6 @@ FOUNDATION_EXPORT NSString * const kTwilioVoiceReactNativeEventKeyCancelledCallI
 
 + (TVODefaultAudioDevice *)twilioAudioDevice;
 
-@property(nonatomic, strong) NSString *incomingCallContactHandleTemplate;
-
 @end
 
 @interface TwilioVoiceReactNative (EventEmitter)

--- a/ios/TwilioVoiceReactNative.m
+++ b/ios/TwilioVoiceReactNative.m
@@ -983,7 +983,10 @@ RCT_EXPORT_METHOD(voice_setIncomingCallContactHandleTemplate:(NSString *)templat
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject)
 {
-    self.incomingCallContactHandleTemplate = template;
+    NSUserDefaults *preferences = [NSUserDefaults standardUserDefaults];
+    NSString *preferenceKey = @"incomingCallContactHandleTemplate";
+    [preferences setObject:template forKey:preferenceKey];
+    [preferences synchronize];
     resolve(NULL);
 }
 


### PR DESCRIPTION
## Submission Checklist

 - [x] Updated the `CHANGELOG.md` to reflect any **feature**, **bug fixes**, or **known issues** made in the source code
 - [x] Tested code changes and observed expected behavior in the example app
 - [x] Performed a visual inspection of the `Files changed` tab prior to submitting the pull request for review to ensure proper usage of the style guide

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Description

This PR fixes an issue where the call contact handle template could be null when the JS runtime is not initialized.

## Breakdown

- Add caching of contact handle template value to native layers.

## Validation

- Manually tested with test app.

## Additional Notes

N/A
