### PR TITLE
[VBLOCKS-4180] fix: update audioswitch and fix override in test app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,22 @@
+1.6.1 (In Progress)
+===================
+
+## Changes
+
+### Platform Specific Changes
+
+#### Android
+
+- Added Bluetooth permissions to the Twilio Voice RN SDK manifest.
+
+## Fixes
+
+### Platform Specific Fixes
+
+#### Android
+
+- Updated Audioswitch library to version `1.2.2`. This should fix missing Bluetooth audio devices on Android platforms.
+
 1.6.0 (June 18, 2025)
 =====================
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     'voiceAndroid'       : '6.7.1',
     'androidxCore'       : '1.10.1',
     'androidxLifecycle'  : '2.2.0',
-    'audioSwitch'        : '1.1.8',
+    'audioSwitch'        : '1.2.2',
     'firebaseMessaging'  : '23.4.0'
   ]
   if (project == rootProject) {

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -9,6 +9,8 @@
   <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
   <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MICROPHONE"/>
   <uses-permission android:name="android.permission.RECORD_AUDIO" />
+  <uses-permission android:name="android.permission.BLUETOOTH" android:maxSdkVersion="30" />
+  <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
 
   <application>
     <service

--- a/test/app/android/app/src/main/java/com/example/twiliovoicereactnative/MainActivity.kt
+++ b/test/app/android/app/src/main/java/com/example/twiliovoicereactnative/MainActivity.kt
@@ -54,8 +54,8 @@ class MainActivity : ReactActivity() {
   override fun createReactActivityDelegate(): ReactActivityDelegate =
       DefaultReactActivityDelegate(this, mainComponentName, fabricEnabled)
 
-  override fun onCreate(savedInstanceState: Bundle?, persistentState: PersistableBundle?) {
-    super.onCreate(savedInstanceState, persistentState)
+  override fun onCreate(savedInstanceState: Bundle?) {
+    super.onCreate(savedInstanceState)
     voiceActivityProxy.onCreate(savedInstanceState)
   }
 


### PR DESCRIPTION
## Submission Checklist

 - [x] Updated the `CHANGELOG.md` to reflect any **feature**, **bug fixes**, or **known issues** made in the source code
 - [x] Tested code changes and observed expected behavior in the example app
 - [x] Performed a visual inspection of the `Files changed` tab prior to submitting the pull request for review to ensure proper usage of the style guide

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Description

JIRA Link: https://twilio-engineering.atlassian.net/browse/VBLOCKS-4180

This PR introduces a fix from @afalls-twilio for the test app and updates the audioswitch dependency to the latest version to fix missing bluetooth devices on Android devices.

## Breakdown

- Fix test app permissions due to an improper override. Thanks @afalls-twilio for the fix.
- Update Audioswitch dependency to fix missing Bluetooth devices on first-start on Android.

## Validation

- Manual testing.

## Additional Notes

N/A
