### PR TITLE
[VBLOCKS-4865] Fix preflight ios events and options

### DIFF
--- a/ios/TwilioVoiceReactNative+PreflightTest.m
+++ b/ios/TwilioVoiceReactNative+PreflightTest.m
@@ -20,44 +20,44 @@ RCT_EXPORT_METHOD(voice_runPreflight:(NSString *)accessToken
                   options:(NSDictionary *)jsPreflightOptions
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject) {
-
+    
     NSString *uuid = [NSUUID UUID].UUIDString;
-
+    
     TVOPreflightOptions *preflightOptions = [self parseJsPreflightOptions:accessToken jsPreflightOptions:jsPreflightOptions];
-
+    
     NSString *preflightTestErrorCode = @"";
     NSString *preflightTestErrorMessage = @"";
     [self startPreflightTestWithAccessToken:accessToken preflightOptions:preflightOptions uuid:uuid errorCode:&preflightTestErrorCode errorMessage:&preflightTestErrorMessage];
-
+    
     if (preflightTestErrorCode != nil) {
         reject(preflightTestErrorCode,
                preflightTestErrorMessage,
                nil);
         return;
     }
-
+    
     resolve(uuid);
 }
 
 RCT_EXPORT_METHOD(preflightTest_getCallSid:(NSString *)uuid
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject) {
-
+    
     if (![self checkForPreflightTest:uuid rejecter:reject]) {
         return;
     }
-
+    
     resolve(self.preflightTest.callSid);
 }
 
 RCT_EXPORT_METHOD(preflightTest_getEndTime:(NSString *)uuid
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject) {
-
+    
     if (![self checkForPreflightTest:uuid rejecter:reject]) {
         return;
     }
-
+    
     NSString *endTime = @(self.preflightTest.endTime).stringValue;
     resolve(endTime);
 }
@@ -65,11 +65,11 @@ RCT_EXPORT_METHOD(preflightTest_getEndTime:(NSString *)uuid
 RCT_EXPORT_METHOD(preflightTest_getLatestSample:(NSString *)uuid
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject) {
-
+    
     if (![self checkForPreflightTest:uuid rejecter:reject]) {
         return;
     }
-
+    
     NSString *jsonSample = [self preflightStatsSampleToJsonString:self.preflightTest.latestSample];
     resolve(jsonSample);
 }
@@ -77,11 +77,11 @@ RCT_EXPORT_METHOD(preflightTest_getLatestSample:(NSString *)uuid
 RCT_EXPORT_METHOD(preflightTest_getReport:(NSString *)uuid
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject) {
-
+    
     if (![self checkForPreflightTest:uuid rejecter:reject]) {
         return;
     }
-
+    
     NSString *jsonReport = [self preflightReportToJsonString:self.preflightTest.preflightReport];
     resolve(jsonReport);
 }
@@ -89,11 +89,11 @@ RCT_EXPORT_METHOD(preflightTest_getReport:(NSString *)uuid
 RCT_EXPORT_METHOD(preflightTest_getStartTime:(NSString *)uuid
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject) {
-
+    
     if (![self checkForPreflightTest:uuid rejecter:reject]) {
         return;
     }
-
+    
     NSString *startTime = @(self.preflightTest.startTime).stringValue;
     resolve(startTime);
 }
@@ -101,11 +101,11 @@ RCT_EXPORT_METHOD(preflightTest_getStartTime:(NSString *)uuid
 RCT_EXPORT_METHOD(preflightTest_getState:(NSString *)uuid
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject) {
-
+    
     if (![self checkForPreflightTest:uuid rejecter:reject]) {
         return;
     }
-
+    
     NSString *state = [self preflightStatusToStateString:self.preflightTest.status];
     resolve(state);
 }
@@ -113,11 +113,11 @@ RCT_EXPORT_METHOD(preflightTest_getState:(NSString *)uuid
 RCT_EXPORT_METHOD(preflightTest_stop:(NSString *)uuid
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject) {
-
+    
     if (![self checkForPreflightTest:uuid rejecter:reject]) {
         return;
     }
-
+    
     [self.preflightTest stop];
     resolve(nil);
 }
@@ -126,14 +126,14 @@ RCT_EXPORT_METHOD(preflightTest_stop:(NSString *)uuid
     if (self.preflightTest == nil ||
         self.preflightTestUuid == nil ||
         ![self.preflightTestUuid isEqualToString:uuid]) {
-
+        
         NSString *errorMessage = [NSString stringWithFormat:@"No existing preflight test object with UUID \"%@\".", uuid];
         reject(kTwilioVoiceReactNativeErrorCodeInvalidStateError,
                errorMessage,
                nil);
         return false;
     }
-
+    
     return true;
 }
 
@@ -153,7 +153,7 @@ RCT_EXPORT_METHOD(preflightTest_stop:(NSString *)uuid
         kTwilioVoiceReactNativePreflightRTCSampleRtt: @(statsSample.rtt),
         kTwilioVoiceReactNativePreflightRTCSampleTimestamp: statsSample.timestamp,
     };
-
+    
     NSError *jsonParseError;
     NSData *jsonData = [NSJSONSerialization dataWithJSONObject:sampleDict options:NSJSONWritingFragmentsAllowed error:&jsonParseError];
     if (jsonParseError != nil) {
@@ -161,7 +161,7 @@ RCT_EXPORT_METHOD(preflightTest_stop:(NSString *)uuid
         NSLog(@"Failed to parse sample as json: %@", jsonParseError);
     }
     NSString *jsonString = [[NSString alloc] initWithData:jsonData encoding:NSUTF8StringEncoding];
-
+    
     return jsonString;
 }
 
@@ -173,7 +173,7 @@ RCT_EXPORT_METHOD(preflightTest_stop:(NSString *)uuid
         NSLog(@"Failed to parse report as json: %@", jsonParseError);
     }
     NSString *jsonString = [[NSString alloc] initWithData:jsonData encoding:NSUTF8StringEncoding];
-
+    
     return jsonString;
 }
 
@@ -204,7 +204,7 @@ RCT_EXPORT_METHOD(preflightTest_stop:(NSString *)uuid
             NSString *password = [jsIceServer objectForKey:kTwilioVoiceReactNativeIceServerKeyPassword];
             NSString *username = [jsIceServer objectForKey:kTwilioVoiceReactNativeIceServerKeyUsername];
             NSString *serverUrl = [jsIceServer objectForKey:kTwilioVoiceReactNativeIceServerKeyServerUrl];
-
+            
             if (serverUrl != nil && username != nil && password != nil) {
                 TVOIceServer *nativeIceServer = [[TVOIceServer alloc] initWithURLString:serverUrl username:username password:password];
                 [nativeIceServers addObject:nativeIceServer];
@@ -216,7 +216,7 @@ RCT_EXPORT_METHOD(preflightTest_stop:(NSString *)uuid
         if (nativeIceServers.count > 0) {
             iceOptionsBuilderBlock.servers = nativeIceServers;
         }
-
+        
         // transport policy logic
         NSString *jsIceTransportPolicy = [jsPreflightOptions objectForKey:kTwilioVoiceReactNativeCallOptionsKeyIceTransportPolicy];
         if ([jsIceTransportPolicy isEqualToString:kTwilioVoiceReactNativeIceTransportPolicyValueAll]) {
@@ -226,7 +226,7 @@ RCT_EXPORT_METHOD(preflightTest_stop:(NSString *)uuid
             iceOptionsBuilderBlock.transportPolicy = TVOIceTransportPolicyRelay;
         }
     }];
-
+    
     // preferred audio codecs option
     NSArray<NSDictionary *> *jsPreferredAudioCodecs = [jsPreflightOptions objectForKey:kTwilioVoiceReactNativeCallOptionsKeyPreferredAudioCodecs];
     NSMutableArray *nativePreferredAudioCodecs = [NSMutableArray new];
@@ -246,14 +246,14 @@ RCT_EXPORT_METHOD(preflightTest_stop:(NSString *)uuid
             [nativePreferredAudioCodecs addObject:[TVOPcmuCodec new]];
         }
     }
-
+    
     TVOPreflightOptions *preflightOptions = [TVOPreflightOptions optionsWithAccessToken:accessToken block:^(TVOPreflightOptionsBuilder *preflightOptionsBuilderBlock) {
         preflightOptionsBuilderBlock.iceOptions = iceOptions;
         if ([nativePreferredAudioCodecs count] > 0) {
             preflightOptionsBuilderBlock.preferredAudioCodecs = nativePreferredAudioCodecs;
         }
     }];
-
+    
     return preflightOptions;
 }
 
@@ -262,7 +262,7 @@ RCT_EXPORT_METHOD(preflightTest_stop:(NSString *)uuid
                                      uuid:(NSString *)uuid
                                 errorCode:(NSString **)errorCode
                              errorMessage:(NSString **)errorMessage {
-
+    
     if (self.preflightTest != nil) {
         NSLog(@"existing preflight test object with status %lu", self.preflightTest.status);
         if (self.preflightTest.status == TVOPreflightTestStatusConnected || self.preflightTest.status == TVOPreflightTestStatusConnecting) {
@@ -271,7 +271,7 @@ RCT_EXPORT_METHOD(preflightTest_stop:(NSString *)uuid
             return;
         }
     }
-
+    
     self.preflightTestUuid = uuid;
     self.preflightTest = [TwilioVoiceSDK runPreflightTestWithOptions:preflightOptions delegate:self];
 }
@@ -305,7 +305,7 @@ RCT_EXPORT_METHOD(preflightTest_stop:(NSString *)uuid
 - (void)preflight:(TVOPreflightTest *)preflightTest didReceiveQualityWarnings:(NSSet<NSNumber *> *)currentWarnings previousWarnings:(NSSet<NSNumber *> *)previousWarnings {
     NSMutableArray *currentWarningsArr = [self callQualityWarningsArrayFromSet:currentWarnings];
     NSMutableArray *previousWarningsArr = [self callQualityWarningsArrayFromSet:previousWarnings];
-
+    
     [self sendEventWithName:kTwilioVoiceReactNativeScopePreflightTest body:@{
         kTwilioVoiceReactNativePreflightTestEventKeyUuid: self.preflightTestUuid,
         kTwilioVoiceReactNativePreflightTestEventKeyType: kTwilioVoiceReactNativePreflightTestEventTypeValueQualityWarning,

--- a/ios/TwilioVoiceReactNative+PreflightTest.m
+++ b/ios/TwilioVoiceReactNative+PreflightTest.m
@@ -25,8 +25,8 @@ RCT_EXPORT_METHOD(voice_runPreflight:(NSString *)accessToken
     
     TVOPreflightOptions *preflightOptions = [self parseJsPreflightOptions:accessToken jsPreflightOptions:jsPreflightOptions];
     
-    NSString *preflightTestErrorCode = @"";
-    NSString *preflightTestErrorMessage = @"";
+    NSString *preflightTestErrorCode = nil;
+    NSString *preflightTestErrorMessage = nil;
     [self startPreflightTestWithAccessToken:accessToken preflightOptions:preflightOptions uuid:uuid errorCode:&preflightTestErrorCode errorMessage:&preflightTestErrorMessage];
     
     if (preflightTestErrorCode != nil) {
@@ -273,11 +273,40 @@ RCT_EXPORT_METHOD(preflightTest_stop:(NSString *)uuid
     }
     
     self.preflightTestUuid = uuid;
+    self.preflightTestEvents = [NSMutableArray array];
     self.preflightTest = [TwilioVoiceSDK runPreflightTestWithOptions:preflightOptions delegate:self];
 }
 
+- (void)sendPreflightEvent:(NSDictionary *)eventPayload {
+    if (self.preflightTestEvents == nil) {
+        // this indicates that the events for this uuid have already been flushed
+        // just send the event instead
+        [self sendEventWithName:kTwilioVoiceReactNativeScopePreflightTest body:eventPayload];
+    } else {
+        // otherwise, enqueue the event
+        [self.preflightTestEvents addObject:eventPayload];
+    }
+}
+
+RCT_EXPORT_METHOD(preflightTest_flushEvents:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject) {
+    
+    if (self.preflightTestEvents == nil) {
+        // this indicates that the events have already been flushed
+        resolve(nil);
+        return;
+    }
+    
+    for (NSMutableDictionary *event in self.preflightTestEvents) {
+        [self sendEventWithName:kTwilioVoiceReactNativeScopePreflightTest body:event];
+    }
+    
+    self.preflightTestEvents = nil;
+    resolve(nil);
+}
+
 - (void)preflight:(nonnull TVOPreflightTest *)preflightTest didCompleteWitReport:(nonnull TVOPreflightReport *)report {
-    [self sendEventWithName:kTwilioVoiceReactNativeScopePreflightTest body:@{
+    [self sendPreflightEvent:@{
         kTwilioVoiceReactNativePreflightTestEventKeyUuid: self.preflightTestUuid,
         kTwilioVoiceReactNativePreflightTestEventKeyType: kTwilioVoiceReactNativePreflightTestEventTypeValueCompleted,
         kTwilioVoiceReactNativePreflightTestCompletedEventKeyReport: [self preflightReportToJsonString:report],
@@ -285,18 +314,18 @@ RCT_EXPORT_METHOD(preflightTest_stop:(NSString *)uuid
 }
 
 - (void)preflight:(nonnull TVOPreflightTest *)preflightTest didFailWithError:(nonnull NSError *)error {
-    [self sendEventWithName:kTwilioVoiceReactNativeScopePreflightTest body:@{
+    [self sendPreflightEvent:@{
         kTwilioVoiceReactNativePreflightTestEventKeyUuid: self.preflightTestUuid,
         kTwilioVoiceReactNativePreflightTestEventKeyType: kTwilioVoiceReactNativePreflightTestEventTypeValueFailed,
         kTwilioVoiceReactNativePreflightTestFailedEventKeyError: @{
-            kTwilioVoiceReactNativeVoiceErrorKeyCode: @(error.code),
+            kTwilioVoiceReactNativeVoiceErrorKeyCode: [NSNumber numberWithLong:error.code],
             kTwilioVoiceReactNativeVoiceErrorKeyMessage: error.localizedDescription,
         },
     }];
 }
 
 - (void)preflightDidConnect:(nonnull TVOPreflightTest *)preflightTest {
-    [self sendEventWithName:kTwilioVoiceReactNativeScopePreflightTest body:@{
+    [self sendPreflightEvent:@{
         kTwilioVoiceReactNativePreflightTestEventKeyUuid: self.preflightTestUuid,
         kTwilioVoiceReactNativePreflightTestEventKeyType: kTwilioVoiceReactNativePreflightTestEventTypeValueConnected,
     }];
@@ -306,7 +335,7 @@ RCT_EXPORT_METHOD(preflightTest_stop:(NSString *)uuid
     NSMutableArray *currentWarningsArr = [self callQualityWarningsArrayFromSet:currentWarnings];
     NSMutableArray *previousWarningsArr = [self callQualityWarningsArrayFromSet:previousWarnings];
     
-    [self sendEventWithName:kTwilioVoiceReactNativeScopePreflightTest body:@{
+    [self sendPreflightEvent:@{
         kTwilioVoiceReactNativePreflightTestEventKeyUuid: self.preflightTestUuid,
         kTwilioVoiceReactNativePreflightTestEventKeyType: kTwilioVoiceReactNativePreflightTestEventTypeValueQualityWarning,
         kTwilioVoiceReactNativePreflightTestQualityWarningEventKeyCurrentWarnings: currentWarningsArr,
@@ -315,7 +344,7 @@ RCT_EXPORT_METHOD(preflightTest_stop:(NSString *)uuid
 }
 
 - (void)preflight:(TVOPreflightTest *)preflightTest didReceiveStatsSample:(TVOPreflightStatsSample *)statsSample {
-    [self sendEventWithName:kTwilioVoiceReactNativeScopePreflightTest body:@{
+    [self sendPreflightEvent:@{
         kTwilioVoiceReactNativePreflightTestEventKeyUuid: self.preflightTestUuid,
         kTwilioVoiceReactNativePreflightTestEventKeyType: kTwilioVoiceReactNativePreflightTestEventTypeValueSample,
         kTwilioVoiceReactNativePreflightTestSampleEventKeySample: [self preflightStatsSampleToJsonString:statsSample],

--- a/ios/TwilioVoiceReactNative+PreflightTest.m
+++ b/ios/TwilioVoiceReactNative+PreflightTest.m
@@ -20,44 +20,44 @@ RCT_EXPORT_METHOD(voice_runPreflight:(NSString *)accessToken
                   options:(NSDictionary *)jsPreflightOptions
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject) {
-    
+
     NSString *uuid = [NSUUID UUID].UUIDString;
-    
+
     TVOPreflightOptions *preflightOptions = [self parseJsPreflightOptions:accessToken jsPreflightOptions:jsPreflightOptions];
-    
+
     NSString *preflightTestErrorCode = @"";
     NSString *preflightTestErrorMessage = @"";
     [self startPreflightTestWithAccessToken:accessToken preflightOptions:preflightOptions uuid:uuid errorCode:&preflightTestErrorCode errorMessage:&preflightTestErrorMessage];
-    
+
     if (preflightTestErrorCode != nil) {
         reject(preflightTestErrorCode,
                preflightTestErrorMessage,
                nil);
         return;
     }
-    
+
     resolve(uuid);
 }
 
 RCT_EXPORT_METHOD(preflightTest_getCallSid:(NSString *)uuid
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject) {
-    
+
     if (![self checkForPreflightTest:uuid rejecter:reject]) {
         return;
     }
-    
+
     resolve(self.preflightTest.callSid);
 }
 
 RCT_EXPORT_METHOD(preflightTest_getEndTime:(NSString *)uuid
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject) {
-    
+
     if (![self checkForPreflightTest:uuid rejecter:reject]) {
         return;
     }
-    
+
     NSString *endTime = @(self.preflightTest.endTime).stringValue;
     resolve(endTime);
 }
@@ -65,11 +65,11 @@ RCT_EXPORT_METHOD(preflightTest_getEndTime:(NSString *)uuid
 RCT_EXPORT_METHOD(preflightTest_getLatestSample:(NSString *)uuid
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject) {
-    
+
     if (![self checkForPreflightTest:uuid rejecter:reject]) {
         return;
     }
-    
+
     NSString *jsonSample = [self preflightStatsSampleToJsonString:self.preflightTest.latestSample];
     resolve(jsonSample);
 }
@@ -77,11 +77,11 @@ RCT_EXPORT_METHOD(preflightTest_getLatestSample:(NSString *)uuid
 RCT_EXPORT_METHOD(preflightTest_getReport:(NSString *)uuid
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject) {
-    
+
     if (![self checkForPreflightTest:uuid rejecter:reject]) {
         return;
     }
-    
+
     NSString *jsonReport = [self preflightReportToJsonString:self.preflightTest.preflightReport];
     resolve(jsonReport);
 }
@@ -89,11 +89,11 @@ RCT_EXPORT_METHOD(preflightTest_getReport:(NSString *)uuid
 RCT_EXPORT_METHOD(preflightTest_getStartTime:(NSString *)uuid
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject) {
-    
+
     if (![self checkForPreflightTest:uuid rejecter:reject]) {
         return;
     }
-    
+
     NSString *startTime = @(self.preflightTest.startTime).stringValue;
     resolve(startTime);
 }
@@ -101,11 +101,11 @@ RCT_EXPORT_METHOD(preflightTest_getStartTime:(NSString *)uuid
 RCT_EXPORT_METHOD(preflightTest_getState:(NSString *)uuid
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject) {
-    
+
     if (![self checkForPreflightTest:uuid rejecter:reject]) {
         return;
     }
-    
+
     NSString *state = [self preflightStatusToStateString:self.preflightTest.status];
     resolve(state);
 }
@@ -113,11 +113,11 @@ RCT_EXPORT_METHOD(preflightTest_getState:(NSString *)uuid
 RCT_EXPORT_METHOD(preflightTest_stop:(NSString *)uuid
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject) {
-    
+
     if (![self checkForPreflightTest:uuid rejecter:reject]) {
         return;
     }
-    
+
     [self.preflightTest stop];
     resolve(nil);
 }
@@ -126,14 +126,14 @@ RCT_EXPORT_METHOD(preflightTest_stop:(NSString *)uuid
     if (self.preflightTest == nil ||
         self.preflightTestUuid == nil ||
         ![self.preflightTestUuid isEqualToString:uuid]) {
-        
+
         NSString *errorMessage = [NSString stringWithFormat:@"No existing preflight test object with UUID \"%@\".", uuid];
         reject(kTwilioVoiceReactNativeErrorCodeInvalidStateError,
                errorMessage,
                nil);
         return false;
     }
-    
+
     return true;
 }
 
@@ -153,7 +153,7 @@ RCT_EXPORT_METHOD(preflightTest_stop:(NSString *)uuid
         kTwilioVoiceReactNativePreflightRTCSampleRtt: @(statsSample.rtt),
         kTwilioVoiceReactNativePreflightRTCSampleTimestamp: statsSample.timestamp,
     };
-    
+
     NSError *jsonParseError;
     NSData *jsonData = [NSJSONSerialization dataWithJSONObject:sampleDict options:NSJSONWritingFragmentsAllowed error:&jsonParseError];
     if (jsonParseError != nil) {
@@ -161,7 +161,7 @@ RCT_EXPORT_METHOD(preflightTest_stop:(NSString *)uuid
         NSLog(@"Failed to parse sample as json: %@", jsonParseError);
     }
     NSString *jsonString = [[NSString alloc] initWithData:jsonData encoding:NSUTF8StringEncoding];
-    
+
     return jsonString;
 }
 
@@ -173,7 +173,7 @@ RCT_EXPORT_METHOD(preflightTest_stop:(NSString *)uuid
         NSLog(@"Failed to parse report as json: %@", jsonParseError);
     }
     NSString *jsonString = [[NSString alloc] initWithData:jsonData encoding:NSUTF8StringEncoding];
-    
+
     return jsonString;
 }
 
@@ -204,7 +204,7 @@ RCT_EXPORT_METHOD(preflightTest_stop:(NSString *)uuid
             NSString *password = [jsIceServer objectForKey:kTwilioVoiceReactNativeIceServerKeyPassword];
             NSString *username = [jsIceServer objectForKey:kTwilioVoiceReactNativeIceServerKeyUsername];
             NSString *serverUrl = [jsIceServer objectForKey:kTwilioVoiceReactNativeIceServerKeyServerUrl];
-            
+
             if (serverUrl != nil && username != nil && password != nil) {
                 TVOIceServer *nativeIceServer = [[TVOIceServer alloc] initWithURLString:serverUrl username:username password:password];
                 [nativeIceServers addObject:nativeIceServer];
@@ -216,7 +216,7 @@ RCT_EXPORT_METHOD(preflightTest_stop:(NSString *)uuid
         if (nativeIceServers.count > 0) {
             iceOptionsBuilderBlock.servers = nativeIceServers;
         }
-        
+
         // transport policy logic
         NSString *jsIceTransportPolicy = [jsPreflightOptions objectForKey:kTwilioVoiceReactNativeCallOptionsKeyIceTransportPolicy];
         if ([jsIceTransportPolicy isEqualToString:kTwilioVoiceReactNativeIceTransportPolicyValueAll]) {
@@ -226,7 +226,7 @@ RCT_EXPORT_METHOD(preflightTest_stop:(NSString *)uuid
             iceOptionsBuilderBlock.transportPolicy = TVOIceTransportPolicyRelay;
         }
     }];
-    
+
     // preferred audio codecs option
     NSArray<NSDictionary *> *jsPreferredAudioCodecs = [jsPreflightOptions objectForKey:kTwilioVoiceReactNativeCallOptionsKeyPreferredAudioCodecs];
     NSMutableArray *nativePreferredAudioCodecs = [NSMutableArray new];
@@ -246,14 +246,14 @@ RCT_EXPORT_METHOD(preflightTest_stop:(NSString *)uuid
             [nativePreferredAudioCodecs addObject:[TVOPcmuCodec new]];
         }
     }
-    
+
     TVOPreflightOptions *preflightOptions = [TVOPreflightOptions optionsWithAccessToken:accessToken block:^(TVOPreflightOptionsBuilder *preflightOptionsBuilderBlock) {
         preflightOptionsBuilderBlock.iceOptions = iceOptions;
         if ([nativePreferredAudioCodecs count] > 0) {
             preflightOptionsBuilderBlock.preferredAudioCodecs = nativePreferredAudioCodecs;
         }
     }];
-    
+
     return preflightOptions;
 }
 
@@ -262,7 +262,7 @@ RCT_EXPORT_METHOD(preflightTest_stop:(NSString *)uuid
                                      uuid:(NSString *)uuid
                                 errorCode:(NSString **)errorCode
                              errorMessage:(NSString **)errorMessage {
-    
+
     if (self.preflightTest != nil) {
         NSLog(@"existing preflight test object with status %lu", self.preflightTest.status);
         if (self.preflightTest.status == TVOPreflightTestStatusConnected || self.preflightTest.status == TVOPreflightTestStatusConnecting) {
@@ -271,9 +271,9 @@ RCT_EXPORT_METHOD(preflightTest_stop:(NSString *)uuid
             return;
         }
     }
-    
+
     self.preflightTestUuid = uuid;
-    self.preflightTest = [TwilioVoiceSDK runPreflightTestWithAccessToken:accessToken delegate:self];
+    self.preflightTest = [TwilioVoiceSDK runPreflightTestWithOptions:preflightOptions delegate:self];
 }
 
 - (void)preflight:(nonnull TVOPreflightTest *)preflightTest didCompleteWitReport:(nonnull TVOPreflightReport *)report {
@@ -305,7 +305,7 @@ RCT_EXPORT_METHOD(preflightTest_stop:(NSString *)uuid
 - (void)preflight:(TVOPreflightTest *)preflightTest didReceiveQualityWarnings:(NSSet<NSNumber *> *)currentWarnings previousWarnings:(NSSet<NSNumber *> *)previousWarnings {
     NSMutableArray *currentWarningsArr = [self callQualityWarningsArrayFromSet:currentWarnings];
     NSMutableArray *previousWarningsArr = [self callQualityWarningsArrayFromSet:previousWarnings];
-    
+
     [self sendEventWithName:kTwilioVoiceReactNativeScopePreflightTest body:@{
         kTwilioVoiceReactNativePreflightTestEventKeyUuid: self.preflightTestUuid,
         kTwilioVoiceReactNativePreflightTestEventKeyType: kTwilioVoiceReactNativePreflightTestEventTypeValueQualityWarning,

--- a/ios/TwilioVoiceReactNative.h
+++ b/ios/TwilioVoiceReactNative.h
@@ -39,6 +39,7 @@ FOUNDATION_EXPORT NSString * const kTwilioVoiceReactNativeEventKeyCancelledCallI
 
 @property (nonatomic, strong) TVOPreflightTest *preflightTest;
 @property (nonatomic, copy) NSString *preflightTestUuid;
+@property (nonatomic, strong) NSMutableArray *preflightTestEvents;
 
 // Indicates if the disconnect is triggered from app UI, instead of the system Call UI
 @property (nonatomic, assign) BOOL userInitiatedDisconnect;

--- a/src/PreflightTest.ts
+++ b/src/PreflightTest.ts
@@ -273,6 +273,15 @@ export class PreflightTest extends EventEmitter {
       Constants.ScopePreflightTest,
       this._handleNativeEvent
     );
+
+    // by using a setTimeout here, we let the call stack empty before we flush
+    // the preflight test events. this way, listeners on this object can bind
+    // before flushing
+    setTimeout(() => {
+      if (Platform.OS === 'ios') {
+        NativeModule.preflightTest_flushEvents();
+      }
+    });
   }
 
   /**

--- a/src/type/NativeModule.ts
+++ b/src/type/NativeModule.ts
@@ -107,4 +107,6 @@ export interface TwilioVoiceReactNative extends NativeModulesStatic {
   preflightTest_getStartTime(preflightTestUuid: Uuid): Promise<string>;
   preflightTest_getState(preflightTestUuid: Uuid): Promise<PreflightTest.State>;
   preflightTest_stop(preflightTestUuid: Uuid): Promise<void>;
+
+  preflightTest_flushEvents(): Promise<void>;
 }


### PR DESCRIPTION
## Submission Checklist

 - [ ] Updated the `CHANGELOG.md` to reflect any **feature**, **bug fixes**, or **known issues** made in the source code
 - [x] Tested code changes and observed expected behavior in the example app
 - [x] Performed a visual inspection of the `Files changed` tab prior to submitting the pull request for review to ensure proper usage of the style guide

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Description

This PR fixes the invocation and uses the parsed PreflightOptions from the JS layer.

## Breakdown

- Change function invocation from `runPreflightTestWithAccessToken` to `runPreflightTestWithOptions`.

## Validation

- N/A

## Additional Notes

N/A
