### PR TITLE
Revert "[VBLOCKS-4627] Fullscreen Notification Permission API (#527)"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,14 +13,6 @@
 
 - The call contact handle template feature now caches the set value. This fixes an issue where the handle template value would be `null` when an incoming call was received and the React Native JS runtime was not initialized or was restarted by the OS.
 
-## Features
-
-### Platform Specific Features
-
-#### Android
-
-- Added a new API to check for and request Full Screen Notification permissions on Android platforms.
-
 1.6.1 (July 7, 2025)
 ====================
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     'androidGradlePlugin': '7.4.2',
     'googleServices'     : '4.3.10',
     'voiceAndroid'       : '6.7.1',
-    'androidxCore'       : '1.12.0',
+    'androidxCore'       : '1.10.1',
     'androidxLifecycle'  : '2.2.0',
     'audioSwitch'        : '1.2.2',
     'firebaseMessaging'  : '23.4.0'

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     'androidGradlePlugin': '7.4.2',
     'googleServices'     : '4.3.10',
     'voiceAndroid'       : '6.7.1',
-    'androidxCore'       : '1.10.1',
+    'androidxCore'       : '1.12.0',
     'androidxLifecycle'  : '2.2.0',
     'audioSwitch'        : '1.2.2',
     'firebaseMessaging'  : '23.4.0'

--- a/android/src/main/java/com/twiliovoicereactnative/ConfigurationProperties.java
+++ b/android/src/main/java/com/twiliovoicereactnative/ConfigurationProperties.java
@@ -27,15 +27,4 @@ class ConfigurationProperties {
     return context.getResources()
       .getBoolean(R.bool.twiliovoicereactnative_firebasemessagingservice_enabled);
   }
-
-  /**
-   * Get configuration boolean, used to determine if full screen notifications are enabled
-   * or not.
-   * @param context the application context
-   * @return a boolean read from the application resources
-   */
-  public static boolean isFullScreenNotificationEnabled(Context context) {
-    return context.getResources()
-      .getBoolean(R.bool.twiliovoicereactnative_fullscreennotification_enabled);
-  }
 }

--- a/android/src/main/java/com/twiliovoicereactnative/NotificationUtility.java
+++ b/android/src/main/java/com/twiliovoicereactnative/NotificationUtility.java
@@ -24,7 +24,6 @@ import androidx.core.app.Person;
 
 import com.twilio.voice.CallInvite;
 
-import static com.twiliovoicereactnative.ConfigurationProperties.isFullScreenNotificationEnabled;
 import static com.twiliovoicereactnative.Constants.VOICE_CHANNEL_DEFAULT_IMPORTANCE;
 import static com.twiliovoicereactnative.Constants.VOICE_CHANNEL_HIGH_IMPORTANCE;
 import static com.twiliovoicereactnative.Constants.VOICE_CHANNEL_LOW_IMPORTANCE;
@@ -166,18 +165,16 @@ class NotificationUtility {
       callRecord.getUuid());
     PendingIntent piAcceptIntent = constructPendingIntentForActivity(context, acceptIntent);
 
-    NotificationCompat.Builder builder = constructNotificationBuilder(context, channelImportance)
+    return constructNotificationBuilder(context, channelImportance)
       .setSmallIcon(notificationResource.getSmallIconId())
       .setCategory(Notification.CATEGORY_CALL)
       .setAutoCancel(true)
       .setContentIntent(piForegroundIntent)
+      .setFullScreenIntent(piForegroundIntent, true)
       .addPerson(incomingCaller)
       .setStyle(NotificationCompat.CallStyle.forIncomingCall(
-        incomingCaller, piRejectIntent, piAcceptIntent));
-    if (isFullscreenIntentEnabled(context)) {
-      builder.setFullScreenIntent(piForegroundIntent, true);
-    }
-    return builder.build();
+        incomingCaller, piRejectIntent, piAcceptIntent))
+      .build();
   }
 
   public static Notification createCallAnsweredNotificationWithLowImportance(@NonNull Context context,
@@ -205,18 +202,16 @@ class NotificationUtility {
       callRecord.getUuid());
     PendingIntent piEndCallIntent = constructPendingIntentForService(context, endCallIntent);
 
-    NotificationCompat.Builder builder = constructNotificationBuilder(context, Constants.VOICE_CHANNEL_LOW_IMPORTANCE)
+    return constructNotificationBuilder(context, Constants.VOICE_CHANNEL_LOW_IMPORTANCE)
       .setSmallIcon(notificationResource.getSmallIconId())
       .setCategory(Notification.CATEGORY_CALL)
       .setAutoCancel(false)
       .setContentIntent(piForegroundIntent)
+      .setFullScreenIntent(piForegroundIntent, true)
       .setOngoing(true)
       .addPerson(activeCaller)
-      .setStyle(NotificationCompat.CallStyle.forOngoingCall(activeCaller, piEndCallIntent));
-    if (isFullscreenIntentEnabled(context)) {
-      builder.setFullScreenIntent(piForegroundIntent, true);
-    }
-    return builder.build();
+      .setStyle(NotificationCompat.CallStyle.forOngoingCall(activeCaller, piEndCallIntent))
+      .build();
   }
 
   public static Notification createOutgoingCallNotificationWithLowImportance(@NonNull Context context,
@@ -244,18 +239,16 @@ class NotificationUtility {
       callRecord.getUuid());
     PendingIntent piEndCallIntent = constructPendingIntentForService(context, endCallIntent);
 
-    NotificationCompat.Builder builder = constructNotificationBuilder(context, Constants.VOICE_CHANNEL_LOW_IMPORTANCE)
+    return constructNotificationBuilder(context, Constants.VOICE_CHANNEL_LOW_IMPORTANCE)
       .setSmallIcon(notificationResource.getSmallIconId())
       .setCategory(Notification.CATEGORY_CALL)
       .setAutoCancel(false)
       .setContentIntent(piForegroundIntent)
+      .setFullScreenIntent(piForegroundIntent, true)
       .setOngoing(true)
       .addPerson(activeCaller)
-      .setStyle(NotificationCompat.CallStyle.forOngoingCall(activeCaller, piEndCallIntent));
-    if (isFullscreenIntentEnabled(context)) {
-      builder.setFullScreenIntent(piForegroundIntent, true);
-    }
-    return builder.build();
+      .setStyle(NotificationCompat.CallStyle.forOngoingCall(activeCaller, piEndCallIntent))
+      .build();
   }
 
   public static void createNotificationChannels(@NonNull Context context) {
@@ -277,11 +270,6 @@ class NotificationUtility {
   public static void destroyNotificationChannels(@NonNull Context context) {
     NotificationManagerCompat notificationManager = NotificationManagerCompat.from(context);
     notificationManager.deleteNotificationChannelGroup(Constants.VOICE_CHANNEL_GROUP);
-  }
-
-  public static boolean isFullscreenIntentEnabled(Context context) {
-    return isFullScreenNotificationEnabled(context) &&
-      NotificationManagerCompat.from(context).canUseFullScreenIntent();
   }
 
   private static NotificationChannelCompat createNotificationChannel(@NonNull Context context,

--- a/android/src/main/java/com/twiliovoicereactnative/TwilioVoiceReactNativeModule.java
+++ b/android/src/main/java/com/twiliovoicereactnative/TwilioVoiceReactNativeModule.java
@@ -1,7 +1,6 @@
 package com.twiliovoicereactnative;
 
 import androidx.annotation.NonNull;
-import androidx.core.app.NotificationManagerCompat;
 
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.Promise;
@@ -38,7 +37,6 @@ import static com.twiliovoicereactnative.CommonConstants.VoiceEventAudioDevicesU
 import static com.twiliovoicereactnative.CommonConstants.VoiceEventError;
 import static com.twiliovoicereactnative.CommonConstants.VoiceEventRegistered;
 import static com.twiliovoicereactnative.CommonConstants.VoiceEventUnregistered;
-import static com.twiliovoicereactnative.ConfigurationProperties.isFullScreenNotificationEnabled;
 import static com.twiliovoicereactnative.JSEventEmitter.constructJSMap;
 import static com.twiliovoicereactnative.ReactNativeArgumentsSerializer.serializeCall;
 import static com.twiliovoicereactnative.ReactNativeArgumentsSerializer.serializeCallInvite;
@@ -48,12 +46,8 @@ import static com.twiliovoicereactnative.VoiceApplicationProxy.getVoiceServiceAp
 import static com.twiliovoicereactnative.ReactNativeArgumentsSerializer.*;
 
 import android.annotation.SuppressLint;
-import android.content.Intent;
-import android.net.Uri;
-import android.os.Build;
 import android.os.Handler;
 import android.os.Looper;
-import android.provider.Settings;
 import android.util.Pair;
 
 import com.twiliovoicereactnative.CallRecordDatabase.CallRecord;
@@ -142,6 +136,67 @@ public class TwilioVoiceReactNativeModule extends ReactContextBaseJavaModule {
   @ReactMethod
   public void removeListeners(Integer count) {
     logger.debug("Calling removeListeners: " + count);
+  }
+
+  @Override
+  @NonNull
+  public String getName() {
+    return TAG;
+  }
+
+  private RegistrationListener createRegistrationListener(Promise promise) {
+    return new RegistrationListener() {
+      @Override
+      public void onRegistered(@NonNull String accessToken, @NonNull String fcmToken) {
+        logger.log("Successfully registered FCM");
+        sendJSEvent(constructJSMap(new Pair<>(VoiceEventType, VoiceEventRegistered)));
+        promise.resolve(null);
+      }
+
+      @Override
+      public void onError(@NonNull RegistrationException registrationException,
+                          @NonNull String accessToken,
+                          @NonNull String fcmToken) {
+        String errorMessage = reactContext.getString(
+          R.string.registration_error,
+          registrationException.getErrorCode(),
+          registrationException.getMessage());
+        logger.error(errorMessage);
+
+        sendJSEvent(constructJSMap(
+          new Pair<>(VoiceEventType, VoiceEventError),
+          new Pair<>(VoiceErrorKeyError, serializeVoiceException(registrationException))));
+
+        promise.reject(errorMessage);
+      }
+    };
+  }
+
+  private UnregistrationListener createUnregistrationListener(Promise promise) {
+    return new UnregistrationListener() {
+      @Override
+      public void onUnregistered(String accessToken, String fcmToken) {
+        logger.log("Successfully unregistered FCM");
+        sendJSEvent(constructJSMap(new Pair<>(VoiceEventType, VoiceEventUnregistered)));
+        promise.resolve(null);
+      }
+
+      @Override
+      public void onError(RegistrationException registrationException, String accessToken, String fcmToken) {
+        @SuppressLint("DefaultLocale")
+        String errorMessage = reactContext.getString(
+          R.string.unregistration_error,
+          registrationException.getErrorCode(),
+          registrationException.getMessage());
+        logger.error(errorMessage);
+
+        sendJSEvent(constructJSMap(
+          new Pair<>(VoiceEventType, VoiceEventError),
+          new Pair<>(VoiceErrorKeyError, serializeVoiceException(registrationException))));
+
+        promise.reject(errorMessage);
+      }
+    };
   }
 
   @ReactMethod
@@ -633,97 +688,6 @@ public class TwilioVoiceReactNativeModule extends ReactContextBaseJavaModule {
         getVoiceServiceApi().rejectCall(callRecord);
       }
     });
-  }
-
-  @ReactMethod
-  public void system_isFullScreenNotificationEnabled(Promise promise) {
-    boolean isEnabled =
-      isFullScreenNotificationEnabled(reactContext) &&
-        NotificationManagerCompat.from(reactContext).canUseFullScreenIntent();
-
-    promise.resolve(isEnabled);
-  }
-
-  @ReactMethod
-  public void system_requestFullScreenNotificationPermission(Promise promise) {
-    final boolean shouldStartActivity =
-      Build.VERSION.SDK_INT > Build.VERSION_CODES.TIRAMISU &&
-        isFullScreenNotificationEnabled(reactContext);
-
-    if (shouldStartActivity) {
-      try {
-        Intent intent = new Intent(
-          Settings.ACTION_MANAGE_APP_USE_FULL_SCREEN_INTENT,
-          Uri.parse("package:" + reactContext.getPackageName()));
-        intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-        reactContext.startActivity(intent);
-      } catch (Exception e) {
-        promise.reject(e);
-      }
-    }
-
-    promise.resolve(null);
-  }
-
-  @Override
-  @NonNull
-  public String getName() {
-    return TAG;
-  }
-
-  private RegistrationListener createRegistrationListener(Promise promise) {
-    return new RegistrationListener() {
-      @Override
-      public void onRegistered(@NonNull String accessToken, @NonNull String fcmToken) {
-        logger.log("Successfully registered FCM");
-        sendJSEvent(constructJSMap(new Pair<>(VoiceEventType, VoiceEventRegistered)));
-        promise.resolve(null);
-      }
-
-      @Override
-      public void onError(@NonNull RegistrationException registrationException,
-                          @NonNull String accessToken,
-                          @NonNull String fcmToken) {
-        String errorMessage = reactContext.getString(
-          R.string.registration_error,
-          registrationException.getErrorCode(),
-          registrationException.getMessage());
-        logger.error(errorMessage);
-
-        sendJSEvent(constructJSMap(
-          new Pair<>(VoiceEventType, VoiceEventError),
-          new Pair<>(VoiceErrorKeyError, serializeVoiceException(registrationException))));
-
-        promise.reject(errorMessage);
-      }
-    };
-  }
-
-  private UnregistrationListener createUnregistrationListener(Promise promise) {
-    return new UnregistrationListener() {
-      @Override
-      public void onUnregistered(String accessToken, String fcmToken) {
-        logger.log("Successfully unregistered FCM");
-        sendJSEvent(constructJSMap(new Pair<>(VoiceEventType, VoiceEventUnregistered)));
-        promise.resolve(null);
-      }
-
-      @Override
-      public void onError(RegistrationException registrationException, String accessToken, String fcmToken) {
-        @SuppressLint("DefaultLocale")
-        String errorMessage = reactContext.getString(
-          R.string.unregistration_error,
-          registrationException.getErrorCode(),
-          registrationException.getMessage());
-        logger.error(errorMessage);
-
-        sendJSEvent(constructJSMap(
-          new Pair<>(VoiceEventType, VoiceEventError),
-          new Pair<>(VoiceErrorKeyError, serializeVoiceException(registrationException))));
-
-        promise.reject(errorMessage);
-      }
-    };
   }
 
   /**

--- a/android/src/main/res/values/config.xml
+++ b/android/src/main/res/values/config.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
   <bool name="twiliovoicereactnative_firebasemessagingservice_enabled">true</bool>
-  <bool name="twiliovoicereactnative_fullscreennotification_enabled">true</bool>
 </resources>

--- a/api/voice-react-native-sdk.api.md
+++ b/api/voice-react-native-sdk.api.md
@@ -1015,9 +1015,7 @@ export class Voice extends EventEmitter {
     getVersion(): Promise<string>;
     handleFirebaseMessage(remoteMessage: Record<string, string>): Promise<boolean>;
     initializePushRegistry(): Promise<void>;
-    isFullScreenNotificationEnabled(): Promise<boolean>;
     register(token: string): Promise<void>;
-    requestFullScreenNotificationPermission(): Promise<void>;
     setCallKitConfiguration(configuration: CallKit.ConfigurationOptions): Promise<void>;
     setIncomingCallContactHandleTemplate(template?: string): Promise<void>;
     showAvRoutePickerView(): Promise<void>;

--- a/src/Voice.tsx
+++ b/src/Voice.tsx
@@ -780,62 +780,6 @@ export class Voice extends EventEmitter {
   async setIncomingCallContactHandleTemplate(template?: string): Promise<void> {
     await NativeModule.voice_setIncomingCallContactHandleTemplate(template);
   }
-
-  /**
-   * Returns a boolean representing whether or not Android Full Screen
-   * notifications are enabled.
-   *
-   * @remarks
-   * Unsupported platforms:
-   *   - iOS
-   *
-   * @returns
-   * A `Promise` that
-   * - Resolves `false` if either of the following is true:
-   *   - Full Screen Notifications are disabled in your app's configuration.
-   *     See `docs/disable-full-screen-notifications.md` for more info.
-   *   - The app was not granted Full Screen Notification permissions by the
-   *     operating system.
-   * - Resolves `true` if none of the above is true.
-   * - Rejects if the Android layer encountered an error.
-   */
-  async isFullScreenNotificationEnabled(): Promise<boolean> {
-    switch (Platform.OS) {
-      case 'ios': {
-        throw new UnsupportedPlatformError(
-          `Unsupported platform "${Platform.OS}". This method is only supported on Android.`
-        );
-      }
-    }
-
-    return NativeModule.system_isFullScreenNotificationEnabled();
-  }
-
-  /**
-   * Opens the Android System Settings app to attempt to request Full Screen
-   * Notification permissions.
-   *
-   * @remarks
-   * Unsupported platforms:
-   * - iOS
-   *
-   * @returns
-   * A `Promise` that
-   * - Resolves `void` if the Android System Settings app was opened.
-   * - Rejects if the Android system encountered an error while trying to open
-   *   the System Settings app.
-   */
-  async requestFullScreenNotificationPermission(): Promise<void> {
-    switch (Platform.OS) {
-      case 'ios': {
-        throw new UnsupportedPlatformError(
-          `Unsupported platform "${Platform.OS}". This method is only supported on Android.`
-        );
-      }
-    }
-
-    return NativeModule.system_requestFullScreenNotificationPermission();
-  }
 }
 
 /**

--- a/src/__mocks__/common.ts
+++ b/src/__mocks__/common.ts
@@ -60,13 +60,6 @@ export const NativeModule = {
     .fn()
     .mockResolvedValue(undefined),
   voice_unregister: jest.fn().mockResolvedValue(undefined),
-
-  system_isFullScreenNotificationEnabled: jest
-    .fn()
-    .mockResolvedValue(undefined),
-  system_requestFullScreenNotificationPermission: jest
-    .fn()
-    .mockResolvedValue(undefined),
 };
 
 export class MockNativeEventEmitter extends EventEmitter {

--- a/src/__tests__/Voice.test.ts
+++ b/src/__tests__/Voice.test.ts
@@ -823,58 +823,6 @@ describe('Voice class', () => {
         ).resolves.toBeUndefined();
       });
     });
-
-    describe('.isFullScreenNotificationEnabled', () => {
-      it('invokes the native module', async () => {
-        jest.spyOn(Platform, 'OS', 'get').mockReturnValueOnce('android');
-        await new Voice().isFullScreenNotificationEnabled();
-        expect(
-          jest.mocked(MockNativeModule.system_isFullScreenNotificationEnabled)
-            .mock.calls
-        ).toEqual([[]]);
-      });
-
-      ([true, false] as boolean[]).forEach((b: boolean) => {
-        it(`resolves ${b} if the native module returns ${b}`, async () => {
-          jest.spyOn(Platform, 'OS', 'get').mockReturnValueOnce('android');
-          jest
-            .mocked(MockNativeModule.system_isFullScreenNotificationEnabled)
-            .mockResolvedValueOnce(b);
-          const result = new Voice().isFullScreenNotificationEnabled();
-          await expect(result).resolves.toStrictEqual(b);
-        });
-      });
-
-      it('rejects if the platform is unsupported', async () => {
-        jest.spyOn(Platform, 'OS', 'get').mockReturnValueOnce('ios');
-        const result = new Voice().isFullScreenNotificationEnabled();
-        await expect(result).rejects.toThrowError(UnsupportedPlatformError);
-      });
-    });
-
-    describe('.requestFullScreenNotificationPermission', () => {
-      it('invokes the native module', async () => {
-        jest.spyOn(Platform, 'OS', 'get').mockReturnValueOnce('android');
-        await new Voice().requestFullScreenNotificationPermission();
-        expect(
-          jest.mocked(
-            NativeModule.system_requestFullScreenNotificationPermission
-          ).mock.calls
-        ).toEqual([[]]);
-      });
-
-      it('resolves with undefined', async () => {
-        jest.spyOn(Platform, 'OS', 'get').mockReturnValue('android');
-        const result = new Voice().requestFullScreenNotificationPermission();
-        await expect(result).resolves.toBeUndefined();
-      });
-
-      it('rejects if the platform is unsupported', async () => {
-        jest.spyOn(Platform, 'OS', 'get').mockReturnValue('ios');
-        const result = new Voice().requestFullScreenNotificationPermission();
-        await expect(result).rejects.toThrowError(UnsupportedPlatformError);
-      });
-    });
   });
 
   describe('private methods', () => {

--- a/src/type/NativeModule.ts
+++ b/src/type/NativeModule.ts
@@ -84,10 +84,4 @@ export interface TwilioVoiceReactNative extends NativeModulesStatic {
   voice_selectAudioDevice(audioDeviceUuid: Uuid): Promise<void>;
   voice_showNativeAvRoutePicker(): Promise<void>;
   voice_unregister(accessToken: string): Promise<void>;
-
-  /**
-   * System/permissions related bindings.
-   */
-  system_isFullScreenNotificationEnabled(): Promise<boolean>;
-  system_requestFullScreenNotificationPermission(): Promise<void>;
 }

--- a/test/app/src/hook.ts
+++ b/test/app/src/hook.ts
@@ -19,13 +19,6 @@ import type {
 
 import { generateAccessToken } from './tokenUtility';
 
-export function settlePromise<T>(p: Promise<T>) {
-  const r = p
-    .then((value: T) => ({ status: 'resolved', value }))
-    .catch((value: any) => ({ status: 'rejected', value }));
-  return r;
-}
-
 export function useNoOp(usage: string) {
   return React.useCallback(() => {
     console.log(usage);
@@ -267,7 +260,7 @@ export function useCallInvites(
             removeCallInvite(callInvite.getCallSid());
             try {
               await callInvite.accept();
-            } catch (err: any) {
+            } catch (err) {
               const message = err.message;
               const code = err.code;
               logEvent(
@@ -388,7 +381,7 @@ export function useVoice(token: string) {
           },
         });
         callHandler(call);
-      } catch (err: any) {
+      } catch (err) {
         const message = err.message;
         const code = err.code;
         logEvent(
@@ -481,15 +474,6 @@ export function useVoice(token: string) {
     const bootstrap = async () => {
       if (Platform.OS === 'ios') {
         await voice.initializePushRegistry();
-      }
-
-      if (Platform.OS === 'android') {
-        const isFullScreen = await voice.isFullScreenNotificationEnabled();
-        if (!isFullScreen) {
-          const requestResult =
-            await settlePromise(voice.requestFullScreenNotificationPermission());
-          console.log(requestResult);
-        }
       }
 
       const calls = await voice.getCalls();


### PR DESCRIPTION
This reverts commit ca00e4135baf91914222448f344bf986b7519454.

## Submission Checklist

 - [x] Updated the `CHANGELOG.md` to reflect any **feature**, **bug fixes**, or **known issues** made in the source code
 - [x] Tested code changes and observed expected behavior in the example app
 - [x] Performed a visual inspection of the `Files changed` tab prior to submitting the pull request for review to ensure proper usage of the style guide

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Description

This PR reverts the fullscreenIntent option API due to OS limitations. Android devices will crash if the CallStyle notification Intent is not set to a fullScreenIntent. Therefore, this API, if used, will cause crashes.

## Breakdown

- Revert the ability to toggle off the "fullscreenIntent" API.

## Validation

- Manual testing with the test app.

## Additional Notes

N/A
