### PR TITLE
[VBLOCKS-5345] fix: runPreflight race condition

### DIFF
--- a/android/src/main/java/com/twiliovoicereactnative/TwilioVoiceReactNativeModule.java
+++ b/android/src/main/java/com/twiliovoicereactnative/TwilioVoiceReactNativeModule.java
@@ -799,9 +799,9 @@ public class TwilioVoiceReactNativeModule extends ReactContextBaseJavaModule {
         new PreflightTestListenerProxy(uuid));
 
       getPreflightTestRecordDatabase().setRecord(uuid, preflightTest);
-    });
 
-    promise.resolve(uuid.toString());
+      promise.resolve(uuid.toString());
+    });
   }
 
   // PreflightTest


### PR DESCRIPTION
## Submission Checklist

 - [ ] Updated the `CHANGELOG.md` to reflect any **feature**, **bug fixes**, or **known issues** made in the source code
 - [x] Tested code changes and observed expected behavior in the example app
 - [x] Performed a visual inspection of the `Files changed` tab prior to submitting the pull request for review to ensure proper usage of the style guide

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Description

This PR fixes a race condition in the preflightTest API in the Android native layer.

## Breakdown

- Adjust promise to be resolved after the preflighttestrecord has been created.

## Validation

- Locally ran e2e tests.

## Additional Notes

N/A
