### PR TITLE
[VBLOCKS-5356] Fix platform report discrepancies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 1.7.0 (In Progress)
 ===================
 
+## Features
+
+### PreflightTest
+
+- You can now perform a `PreflightTest` to help evaluate the quality of calls made on a device ahead of time. Please see this documentation for more details: [Mobile SDK PreflightTest](https://www.twilio.com/docs/voice/sdks/mobile-preflight-test).
+
 ## Changes
 
 ### Platform Specific Changes

--- a/src/PreflightTest.ts
+++ b/src/PreflightTest.ts
@@ -627,7 +627,7 @@ function parseCallQuality(nativeCallQuality: any) {
 function parseCallQualityAndroid(
   nativeCallQuality: string | null
 ): PreflightTest.CallQuality | null {
-  if (nativeCallQuality === null) {
+  if (typeof nativeCallQuality === 'undefined' || nativeCallQuality === null) {
     return null;
   }
 
@@ -654,7 +654,7 @@ function parseCallQualityAndroid(
 function parseCallQualityIos(
   nativeCallQuality: number | null
 ): PreflightTest.CallQuality | null {
-  if (nativeCallQuality === null) {
+  if (typeof nativeCallQuality === 'undefined' || nativeCallQuality === null) {
     return null;
   }
 
@@ -737,10 +737,10 @@ function parseSample(
 /**
  * Parse native "isTurnRequired" value.
  */
-function parseIsTurnRequired(isTurnRequired: any): boolean {
+function parseIsTurnRequired(isTurnRequired: any): boolean | null {
   switch (common.Platform.OS) {
     case 'android': {
-      return isTurnRequired as boolean;
+      return parseIsTurnRequiredAndroid(isTurnRequired);
     }
     case 'ios': {
       return parseIsTurnRequiredIos(isTurnRequired);
@@ -752,9 +752,34 @@ function parseIsTurnRequired(isTurnRequired: any): boolean {
 }
 
 /**
+ * Parse native "isTurnRequired" value on Android.
+ */
+function parseIsTurnRequiredAndroid(
+  isTurnRequired: boolean | undefined
+): boolean | null {
+  if (typeof isTurnRequired === 'undefined') {
+    return null;
+  }
+
+  if (typeof isTurnRequired !== 'boolean') {
+    throw new InvalidStateError(
+      `PreflightTest "isTurnRequired" not valid. Found "${isTurnRequired}".`
+    );
+  }
+
+  return isTurnRequired;
+}
+
+/**
  * Parse native "isTurnRequired" value on iOS.
  */
-function parseIsTurnRequiredIos(isTurnRequired: string): boolean {
+function parseIsTurnRequiredIos(
+  isTurnRequired: string | undefined
+): boolean | null {
+  if (typeof isTurnRequired === 'undefined') {
+    return null;
+  }
+
   if (typeof isTurnRequired !== 'string') {
     throw new InvalidStateError(
       'PreflightTest "isTurnRequired" not of type "string". ' +
@@ -832,7 +857,7 @@ function parseReport(rawReport: string): PreflightTest.Report {
     unprocessedReport.iceCandidates;
 
   // Note: iOS returns a string, Android returns a boolean
-  const isTurnRequired: boolean = parseIsTurnRequired(
+  const isTurnRequired: boolean | null = parseIsTurnRequired(
     unprocessedReport.isTurnRequired
   );
 

--- a/src/PreflightTest.ts
+++ b/src/PreflightTest.ts
@@ -607,7 +607,9 @@ function parseTimeMeasurement(nativeTimeMeasurement: {
 /**
  * Parse native call quality enum.
  */
-function parseCallQuality(nativeCallQuality: any) {
+function parseCallQuality(
+  nativeCallQuality: any
+): PreflightTest.CallQuality | null {
   switch (common.Platform.OS) {
     case 'android': {
       return parseCallQualityAndroid(nativeCallQuality);
@@ -625,7 +627,7 @@ function parseCallQuality(nativeCallQuality: any) {
  * Parse call quality value for Android platform.
  */
 function parseCallQualityAndroid(
-  nativeCallQuality: string | null
+  nativeCallQuality: string | undefined | null
 ): PreflightTest.CallQuality | null {
   if (typeof nativeCallQuality === 'undefined' || nativeCallQuality === null) {
     return null;
@@ -652,7 +654,7 @@ function parseCallQualityAndroid(
  * Parse call quality for iOS platform.
  */
 function parseCallQualityIos(
-  nativeCallQuality: number | null
+  nativeCallQuality: number | undefined | null
 ): PreflightTest.CallQuality | null {
   if (typeof nativeCallQuality === 'undefined' || nativeCallQuality === null) {
     return null;
@@ -755,9 +757,9 @@ function parseIsTurnRequired(isTurnRequired: any): boolean | null {
  * Parse native "isTurnRequired" value on Android.
  */
 function parseIsTurnRequiredAndroid(
-  isTurnRequired: boolean | undefined
+  isTurnRequired: boolean | undefined | null
 ): boolean | null {
-  if (typeof isTurnRequired === 'undefined') {
+  if (typeof isTurnRequired === 'undefined' || isTurnRequired === null) {
     return null;
   }
 
@@ -774,9 +776,9 @@ function parseIsTurnRequiredAndroid(
  * Parse native "isTurnRequired" value on iOS.
  */
 function parseIsTurnRequiredIos(
-  isTurnRequired: string | undefined
+  isTurnRequired: string | undefined | null
 ): boolean | null {
-  if (typeof isTurnRequired === 'undefined') {
+  if (typeof isTurnRequired === 'undefined' || isTurnRequired === null) {
     return null;
   }
 
@@ -802,7 +804,7 @@ function parseIsTurnRequiredIos(
  * Parse native warnings array.
  */
 function parseWarnings(
-  warnings: PreflightTest.Warning[] | undefined
+  warnings: PreflightTest.Warning[] | undefined | null
 ): PreflightTest.Warning[] {
   if (typeof warnings === 'undefined') {
     return [];
@@ -821,7 +823,7 @@ function parseWarnings(
  * Parse native warningsCleared array.
  */
 function parseWarningsCleared(
-  warningsCleared: PreflightTest.WarningCleared[] | undefined
+  warningsCleared: PreflightTest.WarningCleared[] | undefined | null
 ): PreflightTest.WarningCleared[] {
   if (typeof warningsCleared === 'undefined') {
     return [];

--- a/src/PreflightTest.ts
+++ b/src/PreflightTest.ts
@@ -806,7 +806,7 @@ function parseIsTurnRequiredIos(
 function parseWarnings(
   warnings: PreflightTest.Warning[] | undefined | null
 ): PreflightTest.Warning[] {
-  if (typeof warnings === 'undefined') {
+  if (typeof warnings === 'undefined' || warnings === null) {
     return [];
   }
 
@@ -825,7 +825,7 @@ function parseWarnings(
 function parseWarningsCleared(
   warningsCleared: PreflightTest.WarningCleared[] | undefined | null
 ): PreflightTest.WarningCleared[] {
-  if (typeof warningsCleared === 'undefined') {
+  if (typeof warningsCleared === 'undefined' || warningsCleared === null) {
     return [];
   }
 

--- a/src/Voice.tsx
+++ b/src/Voice.tsx
@@ -794,6 +794,60 @@ export class Voice extends EventEmitter {
    * information about the end user's network connection (including jitter,
    * packet loss, and round trip time) and connection settings.
    *
+   * @example
+   * ```typescript
+   * import {
+   *   AudioCodecType,
+   *   IceTransportPolicy,
+   *   PreflightTest,
+   *   Voice,
+   * } from '@twilio/voice-react-native-sdk';
+   *
+   * const voice = new Voice();
+   *
+   * const preflightOptions = {
+   *   iceServers: [{
+   *     username: 'foo',
+   *     password: 'bar',
+   *     serverUrl: 'biffbazz',
+   *   }],
+   *   iceTransportPolicy: IceTransportPolicy.All,
+   *   preferredAudioCodecs: [{
+   *     type: AudioCodecType.Opus,
+   *     maxAverageBitrage: 128000,
+   *   }],
+   * };
+   *
+   * const token = '...';
+   *
+   * const preflightTest = await voice.runPreflight(token, preflightOptions);
+   *
+   * preflightTest.on(PreflightTest.Event.Completed, (report) => {
+   *   // handle the completed event and update your application ui to
+   *   // show report results and reveal any potential issues
+   * });
+   *
+   * preflightTest.on(PreflightTest.Event.Connected, () => {
+   *   // handle the connected event and update your application ui to
+   *   // show that the preflight test has started
+   * });
+   *
+   * preflightTest.on(PreflightTest.Event.Failed, (error) => {
+   *   // handle the failed event and update your application ui to
+   *   // show the error
+   * });
+   *
+   * preflightTest.on(PreflightTest.Event.QualityWarning, (currentWarnings, previousWarnings) => {
+   *   // handle the quality warning event and update your application ui
+   *   // show the warning or the warning cleared
+   * });
+   *
+   * preflightTest.on(PreflightTest.Event.Sample, (sample) => {
+   *   // handle the sample event and update your application ui
+   *   // show the progress
+   * });
+   * ```
+   *
    * @returns
    * A Promise that:
    * - Resolves with a {@link (PreflightTest:class)} object.

--- a/src/__mock-data__/PreflightTest.ts
+++ b/src/__mock-data__/PreflightTest.ts
@@ -63,11 +63,22 @@ export const mockNetworkTiming = {
   preflightTest: mockTiming,
 };
 
+export const mockWarning = {
+  name: 'mock-warningname',
+  threshold: 'mock-warningthreshold',
+  timestamp: 10,
+  values: 'mock-warningvalues',
+};
+
+export const mockWarningCleared = {
+  name: 'mock-warningclearedname',
+  timestamp: 10,
+};
+
 export const baseMockReport = {
   callSid: 'mock-callsid',
   edge: 'mock-edge',
   iceCandidates: [mockRtcIceCandidateStats, mockRtcIceCandidateStats],
-  isTurnRequired: false,
   networkStats: mockPreflightRtcStats,
   networkTiming: mockNetworkTiming,
   statsSamples: [mockSample, mockSample],
@@ -76,30 +87,6 @@ export const baseMockReport = {
     localCandidate: mockRtcIceCandidateStats,
     remoteCandidate: mockRtcIceCandidateStats,
   },
-  warnings: [
-    {
-      name: 'mock-warningname',
-      threshold: 'mock-warningthreshold',
-      timestamp: 10,
-      values: 'mock-warningvalues',
-    },
-    {
-      name: 'mock-warningname',
-      threshold: 'mock-warningthreshold',
-      timestamp: 10,
-      values: 'mock-warningvalues',
-    },
-  ],
-  warningsCleared: [
-    {
-      name: 'mock-warningclearedname',
-      timestamp: 10,
-    },
-    {
-      name: 'mock-warningclearedname',
-      timestamp: 10,
-    },
-  ],
 };
 
 export const expectedReport: PreflightTest.Report = {

--- a/src/__mock-data__/PreflightTest.ts
+++ b/src/__mock-data__/PreflightTest.ts
@@ -87,6 +87,8 @@ export const baseMockReport = {
     localCandidate: mockRtcIceCandidateStats,
     remoteCandidate: mockRtcIceCandidateStats,
   },
+  warnings: [mockWarning, mockWarning],
+  warningsCleared: [mockWarningCleared, mockWarningCleared],
 };
 
 export const expectedReport: PreflightTest.Report = {

--- a/src/__tests__/PreflightTest.test.ts
+++ b/src/__tests__/PreflightTest.test.ts
@@ -722,6 +722,24 @@ describe('PreflightTest', () => {
           expect(report).toEqual({ ...expectedReport, callQuality: null });
         });
 
+        it('handles undefined native call quality', async () => {
+          jest
+            .spyOn(Common.NativeModule, 'preflightTest_getReport')
+            .mockResolvedValue(
+              JSON.stringify({
+                ...baseMockReport,
+                callQuality: undefined,
+                isTurnRequired: false,
+                warnings: [mockWarning, mockWarning],
+                warningsCleared: [mockWarningCleared, mockWarningCleared],
+              })
+            );
+
+          const report = await preflight.getReport();
+
+          expect(report).toEqual({ ...expectedReport, callQuality: null });
+        });
+
         it('throws if the native call quality is an invalid string', async () => {
           jest
             .spyOn(Common.NativeModule, 'preflightTest_getReport')
@@ -823,6 +841,44 @@ describe('PreflightTest', () => {
             await preflight.getReport();
           }).rejects.toBeInstanceOf(InvalidStateError);
         });
+
+        it('throws if "isTurnRequired" is not a boolean', async () => {
+          jest
+            .spyOn(Common.NativeModule, 'preflightTest_getReport')
+            .mockResolvedValue(
+              JSON.stringify({
+                ...baseMockReport,
+                isTurnRequired: 10,
+                warnings: [],
+                warningsCleared: [],
+              })
+            );
+
+          expect(async () => {
+            await preflight.getReport();
+          }).rejects.toBeInstanceOf(InvalidStateError);
+        });
+
+        it('reports null if "isTurnRequired" is undefined', async () => {
+          jest
+            .spyOn(Common.NativeModule, 'preflightTest_getReport')
+            .mockResolvedValue(
+              JSON.stringify({
+                ...baseMockReport,
+                callQuality: 'Excellent',
+                isTurnRequired: undefined,
+                warnings: [mockWarning, mockWarning],
+                warningsCleared: [mockWarningCleared, mockWarningCleared],
+              })
+            );
+
+          const report = await preflight.getReport();
+
+          expect(report).toEqual({
+            ...expectedReport,
+            isTurnRequired: null,
+          });
+        });
       });
 
       describe('ios', () => {
@@ -873,6 +929,24 @@ describe('PreflightTest', () => {
               JSON.stringify({
                 ...baseMockReport,
                 callQuality: null,
+                isTurnRequired: 'false',
+                warnings: [mockWarning, mockWarning],
+                warningsCleared: [mockWarningCleared, mockWarningCleared],
+              })
+            );
+
+          const report = await preflight.getReport();
+
+          expect(report).toEqual({ ...expectedReport, callQuality: null });
+        });
+
+        it('handles undefined native call quality', async () => {
+          jest
+            .spyOn(Common.NativeModule, 'preflightTest_getReport')
+            .mockResolvedValue(
+              JSON.stringify({
+                ...baseMockReport,
+                callQuality: undefined,
                 isTurnRequired: 'false',
                 warnings: [mockWarning, mockWarning],
                 warningsCleared: [mockWarningCleared, mockWarningCleared],
@@ -938,6 +1012,27 @@ describe('PreflightTest', () => {
           await expect(async () => {
             await preflight.getReport();
           }).rejects.toBeInstanceOf(InvalidStateError);
+        });
+
+        it('reports null if "isTurnRequired" is undefined', async () => {
+          jest
+            .spyOn(Common.NativeModule, 'preflightTest_getReport')
+            .mockResolvedValue(
+              JSON.stringify({
+                ...baseMockReport,
+                callQuality: 0,
+                isTurnRequired: undefined,
+                warnings: [mockWarning, mockWarning],
+                warningsCleared: [mockWarningCleared, mockWarningCleared],
+              })
+            );
+
+          const report = await preflight.getReport();
+
+          expect(report).toEqual({
+            ...expectedReport,
+            isTurnRequired: null,
+          });
         });
 
         it('reports an empty warnings array if native warnings is undefined', async () => {

--- a/src/__tests__/PreflightTest.test.ts
+++ b/src/__tests__/PreflightTest.test.ts
@@ -772,6 +772,26 @@ describe('PreflightTest', () => {
           });
         });
 
+        it('reports an empty warnings array if native warnings is null', async () => {
+          jest
+            .spyOn(Common.NativeModule, 'preflightTest_getReport')
+            .mockResolvedValue(
+              JSON.stringify({
+                ...baseMockReport,
+                callQuality: 'Excellent',
+                isTurnRequired: false,
+                warnings: null,
+              })
+            );
+
+          const report = await preflight.getReport();
+
+          expect(report).toEqual({
+            ...expectedReport,
+            warnings: [],
+          });
+        });
+
         it('reports an empty warningsCleared array if native warningsCleared is undefined', async () => {
           jest
             .spyOn(Common.NativeModule, 'preflightTest_getReport')
@@ -781,6 +801,26 @@ describe('PreflightTest', () => {
                 callQuality: 'Excellent',
                 isTurnRequired: false,
                 warningsCleared: undefined,
+              })
+            );
+
+          const report = await preflight.getReport();
+
+          expect(report).toEqual({
+            ...expectedReport,
+            warningsCleared: [],
+          });
+        });
+
+        it('reports an empty warningsCleared array if native warningsCleared is null', async () => {
+          jest
+            .spyOn(Common.NativeModule, 'preflightTest_getReport')
+            .mockResolvedValue(
+              JSON.stringify({
+                ...baseMockReport,
+                callQuality: 'Excellent',
+                isTurnRequired: false,
+                warningsCleared: null,
               })
             );
 
@@ -1067,6 +1107,26 @@ describe('PreflightTest', () => {
           });
         });
 
+        it('reports an empty warnings array if native warnings is null', async () => {
+          jest
+            .spyOn(Common.NativeModule, 'preflightTest_getReport')
+            .mockResolvedValue(
+              JSON.stringify({
+                ...baseMockReport,
+                callQuality: 0,
+                isTurnRequired: 'false',
+                warnings: null,
+              })
+            );
+
+          const report = await preflight.getReport();
+
+          expect(report).toEqual({
+            ...expectedReport,
+            warnings: [],
+          });
+        });
+
         it('reports an empty warningsCleared array if native warningsCleared is undefined', async () => {
           jest
             .spyOn(Common.NativeModule, 'preflightTest_getReport')
@@ -1076,6 +1136,26 @@ describe('PreflightTest', () => {
                 callQuality: 0,
                 isTurnRequired: 'false',
                 warningsCleared: undefined,
+              })
+            );
+
+          const report = await preflight.getReport();
+
+          expect(report).toEqual({
+            ...expectedReport,
+            warningsCleared: [],
+          });
+        });
+
+        it('reports an empty warningsCleared array if native warningsCleared is null', async () => {
+          jest
+            .spyOn(Common.NativeModule, 'preflightTest_getReport')
+            .mockResolvedValue(
+              JSON.stringify({
+                ...baseMockReport,
+                callQuality: 0,
+                isTurnRequired: 'false',
+                warningsCleared: null,
               })
             );
 

--- a/src/__tests__/PreflightTest.test.ts
+++ b/src/__tests__/PreflightTest.test.ts
@@ -13,8 +13,6 @@ import {
   makeMockNativePreflightEvent,
   mockSample,
   mockUuid,
-  mockWarning,
-  mockWarningCleared,
 } from '../__mock-data__/PreflightTest';
 
 jest.mock('../common');
@@ -247,8 +245,6 @@ describe('PreflightTest', () => {
               ...baseMockReport,
               callQuality: 'Excellent',
               isTurnRequired: false,
-              warnings: [mockWarning, mockWarning],
-              warningsCleared: [mockWarningCleared, mockWarningCleared],
             }),
           } as any);
 
@@ -277,8 +273,6 @@ describe('PreflightTest', () => {
               ...baseMockReport,
               callQuality: 0,
               isTurnRequired: 'false',
-              warnings: [mockWarning, mockWarning],
-              warningsCleared: [mockWarningCleared, mockWarningCleared],
             }),
           } as any);
 
@@ -694,8 +688,6 @@ describe('PreflightTest', () => {
                 ...baseMockReport,
                 callQuality: 'Excellent',
                 isTurnRequired: false,
-                warnings: [mockWarning, mockWarning],
-                warningsCleared: [mockWarningCleared, mockWarningCleared],
               })
             );
 
@@ -712,8 +704,6 @@ describe('PreflightTest', () => {
                 ...baseMockReport,
                 callQuality: null,
                 isTurnRequired: false,
-                warnings: [mockWarning, mockWarning],
-                warningsCleared: [mockWarningCleared, mockWarningCleared],
               })
             );
 
@@ -730,8 +720,6 @@ describe('PreflightTest', () => {
                 ...baseMockReport,
                 callQuality: undefined,
                 isTurnRequired: false,
-                warnings: [mockWarning, mockWarning],
-                warningsCleared: [mockWarningCleared, mockWarningCleared],
               })
             );
 
@@ -773,7 +761,6 @@ describe('PreflightTest', () => {
                 callQuality: 'Excellent',
                 isTurnRequired: false,
                 warnings: undefined,
-                warningsCleared: [mockWarningCleared, mockWarningCleared],
               })
             );
 
@@ -793,7 +780,6 @@ describe('PreflightTest', () => {
                 ...baseMockReport,
                 callQuality: 'Excellent',
                 isTurnRequired: false,
-                warnings: [mockWarning, mockWarning],
                 warningsCleared: undefined,
               })
             );
@@ -867,8 +853,25 @@ describe('PreflightTest', () => {
                 ...baseMockReport,
                 callQuality: 'Excellent',
                 isTurnRequired: undefined,
-                warnings: [mockWarning, mockWarning],
-                warningsCleared: [mockWarningCleared, mockWarningCleared],
+              })
+            );
+
+          const report = await preflight.getReport();
+
+          expect(report).toEqual({
+            ...expectedReport,
+            isTurnRequired: null,
+          });
+        });
+
+        it('reports null if "isTurnRequired" is null', async () => {
+          jest
+            .spyOn(Common.NativeModule, 'preflightTest_getReport')
+            .mockResolvedValue(
+              JSON.stringify({
+                ...baseMockReport,
+                callQuality: 'Excellent',
+                isTurnRequired: null,
               })
             );
 
@@ -894,8 +897,6 @@ describe('PreflightTest', () => {
                 ...baseMockReport,
                 callQuality: 0,
                 isTurnRequired: 'false',
-                warnings: [mockWarning, mockWarning],
-                warningsCleared: [mockWarningCleared, mockWarningCleared],
               })
             );
 
@@ -912,8 +913,6 @@ describe('PreflightTest', () => {
                 ...baseMockReport,
                 callQuality: 0,
                 isTurnRequired: 'false',
-                warnings: [mockWarning, mockWarning],
-                warningsCleared: [mockWarningCleared, mockWarningCleared],
               })
             );
 
@@ -930,8 +929,6 @@ describe('PreflightTest', () => {
                 ...baseMockReport,
                 callQuality: null,
                 isTurnRequired: 'false',
-                warnings: [mockWarning, mockWarning],
-                warningsCleared: [mockWarningCleared, mockWarningCleared],
               })
             );
 
@@ -948,8 +945,6 @@ describe('PreflightTest', () => {
                 ...baseMockReport,
                 callQuality: undefined,
                 isTurnRequired: 'false',
-                warnings: [mockWarning, mockWarning],
-                warningsCleared: [mockWarningCleared, mockWarningCleared],
               })
             );
 
@@ -1022,8 +1017,25 @@ describe('PreflightTest', () => {
                 ...baseMockReport,
                 callQuality: 0,
                 isTurnRequired: undefined,
-                warnings: [mockWarning, mockWarning],
-                warningsCleared: [mockWarningCleared, mockWarningCleared],
+              })
+            );
+
+          const report = await preflight.getReport();
+
+          expect(report).toEqual({
+            ...expectedReport,
+            isTurnRequired: null,
+          });
+        });
+
+        it('reports null if "isTurnRequired" is null', async () => {
+          jest
+            .spyOn(Common.NativeModule, 'preflightTest_getReport')
+            .mockResolvedValue(
+              JSON.stringify({
+                ...baseMockReport,
+                callQuality: 0,
+                isTurnRequired: null,
               })
             );
 
@@ -1044,7 +1056,6 @@ describe('PreflightTest', () => {
                 callQuality: 0,
                 isTurnRequired: 'false',
                 warnings: undefined,
-                warningsCleared: [mockWarningCleared, mockWarningCleared],
               })
             );
 
@@ -1064,7 +1075,6 @@ describe('PreflightTest', () => {
                 ...baseMockReport,
                 callQuality: 0,
                 isTurnRequired: 'false',
-                warnings: [mockWarning, mockWarning],
                 warningsCleared: undefined,
               })
             );

--- a/src/type/AudioCodec.ts
+++ b/src/type/AudioCodec.ts
@@ -23,7 +23,8 @@ export type OpusAudioCodec = {
    */
   [Constants.AudioCodecKeyType]: AudioCodecType.Opus;
   /**
-   * The max average bitrate for the codec.
+   * The max average bitrate for the codec. Value should be in the inclusive
+   * range `[6000, 510000]`.
    */
   [Constants.AudioCodecOpusKeyMaxAverageBitrate]?: number;
 };


### PR DESCRIPTION
## Submission Checklist

 - [x] Updated the `CHANGELOG.md` to reflect any **feature**, **bug fixes**, or **known issues** made in the source code
 - [x] Tested code changes and observed expected behavior in the example app
 - [x] Performed a visual inspection of the `Files changed` tab prior to submitting the pull request for review to ensure proper usage of the style guide

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Description

This PR fixes a discrepancy between iOS and Android such that the `isTurnRequired`, `warnings`, and `warningsCleared` members differed between platforms.

## Breakdown

- `warnings` and `warningsCleared` are always arrays. Previously, if they were empty on iOS, they would be `undefined`.
- `isTurnRequired` was a string on iOS and now properly a boolean.

## Validation

- Manual testing with test app.

## Additional Notes

N/A
