### PR TITLE
[VBLOCKS-5676] iOS promise rework

### DIFF
--- a/ios/TwilioVoiceReactNative+PromiseAdapter.m
+++ b/ios/TwilioVoiceReactNative+PromiseAdapter.m
@@ -1,0 +1,39 @@
+//
+//  TwilioVoiceReactNative+JsSerialization.m
+//  TwilioVoiceReactNative
+//
+//  Copyright © 2025 Twilio, Inc. All rights reserved.
+//
+
+#import "TwilioVoiceReactNative.h"
+#import "TwilioVoiceReactNativeConstants.h"
+
+@implementation TwilioVoiceReactNative (PromiseAdapter)
+
+- (void)resolvePromise:(RCTPromiseResolveBlock)resolver value:(id)value {
+    NSDictionary *payload = @{
+        kTwilioVoiceReactNativePromiseKeyStatus: kTwilioVoiceReactNativePromiseStatusValueResolved,
+        kTwilioVoiceReactNativePromiseKeyValue: value
+    };
+    resolver(payload);
+}
+
+- (void)rejectPromiseWithCode:(RCTPromiseResolveBlock)resolver code:(NSNumber *)code message:(NSString *)message {
+    NSDictionary *payload = @{
+        kTwilioVoiceReactNativePromiseKeyStatus: kTwilioVoiceReactNativePromiseStatusValueRejectedWithCode,
+        kTwilioVoiceReactNativePromiseKeyErrorCode: code,
+        kTwilioVoiceReactNativePromiseKeyErrorMessage: message
+    };
+    resolver(payload);
+}
+
+- (void)rejectPromiseWithName:(RCTPromiseResolveBlock)resolver name:(NSString *)name message:(NSString *)message {
+    NSDictionary *payload = @{
+        kTwilioVoiceReactNativePromiseKeyStatus: kTwilioVoiceReactNativePromiseStatusValueRejectedWithName,
+        kTwilioVoiceReactNativePromiseKeyErrorName: name,
+        kTwilioVoiceReactNativePromiseKeyErrorMessage: message
+    };
+    resolver(payload);
+}
+
+@end

--- a/ios/TwilioVoiceReactNative.h
+++ b/ios/TwilioVoiceReactNative.h
@@ -34,7 +34,7 @@ FOUNDATION_EXPORT NSString * const kTwilioVoiceReactNativeEventKeyCancelledCallI
 
 @property (nonatomic, copy) NSString *accessToken;
 @property (nonatomic, copy) NSDictionary *twimlParams;
-@property (nonatomic, strong) void(^callKitCompletionCallback)(BOOL);
+@property (nonatomic, strong) void(^callKitCompletionCallback)(BOOL, NSError *error);
 @property (nonatomic, strong) RCTPromiseResolveBlock callPromiseResolver;
 
 @property (nonatomic, strong) TVOPreflightTest *preflightTest;
@@ -71,12 +71,20 @@ FOUNDATION_EXPORT NSString * const kTwilioVoiceReactNativeEventKeyCancelledCallI
 - (void)endCallWithUuid:(NSUUID *)uuid;
 /* Initiate the answering from the app UI */
 - (void)answerCallInvite:(NSUUID *)uuid
-              completion:(void(^)(BOOL success))completionHandler;
+              completion:(void(^)(BOOL success, NSError *error))completionHandler;
 - (void)updateCall:(NSString *)uuid callerHandle:(NSString *)handle;
 
 /* Utility */
 - (NSDictionary *)callInfo:(TVOCall *)call;
 - (NSDictionary *)callInviteInfo:(TVOCallInvite *)callInvite;
 - (NSDictionary *)cancelledCallInviteInfo:(TVOCancelledCallInvite *)cancelledCallInvite;
+
+@end
+
+@interface TwilioVoiceReactNative (PromiseAdapter)
+
+- (void)resolvePromise:(RCTPromiseResolveBlock)resolver value:(id)value;
+- (void)rejectPromiseWithCode:(RCTPromiseResolveBlock)resolver code:(NSNumber *)code message:(NSString *)message;
+- (void)rejectPromiseWithName:(RCTPromiseResolveBlock)resolver name:(NSString *)name message:(NSString *)message;
 
 @end

--- a/ios/TwilioVoiceReactNative.xcodeproj/project.pbxproj
+++ b/ios/TwilioVoiceReactNative.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		6E0C49172E5F013000EA5CEB /* TwilioVoiceReactNative+PreflightTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 6E0C49162E5F013000EA5CEB /* TwilioVoiceReactNative+PreflightTest.m */; };
+		6EE3FDD42ECC45DD000FC4EC /* TwilioVoiceReactNative+PromiseAdapter.m in Sources */ = {isa = PBXBuildFile; fileRef = 6EE3FDD32ECC45CE000FC4EC /* TwilioVoiceReactNative+PromiseAdapter.m */; };
 		8F19C42D2683AE0200F765F1 /* TwilioVoicePushRegistry.m in Sources */ = {isa = PBXBuildFile; fileRef = 8F19C42C2683AE0200F765F1 /* TwilioVoicePushRegistry.m */; };
 		8FC9E80D2B74A4A100F5D778 /* TwilioVoiceReactNative+CallInvite.m in Sources */ = {isa = PBXBuildFile; fileRef = 8FC9E80C2B74A4A100F5D778 /* TwilioVoiceReactNative+CallInvite.m */; };
 		8FC9E80F2B74A57800F5D778 /* TwilioVoiceReactNative+CallMessage.m in Sources */ = {isa = PBXBuildFile; fileRef = 8FC9E80E2B74A57800F5D778 /* TwilioVoiceReactNative+CallMessage.m */; };
@@ -28,11 +29,11 @@
 /* Begin PBXFileReference section */
 		134814201AA4EA6300B7C361 /* libTwilioVoiceReactNative.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libTwilioVoiceReactNative.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		6E0C49162E5F013000EA5CEB /* TwilioVoiceReactNative+PreflightTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "TwilioVoiceReactNative+PreflightTest.m"; sourceTree = "<group>"; };
+		6EE3FDD32ECC45CE000FC4EC /* TwilioVoiceReactNative+PromiseAdapter.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "TwilioVoiceReactNative+PromiseAdapter.m"; sourceTree = "<group>"; };
 		8F19C42B2683AE0200F765F1 /* TwilioVoicePushRegistry.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TwilioVoicePushRegistry.h; sourceTree = "<group>"; };
 		8F19C42C2683AE0200F765F1 /* TwilioVoicePushRegistry.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TwilioVoicePushRegistry.m; sourceTree = "<group>"; };
 		8F5ED22E268D428F00572F00 /* TwilioVoiceReactNative+CallKit.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "TwilioVoiceReactNative+CallKit.m"; sourceTree = "<group>"; };
 		8F78B80726A100C4007AE617 /* TwilioVoiceReactNativeConstants.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TwilioVoiceReactNativeConstants.h; sourceTree = "<group>"; };
-		8F7D343C2AB01BF100B86D94 /* TwilioVoiceReactNativeVersion.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TwilioVoiceReactNativeVersion.h; sourceTree = "<group>"; };
 		8F9DA21A281A0EE900EBB341 /* TwilioVoiceStatsReport.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TwilioVoiceStatsReport.h; sourceTree = "<group>"; };
 		8FC9E80C2B74A4A100F5D778 /* TwilioVoiceReactNative+CallInvite.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "TwilioVoiceReactNative+CallInvite.m"; sourceTree = "<group>"; };
 		8FC9E80E2B74A57800F5D778 /* TwilioVoiceReactNative+CallMessage.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "TwilioVoiceReactNative+CallMessage.m"; sourceTree = "<group>"; };
@@ -70,8 +71,8 @@
 				8FC9E80C2B74A4A100F5D778 /* TwilioVoiceReactNative+CallInvite.m */,
 				8F5ED22E268D428F00572F00 /* TwilioVoiceReactNative+CallKit.m */,
 				8FC9E80E2B74A57800F5D778 /* TwilioVoiceReactNative+CallMessage.m */,
+				6EE3FDD32ECC45CE000FC4EC /* TwilioVoiceReactNative+PromiseAdapter.m */,
 				8F78B80726A100C4007AE617 /* TwilioVoiceReactNativeConstants.h */,
-				8F7D343C2AB01BF100B86D94 /* TwilioVoiceReactNativeVersion.h */,
 				134814211AA4EA7D00B7C361 /* Products */,
 				8F53CB6826794330002F8D61 /* Frameworks */,
 				6E0C49162E5F013000EA5CEB /* TwilioVoiceReactNative+PreflightTest.m */,
@@ -151,6 +152,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				8FC9E80F2B74A57800F5D778 /* TwilioVoiceReactNative+CallMessage.m in Sources */,
+				6EE3FDD42ECC45DD000FC4EC /* TwilioVoiceReactNative+PromiseAdapter.m in Sources */,
 				6E0C49172E5F013000EA5CEB /* TwilioVoiceReactNative+PreflightTest.m in Sources */,
 				8FC9E80D2B74A4A100F5D778 /* TwilioVoiceReactNative+CallInvite.m in Sources */,
 				8F19C42D2683AE0200F765F1 /* TwilioVoicePushRegistry.m in Sources */,


### PR DESCRIPTION
## Submission Checklist

 - [ ] Updated the `CHANGELOG.md` to reflect any **feature**, **bug fixes**, or **known issues** made in the source code
 - [x] Tested code changes and observed expected behavior in the example app
 - [x] Performed a visual inspection of the `Files changed` tab prior to submitting the pull request for review to ensure proper usage of the style guide

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Description

This PR modifies the iOS layer promise resolution/rejection so that native method invocation is determined by a tagged union instead of resolution/rejection. We need this because Expo promise rejection does not accept the `userInfo` parameter and we cannot send extra info to the JS layer.

## Breakdown

- Don't use promise reject in iOS.
- Send success and failure cases via a tagged union to the JS layer.

## Validation

- Manually tested with test app.

## Additional Notes

N/A
