### PR TITLE
[VBLOCKS-5677] feat: match js layer to native promise rework

### DIFF
--- a/src/AudioDevice.tsx
+++ b/src/AudioDevice.tsx
@@ -62,8 +62,8 @@ export class AudioDevice {
    *      selected as the active audio device.
    *    - Rejects if the audio device cannot be selected.
    */
-  select(): Promise<void> {
-    return NativeModule.voice_selectAudioDevice(this.uuid);
+  async select(): Promise<void> {
+    await NativeModule.voice_selectAudioDevice(this.uuid);
   }
 }
 

--- a/src/PreflightTest.ts
+++ b/src/PreflightTest.ts
@@ -14,6 +14,7 @@ import { constructTwilioError } from './error/utility';
 import type { AudioCodec } from './type/AudioCodec';
 import type { IceServer, IceTransportPolicy } from './type/Ice';
 import type * as PreflightTestType from './type/PreflightTest';
+import { settleNativePromise } from './utility/nativePromise';
 
 export interface PreflightTest {
   /**
@@ -457,24 +458,6 @@ export class PreflightTest extends EventEmitter {
   };
 
   /**
-   * Internal helper method to invoke a native method and handle the returned
-   * promise from the native method.
-   */
-  private async _invokeAndCatchNativeMethod<T>(
-    method: (uuid: string) => Promise<T>
-  ) {
-    return method(this._uuid).catch((error: any): never => {
-      if (typeof error.code === 'number' && error.message)
-        throw constructTwilioError(error.message, error.code);
-
-      if (error.code === Constants.ErrorCodeInvalidStateError)
-        throw new InvalidStateError(error.message);
-
-      throw error;
-    });
-  }
-
-  /**
    * Get the CallSid of the underlying Call in the PreflightTest.
    *
    * @returns
@@ -484,9 +467,10 @@ export class PreflightTest extends EventEmitter {
    *   PreflightTest object.
    */
   public async getCallSid(): Promise<string> {
-    return this._invokeAndCatchNativeMethod(
-      common.NativeModule.preflightTest_getCallSid
+    const callSid = await settleNativePromise(
+      common.NativeModule.preflightTest_getCallSid(this._uuid)
     );
+    return callSid;
   }
 
   /**
@@ -499,9 +483,10 @@ export class PreflightTest extends EventEmitter {
    * - Rejects if the native layer encountered an error.
    */
   public async getEndTime(): Promise<number> {
-    return this._invokeAndCatchNativeMethod(
-      common.NativeModule.preflightTest_getEndTime
+    const endTime = await settleNativePromise(
+      common.NativeModule.preflightTest_getEndTime(this._uuid)
     ).then(Number);
+    return endTime;
   }
 
   /**
@@ -515,12 +500,13 @@ export class PreflightTest extends EventEmitter {
    * - Rejects if the native layer encountered an error.
    */
   public async getLatestSample(): Promise<PreflightTest.RTCSample> {
-    return this._invokeAndCatchNativeMethod(
-      common.NativeModule.preflightTest_getLatestSample
+    const sample = await settleNativePromise(
+      common.NativeModule.preflightTest_getLatestSample(this._uuid)
     ).then((sampleStr) => {
       const sampleObj = JSON.parse(sampleStr);
       return parseSample(sampleObj);
     });
+    return sample;
   }
 
   /**
@@ -533,9 +519,10 @@ export class PreflightTest extends EventEmitter {
    * - Rejects if the native layer encountered an error.
    */
   public async getReport(): Promise<PreflightTest.Report> {
-    return this._invokeAndCatchNativeMethod(
-      common.NativeModule.preflightTest_getReport
+    const report = await settleNativePromise(
+      common.NativeModule.preflightTest_getReport(this._uuid)
     ).then(parseReport);
+    return report;
   }
 
   /**
@@ -548,9 +535,10 @@ export class PreflightTest extends EventEmitter {
    * - Rejects if the native layer encountered an error.
    */
   public async getStartTime(): Promise<number> {
-    return this._invokeAndCatchNativeMethod(
-      common.NativeModule.preflightTest_getStartTime
+    const startTime = await settleNativePromise(
+      common.NativeModule.preflightTest_getStartTime(this._uuid)
     ).then(Number);
+    return startTime;
   }
 
   /**
@@ -562,9 +550,10 @@ export class PreflightTest extends EventEmitter {
    * - Rejects if the native layer encountered an error.
    */
   public async getState(): Promise<PreflightTest.State> {
-    return this._invokeAndCatchNativeMethod(
-      common.NativeModule.preflightTest_getState
+    const state = await settleNativePromise(
+      common.NativeModule.preflightTest_getState(this._uuid)
     ).then(parseState);
+    return state;
   }
 
   /**
@@ -576,8 +565,8 @@ export class PreflightTest extends EventEmitter {
    * - Rejects if the native layer encountered an error.
    */
   public async stop(): Promise<void> {
-    return this._invokeAndCatchNativeMethod(
-      common.NativeModule.preflightTest_stop
+    await settleNativePromise(
+      common.NativeModule.preflightTest_stop(this._uuid)
     );
   }
 }

--- a/src/__mocks__/common.ts
+++ b/src/__mocks__/common.ts
@@ -9,58 +9,99 @@ import { createNativeAudioDevicesInfo } from './AudioDevice';
 import { createNativeCallInfo } from './Call';
 import { createNativeCallInviteInfo } from './CallInvite';
 import { createStatsReport } from './RTCStats';
+import { Constants } from '../constants';
+
+export function mockNativePromiseResolutionValue(value: any) {
+  return {
+    [Constants.PromiseKeyStatus]: Constants.PromiseStatusValueResolved as const,
+    [Constants.PromiseKeyValue]: value,
+  };
+}
+
+export function mockNativePromiseRejectionWithNameValue(
+  name:
+    | Constants.ErrorCodeInvalidArgumentError
+    | Constants.ErrorCodeInvalidStateError,
+  message: string
+) {
+  return {
+    [Constants.PromiseKeyStatus]:
+      Constants.PromiseStatusValueRejectedWithName as const,
+    [Constants.PromiseKeyErrorName]: name,
+    [Constants.PromiseKeyErrorMessage]: message,
+  };
+}
+
+export function mockNativePromiseRejectionWithCodeValue(
+  code: number,
+  message: string
+) {
+  return {
+    [Constants.PromiseKeyStatus]:
+      Constants.PromiseStatusValueRejectedWithCode as const,
+    [Constants.PromiseKeyErrorCode]: code,
+    [Constants.PromiseKeyErrorMessage]: message,
+  };
+}
+
+function createMockWithResolvedValue(value: any) {
+  return jest.fn().mockResolvedValue(mockNativePromiseResolutionValue(value));
+}
 
 export const NativeModule = {
   /**
    * Call Mocks
    */
-  call_disconnect: jest.fn().mockResolvedValue(undefined),
-  call_getStats: jest.fn().mockResolvedValue(createStatsReport()),
-  call_hold: jest.fn((_uuid: Uuid, hold: boolean) => Promise.resolve(hold)),
-  call_isMuted: jest.fn().mockResolvedValue(false),
-  call_isOnHold: jest.fn().mockResolvedValue(false),
-  call_mute: jest.fn((_uuid: Uuid, mute: boolean) => Promise.resolve(mute)),
-  call_postFeedback: jest.fn().mockResolvedValue(undefined),
-  call_sendDigits: jest.fn().mockResolvedValue(undefined),
-  call_sendMessage: jest
-    .fn()
-    .mockResolvedValue('mock-nativemodule-tracking-id'),
+  call_disconnect: createMockWithResolvedValue(undefined),
+  call_getStats: createMockWithResolvedValue(createStatsReport()),
+  call_hold: jest.fn((_uuid: Uuid, hold: boolean) =>
+    Promise.resolve(mockNativePromiseResolutionValue(hold))
+  ),
+  call_isMuted: createMockWithResolvedValue(false),
+  call_isOnHold: createMockWithResolvedValue(false),
+  call_mute: jest.fn((_uuid: Uuid, mute: boolean) =>
+    Promise.resolve(mockNativePromiseResolutionValue(mute))
+  ),
+  call_postFeedback: createMockWithResolvedValue(undefined),
+  call_sendDigits: createMockWithResolvedValue(undefined),
+  call_sendMessage: createMockWithResolvedValue(
+    'mock-nativemodule-tracking-id'
+  ),
 
   /**
    * Call Invite Mocks
    */
-  callInvite_accept: jest.fn().mockResolvedValue(createNativeCallInfo()),
-  callInvite_isValid: jest.fn().mockResolvedValue(false),
-  callInvite_reject: jest.fn().mockResolvedValue(undefined),
-  callInvite_updateCallerHandle: jest.fn().mockResolvedValue(undefined),
+  callInvite_accept: createMockWithResolvedValue(createNativeCallInfo()),
+  callInvite_isValid: createMockWithResolvedValue(false),
+  callInvite_reject: createMockWithResolvedValue(undefined),
+  callInvite_updateCallerHandle: createMockWithResolvedValue(undefined),
 
   /**
    * Voice Mocks
    */
-  voice_connect_android: jest.fn().mockResolvedValue(createNativeCallInfo()),
-  voice_connect_ios: jest.fn().mockResolvedValue(createNativeCallInfo()),
-  voice_getAudioDevices: jest
-    .fn()
-    .mockResolvedValue(createNativeAudioDevicesInfo()),
-  voice_getCalls: jest.fn().mockResolvedValue([createNativeCallInfo()]),
-  voice_getCallInvites: jest
-    .fn()
-    .mockResolvedValue([createNativeCallInviteInfo()]),
-  voice_getDeviceToken: jest
-    .fn()
-    .mockResolvedValue('mock-nativemodule-devicetoken'),
-  voice_getVersion: jest.fn().mockResolvedValue('mock-nativemodule-version'),
-  voice_handleEvent: jest.fn().mockResolvedValue(true),
-  voice_initializePushRegistry: jest.fn().mockResolvedValue(undefined),
-  voice_register: jest.fn().mockResolvedValue(undefined),
-  voice_selectAudioDevice: jest.fn().mockResolvedValue(undefined),
-  voice_setCallKitConfiguration: jest.fn().mockResolvedValue(undefined),
-  voice_showNativeAvRoutePicker: jest.fn().mockResolvedValue(undefined),
-  voice_setIncomingCallContactHandleTemplate: jest
-    .fn()
-    .mockResolvedValue(undefined),
-  voice_unregister: jest.fn().mockResolvedValue(undefined),
-  voice_runPreflight: jest.fn().mockResolvedValue(undefined),
+  voice_connect_android: createMockWithResolvedValue(createNativeCallInfo()),
+  voice_connect_ios: createMockWithResolvedValue(createNativeCallInfo()),
+  voice_getAudioDevices: createMockWithResolvedValue(
+    createNativeAudioDevicesInfo()
+  ),
+  voice_getCalls: createMockWithResolvedValue([createNativeCallInfo()]),
+  voice_getCallInvites: createMockWithResolvedValue([
+    createNativeCallInviteInfo(),
+  ]),
+  voice_getDeviceToken: createMockWithResolvedValue(
+    'mock-nativemodule-devicetoken'
+  ),
+  voice_getVersion: createMockWithResolvedValue('mock-nativemodule-version'),
+  voice_handleEvent: createMockWithResolvedValue(true),
+  voice_initializePushRegistry: createMockWithResolvedValue(undefined),
+  voice_register: createMockWithResolvedValue(undefined),
+  voice_selectAudioDevice: createMockWithResolvedValue(undefined),
+  voice_setCallKitConfiguration: createMockWithResolvedValue(undefined),
+  voice_showNativeAvRoutePicker: createMockWithResolvedValue(undefined),
+  voice_setIncomingCallContactHandleTemplate:
+    createMockWithResolvedValue(undefined),
+  voice_unregister: createMockWithResolvedValue(undefined),
+  voice_runPreflight: createMockWithResolvedValue(undefined),
 
   /**
    * PreflightTest mocks.

--- a/src/__tests__/CallInvite.test.ts
+++ b/src/__tests__/CallInvite.test.ts
@@ -3,7 +3,10 @@ import {
   createNativeCallInviteInfo,
   createMockNativeCallInviteEvents,
 } from '../__mocks__/CallInvite';
-import type { NativeEventEmitter as MockNativeEventEmitterType } from '../__mocks__/common';
+import {
+  mockNativePromiseRejectionWithCodeValue,
+  NativeEventEmitter as MockNativeEventEmitterType,
+} from '../__mocks__/common';
 import { Call } from '../Call';
 import { CallInvite } from '../CallInvite';
 import { IncomingCallMessage } from '../CallMessage/IncomingCallMessage';
@@ -293,12 +296,14 @@ describe('CallInvite class', () => {
         CallInvite.State.Pending
       );
 
-      jest.mocked(NativeModule.callInvite_accept).mockRejectedValueOnce({
-        userInfo: {
-          code: 31401,
-          message: 'Missing permissions.',
-        },
-      });
+      const errorPayload = mockNativePromiseRejectionWithCodeValue(
+        31401,
+        'Missing permissions.'
+      );
+
+      jest
+        .mocked(NativeModule.callInvite_accept)
+        .mockResolvedValueOnce(errorPayload);
 
       expect.assertions(1);
       await callPromise.accept(acceptOptions).catch((error) => {

--- a/src/__tests__/PreflightTest.test.ts
+++ b/src/__tests__/PreflightTest.test.ts
@@ -14,6 +14,7 @@ import {
   mockSample,
   mockUuid,
 } from '../__mock-data__/PreflightTest';
+import { mockNativePromiseResolutionValue } from '../__mocks__/common';
 
 jest.mock('../common');
 
@@ -468,76 +469,6 @@ describe('PreflightTest', () => {
         ]);
       });
     });
-
-    describe('_invokeAndCatchNativeMethod', () => {
-      it('passes the uuid to the wrapped method', () => {
-        const preflight = new PreflightTest(mockUuid);
-
-        const spy = jest.fn(async () => {});
-
-        preflight['_invokeAndCatchNativeMethod'](spy);
-
-        expect(spy.mock.calls).toEqual([[mockUuid]]);
-      });
-
-      it('does not affect the resolved value', async () => {
-        const preflight = new PreflightTest(mockUuid);
-
-        const spy = jest.fn(async () => ({ biff: 'bazz' }));
-
-        await expect(
-          preflight['_invokeAndCatchNativeMethod'](spy)
-        ).resolves.toEqual({
-          biff: 'bazz',
-        });
-      });
-
-      it('handles a valid code and message', async () => {
-        const preflight = new PreflightTest(mockUuid);
-
-        const spy = jest.fn(async () => {
-          throw {
-            code: 100,
-            message: 'foobar',
-          };
-        });
-
-        await expect(
-          preflight['_invokeAndCatchNativeMethod'](spy)
-        ).rejects.toBeInstanceOf(TwilioError);
-      });
-
-      it('handles an invalid state error', async () => {
-        const preflight = new PreflightTest(mockUuid);
-
-        const spy = jest.fn(async () => {
-          throw {
-            code: Constants.ErrorCodeInvalidStateError,
-            message: 'foobar',
-          };
-        });
-
-        await expect(
-          preflight['_invokeAndCatchNativeMethod'](spy)
-        ).rejects.toBeInstanceOf(InvalidStateError);
-      });
-
-      it('handles any other type of error', async () => {
-        const preflight = new PreflightTest(mockUuid);
-
-        const spy = jest.fn(async () => {
-          throw {
-            foo: 'bar',
-          };
-        });
-
-        await expect(
-          preflight['_invokeAndCatchNativeMethod'](spy)
-        ).rejects.toEqual({
-          foo: 'bar',
-        });
-      });
-    });
   });
 
   describe('public methods', () => {
@@ -551,7 +482,7 @@ describe('PreflightTest', () => {
       it('invokes the native module', async () => {
         const spy = jest
           .spyOn(Common.NativeModule, 'preflightTest_getCallSid')
-          .mockResolvedValue('mock-callsid');
+          .mockResolvedValue(mockNativePromiseResolutionValue('mock-callsid'));
 
         await preflight.getCallSid();
 
@@ -565,7 +496,7 @@ describe('PreflightTest', () => {
       beforeEach(() => {
         spy = jest
           .spyOn(Common.NativeModule, 'preflightTest_getEndTime')
-          .mockResolvedValue('100');
+          .mockResolvedValue(mockNativePromiseResolutionValue('100'));
       });
 
       it('invokes the native module', async () => {
@@ -587,7 +518,9 @@ describe('PreflightTest', () => {
       beforeEach(() => {
         spy = jest
           .spyOn(Common.NativeModule, 'preflightTest_getLatestSample')
-          .mockResolvedValue(JSON.stringify(mockSample));
+          .mockResolvedValue(
+            mockNativePromiseResolutionValue(JSON.stringify(mockSample))
+          );
       });
 
       it('invokes the native module', async () => {
@@ -627,10 +560,12 @@ describe('PreflightTest', () => {
           jest
             .spyOn(Common.NativeModule, 'preflightTest_getReport')
             .mockImplementation(async () =>
-              JSON.stringify({
-                ...baseMockReport,
-                callQuality: 'foobar',
-              })
+              mockNativePromiseResolutionValue(
+                JSON.stringify({
+                  ...baseMockReport,
+                  callQuality: 'foobar',
+                })
+              )
             );
 
           await expect(async () => {
@@ -651,10 +586,12 @@ describe('PreflightTest', () => {
           jest
             .spyOn(Common.NativeModule, 'preflightTest_getReport')
             .mockImplementation(async () =>
-              JSON.stringify({
-                ...baseMockReport,
-                callQuality: 'Excellent',
-              })
+              mockNativePromiseResolutionValue(
+                JSON.stringify({
+                  ...baseMockReport,
+                  callQuality: 'Excellent',
+                })
+              )
             );
 
           await expect(async () => {
@@ -672,7 +609,9 @@ describe('PreflightTest', () => {
           const spy = jest
             .spyOn(Common.NativeModule, 'preflightTest_getReport')
             .mockResolvedValue(
-              JSON.stringify({ ...baseMockReport, callQuality: 'Excellent' })
+              mockNativePromiseResolutionValue(
+                JSON.stringify({ ...baseMockReport, callQuality: 'Excellent' })
+              )
             );
 
           await preflight.getReport();
@@ -684,11 +623,13 @@ describe('PreflightTest', () => {
           jest
             .spyOn(Common.NativeModule, 'preflightTest_getReport')
             .mockResolvedValue(
-              JSON.stringify({
-                ...baseMockReport,
-                callQuality: 'Excellent',
-                isTurnRequired: false,
-              })
+              mockNativePromiseResolutionValue(
+                JSON.stringify({
+                  ...baseMockReport,
+                  callQuality: 'Excellent',
+                  isTurnRequired: false,
+                })
+              )
             );
 
           const report = await preflight.getReport();
@@ -700,11 +641,13 @@ describe('PreflightTest', () => {
           jest
             .spyOn(Common.NativeModule, 'preflightTest_getReport')
             .mockResolvedValue(
-              JSON.stringify({
-                ...baseMockReport,
-                callQuality: null,
-                isTurnRequired: false,
-              })
+              mockNativePromiseResolutionValue(
+                JSON.stringify({
+                  ...baseMockReport,
+                  callQuality: null,
+                  isTurnRequired: false,
+                })
+              )
             );
 
           const report = await preflight.getReport();
@@ -716,11 +659,13 @@ describe('PreflightTest', () => {
           jest
             .spyOn(Common.NativeModule, 'preflightTest_getReport')
             .mockResolvedValue(
-              JSON.stringify({
-                ...baseMockReport,
-                callQuality: undefined,
-                isTurnRequired: false,
-              })
+              mockNativePromiseResolutionValue(
+                JSON.stringify({
+                  ...baseMockReport,
+                  callQuality: undefined,
+                  isTurnRequired: false,
+                })
+              )
             );
 
           const report = await preflight.getReport();
@@ -732,7 +677,9 @@ describe('PreflightTest', () => {
           jest
             .spyOn(Common.NativeModule, 'preflightTest_getReport')
             .mockResolvedValue(
-              JSON.stringify({ ...baseMockReport, callQuality: 'foobar' })
+              mockNativePromiseResolutionValue(
+                JSON.stringify({ ...baseMockReport, callQuality: 'foobar' })
+              )
             );
 
           await expect(async () => {
@@ -744,7 +691,9 @@ describe('PreflightTest', () => {
           jest
             .spyOn(Common.NativeModule, 'preflightTest_getReport')
             .mockResolvedValue(
-              JSON.stringify({ ...baseMockReport, callQuality: 10 })
+              mockNativePromiseResolutionValue(
+                JSON.stringify({ ...baseMockReport, callQuality: 10 })
+              )
             );
 
           await expect(async () => {
@@ -756,12 +705,14 @@ describe('PreflightTest', () => {
           jest
             .spyOn(Common.NativeModule, 'preflightTest_getReport')
             .mockResolvedValue(
-              JSON.stringify({
-                ...baseMockReport,
-                callQuality: 'Excellent',
-                isTurnRequired: false,
-                warnings: undefined,
-              })
+              mockNativePromiseResolutionValue(
+                JSON.stringify({
+                  ...baseMockReport,
+                  callQuality: 'Excellent',
+                  isTurnRequired: false,
+                  warnings: undefined,
+                })
+              )
             );
 
           const report = await preflight.getReport();
@@ -776,12 +727,14 @@ describe('PreflightTest', () => {
           jest
             .spyOn(Common.NativeModule, 'preflightTest_getReport')
             .mockResolvedValue(
-              JSON.stringify({
-                ...baseMockReport,
-                callQuality: 'Excellent',
-                isTurnRequired: false,
-                warnings: null,
-              })
+              mockNativePromiseResolutionValue(
+                JSON.stringify({
+                  ...baseMockReport,
+                  callQuality: 'Excellent',
+                  isTurnRequired: false,
+                  warnings: null,
+                })
+              )
             );
 
           const report = await preflight.getReport();
@@ -796,12 +749,14 @@ describe('PreflightTest', () => {
           jest
             .spyOn(Common.NativeModule, 'preflightTest_getReport')
             .mockResolvedValue(
-              JSON.stringify({
-                ...baseMockReport,
-                callQuality: 'Excellent',
-                isTurnRequired: false,
-                warningsCleared: undefined,
-              })
+              mockNativePromiseResolutionValue(
+                JSON.stringify({
+                  ...baseMockReport,
+                  callQuality: 'Excellent',
+                  isTurnRequired: false,
+                  warningsCleared: undefined,
+                })
+              )
             );
 
           const report = await preflight.getReport();
@@ -816,12 +771,14 @@ describe('PreflightTest', () => {
           jest
             .spyOn(Common.NativeModule, 'preflightTest_getReport')
             .mockResolvedValue(
-              JSON.stringify({
-                ...baseMockReport,
-                callQuality: 'Excellent',
-                isTurnRequired: false,
-                warningsCleared: null,
-              })
+              mockNativePromiseResolutionValue(
+                JSON.stringify({
+                  ...baseMockReport,
+                  callQuality: 'Excellent',
+                  isTurnRequired: false,
+                  warningsCleared: null,
+                })
+              )
             );
 
           const report = await preflight.getReport();
@@ -836,13 +793,15 @@ describe('PreflightTest', () => {
           jest
             .spyOn(Common.NativeModule, 'preflightTest_getReport')
             .mockResolvedValue(
-              JSON.stringify({
-                ...baseMockReport,
-                callQuality: 'Excellent',
-                isTurnRequired: false,
-                warnings: 'foobar',
-                warningsCleared: undefined,
-              })
+              mockNativePromiseResolutionValue(
+                JSON.stringify({
+                  ...baseMockReport,
+                  callQuality: 'Excellent',
+                  isTurnRequired: false,
+                  warnings: 'foobar',
+                  warningsCleared: undefined,
+                })
+              )
             );
 
           expect(async () => {
@@ -854,13 +813,15 @@ describe('PreflightTest', () => {
           jest
             .spyOn(Common.NativeModule, 'preflightTest_getReport')
             .mockResolvedValue(
-              JSON.stringify({
-                ...baseMockReport,
-                callQuality: 'Excellent',
-                isTurnRequired: false,
-                warnings: undefined,
-                warningsCleared: 'foobar',
-              })
+              mockNativePromiseResolutionValue(
+                JSON.stringify({
+                  ...baseMockReport,
+                  callQuality: 'Excellent',
+                  isTurnRequired: false,
+                  warnings: undefined,
+                  warningsCleared: 'foobar',
+                })
+              )
             );
 
           expect(async () => {
@@ -872,12 +833,14 @@ describe('PreflightTest', () => {
           jest
             .spyOn(Common.NativeModule, 'preflightTest_getReport')
             .mockResolvedValue(
-              JSON.stringify({
-                ...baseMockReport,
-                isTurnRequired: 10,
-                warnings: [],
-                warningsCleared: [],
-              })
+              mockNativePromiseResolutionValue(
+                JSON.stringify({
+                  ...baseMockReport,
+                  isTurnRequired: 10,
+                  warnings: [],
+                  warningsCleared: [],
+                })
+              )
             );
 
           expect(async () => {
@@ -889,11 +852,13 @@ describe('PreflightTest', () => {
           jest
             .spyOn(Common.NativeModule, 'preflightTest_getReport')
             .mockResolvedValue(
-              JSON.stringify({
-                ...baseMockReport,
-                callQuality: 'Excellent',
-                isTurnRequired: undefined,
-              })
+              mockNativePromiseResolutionValue(
+                JSON.stringify({
+                  ...baseMockReport,
+                  callQuality: 'Excellent',
+                  isTurnRequired: undefined,
+                })
+              )
             );
 
           const report = await preflight.getReport();
@@ -908,11 +873,13 @@ describe('PreflightTest', () => {
           jest
             .spyOn(Common.NativeModule, 'preflightTest_getReport')
             .mockResolvedValue(
-              JSON.stringify({
-                ...baseMockReport,
-                callQuality: 'Excellent',
-                isTurnRequired: null,
-              })
+              mockNativePromiseResolutionValue(
+                JSON.stringify({
+                  ...baseMockReport,
+                  callQuality: 'Excellent',
+                  isTurnRequired: null,
+                })
+              )
             );
 
           const report = await preflight.getReport();
@@ -933,11 +900,13 @@ describe('PreflightTest', () => {
           const spy = jest
             .spyOn(Common.NativeModule, 'preflightTest_getReport')
             .mockResolvedValue(
-              JSON.stringify({
-                ...baseMockReport,
-                callQuality: 0,
-                isTurnRequired: 'false',
-              })
+              mockNativePromiseResolutionValue(
+                JSON.stringify({
+                  ...baseMockReport,
+                  callQuality: 0,
+                  isTurnRequired: 'false',
+                })
+              )
             );
 
           await preflight.getReport();
@@ -949,11 +918,13 @@ describe('PreflightTest', () => {
           jest
             .spyOn(Common.NativeModule, 'preflightTest_getReport')
             .mockResolvedValue(
-              JSON.stringify({
-                ...baseMockReport,
-                callQuality: 0,
-                isTurnRequired: 'false',
-              })
+              mockNativePromiseResolutionValue(
+                JSON.stringify({
+                  ...baseMockReport,
+                  callQuality: 0,
+                  isTurnRequired: 'false',
+                })
+              )
             );
 
           const report = await preflight.getReport();
@@ -965,11 +936,13 @@ describe('PreflightTest', () => {
           jest
             .spyOn(Common.NativeModule, 'preflightTest_getReport')
             .mockResolvedValue(
-              JSON.stringify({
-                ...baseMockReport,
-                callQuality: null,
-                isTurnRequired: 'false',
-              })
+              mockNativePromiseResolutionValue(
+                JSON.stringify({
+                  ...baseMockReport,
+                  callQuality: null,
+                  isTurnRequired: 'false',
+                })
+              )
             );
 
           const report = await preflight.getReport();
@@ -981,11 +954,13 @@ describe('PreflightTest', () => {
           jest
             .spyOn(Common.NativeModule, 'preflightTest_getReport')
             .mockResolvedValue(
-              JSON.stringify({
-                ...baseMockReport,
-                callQuality: undefined,
-                isTurnRequired: 'false',
-              })
+              mockNativePromiseResolutionValue(
+                JSON.stringify({
+                  ...baseMockReport,
+                  callQuality: undefined,
+                  isTurnRequired: 'false',
+                })
+              )
             );
 
           const report = await preflight.getReport();
@@ -997,7 +972,9 @@ describe('PreflightTest', () => {
           jest
             .spyOn(Common.NativeModule, 'preflightTest_getReport')
             .mockResolvedValue(
-              JSON.stringify({ ...baseMockReport, callQuality: 100 })
+              mockNativePromiseResolutionValue(
+                JSON.stringify({ ...baseMockReport, callQuality: 100 })
+              )
             );
 
           await expect(async () => {
@@ -1009,7 +986,9 @@ describe('PreflightTest', () => {
           jest
             .spyOn(Common.NativeModule, 'preflightTest_getReport')
             .mockResolvedValue(
-              JSON.stringify({ ...baseMockReport, callQuality: 'foobar' })
+              mockNativePromiseResolutionValue(
+                JSON.stringify({ ...baseMockReport, callQuality: 'foobar' })
+              )
             );
 
           await expect(async () => {
@@ -1021,11 +1000,13 @@ describe('PreflightTest', () => {
           jest
             .spyOn(Common.NativeModule, 'preflightTest_getReport')
             .mockResolvedValue(
-              JSON.stringify({
-                ...baseMockReport,
-                callQuality: 0,
-                isTurnRequired: 10,
-              })
+              mockNativePromiseResolutionValue(
+                JSON.stringify({
+                  ...baseMockReport,
+                  callQuality: 0,
+                  isTurnRequired: 10,
+                })
+              )
             );
 
           await expect(async () => {
@@ -1037,11 +1018,13 @@ describe('PreflightTest', () => {
           jest
             .spyOn(Common.NativeModule, 'preflightTest_getReport')
             .mockResolvedValue(
-              JSON.stringify({
-                ...baseMockReport,
-                callQuality: 0,
-                isTurnRequired: 'foobar',
-              })
+              mockNativePromiseResolutionValue(
+                JSON.stringify({
+                  ...baseMockReport,
+                  callQuality: 0,
+                  isTurnRequired: 'foobar',
+                })
+              )
             );
 
           await expect(async () => {
@@ -1053,11 +1036,13 @@ describe('PreflightTest', () => {
           jest
             .spyOn(Common.NativeModule, 'preflightTest_getReport')
             .mockResolvedValue(
-              JSON.stringify({
-                ...baseMockReport,
-                callQuality: 0,
-                isTurnRequired: undefined,
-              })
+              mockNativePromiseResolutionValue(
+                JSON.stringify({
+                  ...baseMockReport,
+                  callQuality: 0,
+                  isTurnRequired: undefined,
+                })
+              )
             );
 
           const report = await preflight.getReport();
@@ -1072,11 +1057,13 @@ describe('PreflightTest', () => {
           jest
             .spyOn(Common.NativeModule, 'preflightTest_getReport')
             .mockResolvedValue(
-              JSON.stringify({
-                ...baseMockReport,
-                callQuality: 0,
-                isTurnRequired: null,
-              })
+              mockNativePromiseResolutionValue(
+                JSON.stringify({
+                  ...baseMockReport,
+                  callQuality: 0,
+                  isTurnRequired: null,
+                })
+              )
             );
 
           const report = await preflight.getReport();
@@ -1091,12 +1078,14 @@ describe('PreflightTest', () => {
           jest
             .spyOn(Common.NativeModule, 'preflightTest_getReport')
             .mockResolvedValue(
-              JSON.stringify({
-                ...baseMockReport,
-                callQuality: 0,
-                isTurnRequired: 'false',
-                warnings: undefined,
-              })
+              mockNativePromiseResolutionValue(
+                JSON.stringify({
+                  ...baseMockReport,
+                  callQuality: 0,
+                  isTurnRequired: 'false',
+                  warnings: undefined,
+                })
+              )
             );
 
           const report = await preflight.getReport();
@@ -1111,12 +1100,14 @@ describe('PreflightTest', () => {
           jest
             .spyOn(Common.NativeModule, 'preflightTest_getReport')
             .mockResolvedValue(
-              JSON.stringify({
-                ...baseMockReport,
-                callQuality: 0,
-                isTurnRequired: 'false',
-                warnings: null,
-              })
+              mockNativePromiseResolutionValue(
+                JSON.stringify({
+                  ...baseMockReport,
+                  callQuality: 0,
+                  isTurnRequired: 'false',
+                  warnings: null,
+                })
+              )
             );
 
           const report = await preflight.getReport();
@@ -1131,12 +1122,14 @@ describe('PreflightTest', () => {
           jest
             .spyOn(Common.NativeModule, 'preflightTest_getReport')
             .mockResolvedValue(
-              JSON.stringify({
-                ...baseMockReport,
-                callQuality: 0,
-                isTurnRequired: 'false',
-                warningsCleared: undefined,
-              })
+              mockNativePromiseResolutionValue(
+                JSON.stringify({
+                  ...baseMockReport,
+                  callQuality: 0,
+                  isTurnRequired: 'false',
+                  warningsCleared: undefined,
+                })
+              )
             );
 
           const report = await preflight.getReport();
@@ -1151,12 +1144,14 @@ describe('PreflightTest', () => {
           jest
             .spyOn(Common.NativeModule, 'preflightTest_getReport')
             .mockResolvedValue(
-              JSON.stringify({
-                ...baseMockReport,
-                callQuality: 0,
-                isTurnRequired: 'false',
-                warningsCleared: null,
-              })
+              mockNativePromiseResolutionValue(
+                JSON.stringify({
+                  ...baseMockReport,
+                  callQuality: 0,
+                  isTurnRequired: 'false',
+                  warningsCleared: null,
+                })
+              )
             );
 
           const report = await preflight.getReport();
@@ -1171,13 +1166,15 @@ describe('PreflightTest', () => {
           jest
             .spyOn(Common.NativeModule, 'preflightTest_getReport')
             .mockResolvedValue(
-              JSON.stringify({
-                ...baseMockReport,
-                callQuality: 0,
-                isTurnRequired: 'false',
-                warnings: 'foobar',
-                warningsCleared: undefined,
-              })
+              mockNativePromiseResolutionValue(
+                JSON.stringify({
+                  ...baseMockReport,
+                  callQuality: 0,
+                  isTurnRequired: 'false',
+                  warnings: 'foobar',
+                  warningsCleared: undefined,
+                })
+              )
             );
 
           expect(async () => {
@@ -1189,13 +1186,15 @@ describe('PreflightTest', () => {
           jest
             .spyOn(Common.NativeModule, 'preflightTest_getReport')
             .mockResolvedValue(
-              JSON.stringify({
-                ...baseMockReport,
-                callQuality: 0,
-                isTurnRequired: 'false',
-                warnings: undefined,
-                warningsCleared: 'foobar',
-              })
+              mockNativePromiseResolutionValue(
+                JSON.stringify({
+                  ...baseMockReport,
+                  callQuality: 0,
+                  isTurnRequired: 'false',
+                  warnings: undefined,
+                  warningsCleared: 'foobar',
+                })
+              )
             );
 
           expect(async () => {
@@ -1209,7 +1208,9 @@ describe('PreflightTest', () => {
       it('invokes the native module', async () => {
         const spy = jest
           .spyOn(Common.NativeModule, 'preflightTest_getStartTime')
-          .mockImplementation(async () => '10');
+          .mockImplementation(async () =>
+            mockNativePromiseResolutionValue('10')
+          );
 
         await preflight.getStartTime();
 
@@ -1219,7 +1220,9 @@ describe('PreflightTest', () => {
       it('returns a number', async () => {
         jest
           .spyOn(Common.NativeModule, 'preflightTest_getStartTime')
-          .mockImplementation(async () => '10');
+          .mockImplementation(async () =>
+            mockNativePromiseResolutionValue('10')
+          );
 
         const startTime = await preflight.getStartTime();
 
@@ -1231,7 +1234,9 @@ describe('PreflightTest', () => {
       it('invokes the native module', async () => {
         const spy = jest
           .spyOn(Common.NativeModule, 'preflightTest_getState')
-          .mockImplementation(async () => 'completed');
+          .mockImplementation(async () =>
+            mockNativePromiseResolutionValue('completed')
+          );
 
         await preflight.getState();
 
@@ -1241,7 +1246,9 @@ describe('PreflightTest', () => {
       it('returns a valid state', async () => {
         jest
           .spyOn(Common.NativeModule, 'preflightTest_getState')
-          .mockImplementation(async () => 'completed');
+          .mockImplementation(async () =>
+            mockNativePromiseResolutionValue('completed')
+          );
 
         const state = await preflight.getState();
 
@@ -1263,7 +1270,9 @@ describe('PreflightTest', () => {
       it('invokes the native module', async () => {
         const spy = jest
           .spyOn(Common.NativeModule, 'preflightTest_stop')
-          .mockImplementation(async () => {});
+          .mockImplementation(async () =>
+            mockNativePromiseResolutionValue(undefined)
+          );
 
         await preflight.stop();
 
@@ -1273,7 +1282,9 @@ describe('PreflightTest', () => {
       it('returns undefined', async () => {
         jest
           .spyOn(Common.NativeModule, 'preflightTest_stop')
-          .mockImplementation(async () => {});
+          .mockImplementation(async () =>
+            mockNativePromiseResolutionValue(undefined)
+          );
 
         const retVal = await preflight.stop();
 

--- a/src/__tests__/nativePromise.test.ts
+++ b/src/__tests__/nativePromise.test.ts
@@ -1,0 +1,94 @@
+import {
+  AuthorizationErrors,
+  InvalidArgumentError,
+  InvalidStateError,
+  UnexpectedNativeError,
+} from '../error';
+import { settleNativePromise } from '../utility/nativePromise';
+import { Constants } from '../constants';
+
+describe('settleNativePromise', () => {
+  it('resolves with the unwrapped value', async () => {
+    const testAsyncFn = async () => ({
+      [Constants.PromiseKeyStatus]:
+        Constants.PromiseStatusValueResolved as const,
+      [Constants.PromiseKeyValue]: 'foobar',
+    });
+    await expect(settleNativePromise(testAsyncFn())).resolves.toBe('foobar');
+  });
+
+  it('rejects with an error code', async () => {
+    expect.assertions(2);
+
+    const testAsyncFn = async () => ({
+      [Constants.PromiseKeyStatus]:
+        Constants.PromiseStatusValueRejectedWithCode as const,
+      [Constants.PromiseKeyErrorCode]: 20101,
+      [Constants.PromiseKeyErrorMessage]: 'foobar',
+    });
+    await settleNativePromise(testAsyncFn()).catch((error) => {
+      expect(error).toBeInstanceOf(AuthorizationErrors.AccessTokenInvalid);
+      expect(error.message).toBe('AccessTokenInvalid (20101): foobar');
+    });
+  });
+
+  it('rejects with an invalid argument error', async () => {
+    expect.assertions(2);
+
+    const testAsyncFn = async () => ({
+      [Constants.PromiseKeyStatus]:
+        Constants.PromiseStatusValueRejectedWithName as const,
+      [Constants.PromiseKeyErrorName]:
+        Constants.ErrorCodeInvalidArgumentError as const,
+      [Constants.PromiseKeyErrorMessage]: 'foobar',
+    });
+    await settleNativePromise(testAsyncFn()).catch((error) => {
+      expect(error).toBeInstanceOf(InvalidArgumentError);
+      expect(error.message).toBe('foobar');
+    });
+  });
+
+  it('rejects with an invalid state error', async () => {
+    expect.assertions(2);
+
+    const testAsyncFn = async () => ({
+      [Constants.PromiseKeyStatus]:
+        Constants.PromiseStatusValueRejectedWithName as const,
+      [Constants.PromiseKeyErrorName]:
+        Constants.ErrorCodeInvalidStateError as const,
+      [Constants.PromiseKeyErrorMessage]: 'foobar',
+    });
+    await settleNativePromise(testAsyncFn()).catch((error) => {
+      expect(error).toBeInstanceOf(InvalidStateError);
+      expect(error.message).toBe('foobar');
+    });
+  });
+
+  it('rejects with an unexpected native error', async () => {
+    expect.assertions(2);
+
+    const testAsyncFn = async () => ({
+      [Constants.PromiseKeyStatus]:
+        Constants.PromiseStatusValueRejectedWithName as const,
+      [Constants.PromiseKeyErrorName]: 'foo' as any,
+      [Constants.PromiseKeyErrorMessage]: 'bar',
+    });
+    await settleNativePromise(testAsyncFn()).catch((error) => {
+      expect(error).toBeInstanceOf(UnexpectedNativeError);
+      expect(error.message).toBe('bar');
+    });
+  });
+
+  it('rejects if the native promise is unexpectedly rejected', async () => {
+    expect.assertions(1);
+
+    class SomeMockNativeError extends Error {}
+
+    const testAsyncFn = async () => {
+      throw new SomeMockNativeError();
+    };
+    await settleNativePromise(testAsyncFn()).catch((error) => {
+      expect(error).toBeInstanceOf(SomeMockNativeError);
+    });
+  });
+});

--- a/src/common.ts
+++ b/src/common.ts
@@ -5,14 +5,29 @@
  * See LICENSE in the project root for license information.
  */
 
+import { requireNativeModule } from 'expo-modules-core';
 import * as ReactNative from 'react-native';
+import { Constants } from './constants';
 import type { TwilioVoiceReactNative as TwilioVoiceReactNativeType } from './type/NativeModule';
 
-export const NativeModule = ReactNative.NativeModules
-  .TwilioVoiceReactNative as TwilioVoiceReactNativeType;
-export const NativeEventEmitter = new ReactNative.NativeEventEmitter(
-  NativeModule
-);
+const expo = () => {
+  const NativeModule: TwilioVoiceReactNativeType = requireNativeModule(
+    'TwilioVoiceExpoModule'
+  );
+  const NativeEventEmitter = new ReactNative.NativeEventEmitter();
+  return { NativeEventEmitter, NativeModule };
+};
+
+const bare = () => {
+  const NativeModule: TwilioVoiceReactNativeType =
+    ReactNative.NativeModules.TwilioVoiceReactNative;
+  const NativeEventEmitter = new ReactNative.NativeEventEmitter(NativeModule);
+  return { NativeEventEmitter, NativeModule };
+};
+
+export const { NativeEventEmitter, NativeModule } =
+  Constants.ReactNativeVoiceSDK === 'react-native' ? bare() : expo();
+
 export const Platform = ReactNative.Platform;
 
 export const setTimeout = global.setTimeout;

--- a/src/error/UnexpectedNativeError.ts
+++ b/src/error/UnexpectedNativeError.ts
@@ -1,0 +1,21 @@
+import { TwilioError } from './TwilioError';
+
+/**
+ * Error describing that the SDK has entered or is attempting to enter an
+ * invalid state.
+ *
+ * @public
+ */
+export class UnexpectedNativeError extends TwilioError {
+  description: string = 'Unexpected native error.';
+  explanation: string = 'An unexpected native error has occurred.';
+  miscellaneousInfo: any;
+
+  constructor(message: string, miscellaneousInfo?: any) {
+    super(message);
+
+    Object.setPrototypeOf(this, UnexpectedNativeError.prototype);
+    this.name = UnexpectedNativeError.name;
+    this.miscellaneousInfo = miscellaneousInfo;
+  }
+}

--- a/src/error/index.ts
+++ b/src/error/index.ts
@@ -1,5 +1,6 @@
 export { InvalidArgumentError } from './InvalidArgumentError';
 export { InvalidStateError } from './InvalidStateError';
+export { UnexpectedNativeError } from './UnexpectedNativeError';
 export { UnsupportedPlatformError } from './UnsupportedPlatformError';
 export { TwilioError } from './TwilioError';
 export {

--- a/src/type/NativeModule.ts
+++ b/src/type/NativeModule.ts
@@ -10,6 +10,32 @@ import type {
 import type { NativeCallInviteInfo } from './CallInvite';
 import type { Uuid } from './common';
 import type { RTCStats } from './RTCStats';
+import type { Constants } from '../constants';
+
+export type NativePromiseResolution<T> = {
+  [Constants.PromiseKeyStatus]: Constants.PromiseStatusValueResolved;
+  [Constants.PromiseKeyValue]: T;
+};
+
+export type NativePromiseNamedRejection = {
+  [Constants.PromiseKeyStatus]: Constants.PromiseStatusValueRejectedWithName;
+  [Constants.PromiseKeyErrorName]:
+    | Constants.ErrorCodeInvalidArgumentError
+    | Constants.ErrorCodeInvalidStateError;
+  [Constants.PromiseKeyErrorMessage]: string;
+};
+
+export type NativePromiseCodedRejection = {
+  [Constants.PromiseKeyStatus]: Constants.PromiseStatusValueRejectedWithCode;
+  [Constants.PromiseKeyErrorCode]: number;
+  [Constants.PromiseKeyErrorMessage]: string;
+};
+
+export type NativePromise<T> = Promise<
+  | NativePromiseResolution<T>
+  | NativePromiseCodedRejection
+  | NativePromiseNamedRejection
+>;
 
 export interface TwilioVoiceReactNative extends NativeModulesStatic {
   /**
@@ -24,24 +50,24 @@ export interface TwilioVoiceReactNative extends NativeModulesStatic {
   /**
    * Call bindings.
    */
-  call_disconnect(callUuid: Uuid): Promise<void>;
-  call_getStats(callUuid: Uuid): Promise<RTCStats.StatsReport>;
-  call_hold(callUuid: Uuid, hold: boolean): Promise<boolean>;
-  call_isOnHold(callUuid: Uuid): Promise<boolean>;
-  call_isMuted(callUuid: Uuid): Promise<boolean>;
-  call_mute(callUuid: Uuid, mute: boolean): Promise<boolean>;
+  call_disconnect(callUuid: Uuid): NativePromise<void>;
+  call_getStats(callUuid: Uuid): NativePromise<RTCStats.StatsReport>;
+  call_hold(callUuid: Uuid, hold: boolean): NativePromise<boolean>;
+  call_isOnHold(callUuid: Uuid): NativePromise<boolean>;
+  call_isMuted(callUuid: Uuid): NativePromise<boolean>;
+  call_mute(callUuid: Uuid, mute: boolean): NativePromise<boolean>;
   call_postFeedback(
     callUuid: Uuid,
     score: NativeCallFeedbackScore,
     issue: NativeCallFeedbackIssue
-  ): Promise<void>;
-  call_sendDigits(callUuid: Uuid, digits: string): Promise<void>;
+  ): NativePromise<void>;
+  call_sendDigits(callUuid: Uuid, digits: string): NativePromise<void>;
   call_sendMessage(
     callUuid: Uuid,
     content: string,
     contentType: string,
     messageType: string
-  ): Promise<string>;
+  ): NativePromise<string>;
 
   /**
    * Call Invite bindings.
@@ -49,13 +75,13 @@ export interface TwilioVoiceReactNative extends NativeModulesStatic {
   callInvite_accept(
     callInviteUuid: Uuid,
     acceptOptions: CallInvite.AcceptOptions
-  ): Promise<NativeCallInfo>;
-  callInvite_isValid(callInviteUuid: Uuid): Promise<boolean>;
-  callInvite_reject(callInviteUuid: Uuid): Promise<void>;
+  ): NativePromise<NativeCallInfo>;
+  callInvite_isValid(callInviteUuid: Uuid): NativePromise<boolean>;
+  callInvite_reject(callInviteUuid: Uuid): NativePromise<void>;
   callInvite_updateCallerHandle(
     callInviteUuid: Uuid,
     handle: string
-  ): Promise<void>;
+  ): NativePromise<void>;
 
   /**
    * Voice bindings.
@@ -64,27 +90,31 @@ export interface TwilioVoiceReactNative extends NativeModulesStatic {
     token: string,
     twimlParams: Record<string, any>,
     notificationDisplayName: string | undefined
-  ): Promise<NativeCallInfo>;
+  ): NativePromise<NativeCallInfo>;
   voice_connect_ios(
     token: string,
     twimlParams: Record<string, any>,
     contactHandle: string
-  ): Promise<NativeCallInfo>;
-  voice_initializePushRegistry(): Promise<void>;
+  ): NativePromise<NativeCallInfo>;
+  voice_initializePushRegistry(): NativePromise<void>;
   voice_setCallKitConfiguration(
     configuration: Record<string, any>
-  ): Promise<void>;
-  voice_setIncomingCallContactHandleTemplate(template?: string): Promise<void>;
-  voice_getAudioDevices(): Promise<NativeAudioDevicesInfo>;
-  voice_getCalls(): Promise<NativeCallInfo[]>;
-  voice_getCallInvites(): Promise<NativeCallInviteInfo[]>;
-  voice_getDeviceToken(): Promise<string>;
-  voice_getVersion(): Promise<string>;
-  voice_handleEvent(remoteMessage: Record<string, string>): Promise<boolean>;
-  voice_register(accessToken: string): Promise<void>;
-  voice_selectAudioDevice(audioDeviceUuid: Uuid): Promise<void>;
-  voice_showNativeAvRoutePicker(): Promise<void>;
-  voice_unregister(accessToken: string): Promise<void>;
+  ): NativePromise<void>;
+  voice_setIncomingCallContactHandleTemplate(
+    template?: string
+  ): NativePromise<void>;
+  voice_getAudioDevices(): NativePromise<NativeAudioDevicesInfo>;
+  voice_getCalls(): NativePromise<NativeCallInfo[]>;
+  voice_getCallInvites(): NativePromise<NativeCallInviteInfo[]>;
+  voice_getDeviceToken(): NativePromise<string>;
+  voice_getVersion(): NativePromise<string>;
+  voice_handleEvent(
+    remoteMessage: Record<string, string>
+  ): NativePromise<boolean>;
+  voice_register(accessToken: string): NativePromise<void>;
+  voice_selectAudioDevice(audioDeviceUuid: Uuid): NativePromise<void>;
+  voice_showNativeAvRoutePicker(): NativePromise<void>;
+  voice_unregister(accessToken: string): NativePromise<void>;
 
   /**
    * Preflight related bindings.
@@ -92,15 +122,15 @@ export interface TwilioVoiceReactNative extends NativeModulesStatic {
   voice_runPreflight(
     accessToken: string,
     options: PreflightTest.Options
-  ): Promise<Uuid>;
+  ): NativePromise<Uuid>;
 
-  preflightTest_getCallSid(preflightTestUuid: Uuid): Promise<string>;
-  preflightTest_getEndTime(preflightTestUuid: Uuid): Promise<string>;
-  preflightTest_getLatestSample(preflightTestUuid: Uuid): Promise<string>;
-  preflightTest_getReport(preflightTestUuid: Uuid): Promise<string>;
-  preflightTest_getStartTime(preflightTestUuid: Uuid): Promise<string>;
-  preflightTest_getState(preflightTestUuid: Uuid): Promise<string>;
-  preflightTest_stop(preflightTestUuid: Uuid): Promise<void>;
+  preflightTest_getCallSid(preflightTestUuid: Uuid): NativePromise<string>;
+  preflightTest_getEndTime(preflightTestUuid: Uuid): NativePromise<string>;
+  preflightTest_getLatestSample(preflightTestUuid: Uuid): NativePromise<string>;
+  preflightTest_getReport(preflightTestUuid: Uuid): NativePromise<string>;
+  preflightTest_getStartTime(preflightTestUuid: Uuid): NativePromise<string>;
+  preflightTest_getState(preflightTestUuid: Uuid): NativePromise<string>;
+  preflightTest_stop(preflightTestUuid: Uuid): NativePromise<void>;
 
-  preflightTest_flushEvents(): Promise<void>;
+  preflightTest_flushEvents(): NativePromise<void>;
 }

--- a/src/utility/nativePromise.ts
+++ b/src/utility/nativePromise.ts
@@ -1,0 +1,40 @@
+import { Constants } from '../constants';
+import { InvalidArgumentError } from '../error/InvalidArgumentError';
+import { InvalidStateError } from '../error/InvalidStateError';
+import { UnexpectedNativeError } from '../error/UnexpectedNativeError';
+import { constructTwilioError } from '../error/utility';
+import { NativePromise } from '../type/NativeModule';
+
+export const settleNativePromise = async <T>(
+  nativePromise: NativePromise<T>
+): Promise<T> => {
+  const nativePromiseResult = await nativePromise;
+
+  if (
+    nativePromiseResult.promiseKeyStatus ===
+    Constants.PromiseStatusValueRejectedWithCode
+  ) {
+    throw constructTwilioError(
+      nativePromiseResult.promiseKeyErrorMessage,
+      nativePromiseResult.promiseKeyErrorCode
+    );
+  }
+
+  if (
+    nativePromiseResult.promiseKeyStatus ===
+    Constants.PromiseStatusValueRejectedWithName
+  ) {
+    const { promiseKeyErrorMessage: message } = nativePromiseResult;
+
+    switch (nativePromiseResult.promiseKeyErrorName) {
+      case Constants.ErrorCodeInvalidArgumentError:
+        throw new InvalidArgumentError(message);
+      case Constants.ErrorCodeInvalidStateError:
+        throw new InvalidStateError(message);
+      default:
+        throw new UnexpectedNativeError(message);
+    }
+  }
+
+  return nativePromiseResult.promiseKeyValue;
+};


### PR DESCRIPTION
## Submission Checklist

 - [ ] Updated the `CHANGELOG.md` to reflect any **feature**, **bug fixes**, or **known issues** made in the source code
 - [x] Tested code changes and observed expected behavior in the example app
 - [x] Performed a visual inspection of the `Files changed` tab prior to submitting the pull request for review to ensure proper usage of the style guide

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Description

This PR implements the native promise refactor on the JS layer.

## Breakdown

- Implement the JS layer native promise refactor.
- Add conditional code to use the expo module if present.

## Validation

- Manually tested.

## Additional Notes

N/A
