### PR TITLE
[VBLOCKS-5991] Expo insights

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -374,6 +374,11 @@ jobs:
           command: |
             cd test/expo
             yarn run expo prebuild --clean --platform=android
+            cd ../..
+      - run:
+          name: "Patch Android native prebuild files with Detox support"
+          command: |
+            cd test/expo
             bash detox/scripts/patch-all.bash
             cd ../..
       - detox-build:

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -3,7 +3,7 @@ buildscript {
     'java'               : JavaVersion.VERSION_11,
     'androidGradlePlugin': '7.4.2',
     'googleServices'     : '4.3.10',
-    'voiceAndroid'       : '6.7.1',
+    'voiceAndroid'       : '6.10.3',
     'androidxCore'       : '1.12.0',
     'androidxLifecycle'  : '2.2.0',
     'audioSwitch'        : '1.2.2',

--- a/android/src/main/java/com/twiliovoicereactnative/Constants.java
+++ b/android/src/main/java/com/twiliovoicereactnative/Constants.java
@@ -22,4 +22,5 @@ class Constants {
   public static final String INCOMING_CALL_CONTACT_HANDLE_TEMPLATE_PREFERENCES_KEY = "incomingCallContactHandleTemplatePreferenceKey";
   public static final String GLOBAL_ENV = "com.twilio.voice.env";
   public static final String SDK_VERSION = "com.twilio.voice.env.sdk.version";
+  public static final String EXPO_VERSION = "com.twilio.voice.env.sdk.expo_version";
 }

--- a/android/src/main/java/com/twiliovoicereactnative/ExpoModule.kt
+++ b/android/src/main/java/com/twiliovoicereactnative/ExpoModule.kt
@@ -438,7 +438,7 @@ class ExpoModule : Module() {
     }
 
     AsyncFunction("voice_setExpoVersion") {
-      expoVersion: String,
+      expoVersion: String?,
       promise: Promise ->
 
       this@ExpoModule.moduleProxy.voice.setExpoVersion(

--- a/android/src/main/java/com/twiliovoicereactnative/ExpoModule.kt
+++ b/android/src/main/java/com/twiliovoicereactnative/ExpoModule.kt
@@ -437,6 +437,16 @@ class ExpoModule : Module() {
       this@ExpoModule.moduleProxy.voice.selectAudioDevice(uuid, PromiseAdapter(promise))
     }
 
+    AsyncFunction("voice_setExpoVersion") {
+      expoVersion: String,
+      promise: Promise ->
+
+      this@ExpoModule.moduleProxy.voice.setExpoVersion(
+        expoVersion,
+        PromiseAdapter(promise)
+      )
+    }
+
     AsyncFunction("voice_setIncomingCallContactHandleTemplate") {
       template: String,
       promise: Promise ->

--- a/android/src/main/java/com/twiliovoicereactnative/TwilioVoiceReactNativeModule.java
+++ b/android/src/main/java/com/twiliovoicereactnative/TwilioVoiceReactNativeModule.java
@@ -520,6 +520,11 @@ public class TwilioVoiceReactNativeModule extends ReactContextBaseJavaModule {
   }
 
   @ReactMethod
+  public void voice_setExpoVersion(String expoVersion, Promise promise) {
+    this.moduleProxy.voice.setExpoVersion(expoVersion, new PromiseAdapter(promise));
+  }
+
+  @ReactMethod
   public void voice_setIncomingCallContactHandleTemplate(String template, Promise promise) {
     this.moduleProxy.voice.setIncomingCallContactHandleTemplate(template, new PromiseAdapter(promise));
   }

--- a/android/src/main/java/com/twiliovoicereactnative/VoiceModuleProxy.java
+++ b/android/src/main/java/com/twiliovoicereactnative/VoiceModuleProxy.java
@@ -305,7 +305,7 @@ class VoiceModuleProxy {
 
   public void setExpoVersion(String expoVersion, ModuleProxy.UniversalPromise promise) {
     logger.debug(String.format(".setExpoVersion(%s)", expoVersion));
-    if (expoVersion == null) {
+    if (expoVersion == null || expoVersion.isEmpty()) {
       System.clearProperty(Constants.EXPO_VERSION);
     } else {
       System.setProperty(Constants.EXPO_VERSION, expoVersion);

--- a/android/src/main/java/com/twiliovoicereactnative/VoiceModuleProxy.java
+++ b/android/src/main/java/com/twiliovoicereactnative/VoiceModuleProxy.java
@@ -305,7 +305,11 @@ class VoiceModuleProxy {
 
   public void setExpoVersion(String expoVersion, ModuleProxy.UniversalPromise promise) {
     logger.debug(String.format(".setExpoVersion(%s)", expoVersion));
-    System.setProperty(Constants.EXPO_VERSION, expoVersion);
+    if (expoVersion == null) {
+      System.clearProperty(Constants.EXPO_VERSION);
+    } else {
+      System.setProperty(Constants.EXPO_VERSION, expoVersion);
+    }
     promise.resolve(null);
   }
 

--- a/android/src/main/java/com/twiliovoicereactnative/VoiceModuleProxy.java
+++ b/android/src/main/java/com/twiliovoicereactnative/VoiceModuleProxy.java
@@ -65,7 +65,7 @@ class VoiceModuleProxy {
       if (iceOptions != null) {
         builder.iceOptions(iceOptions);
       }
-       
+
       ConnectOptions connectOptions = builder.build();
       try {
         final Call call = VoiceApplicationProxy.getVoiceServiceApi().connect(
@@ -301,6 +301,12 @@ class VoiceModuleProxy {
 
       promise.resolve(uuid.toString());
     });
+  }
+
+  public void setExpoVersion(String expoVersion, ModuleProxy.UniversalPromise promise) {
+    logger.debug(String.format(".setExpoVersion(%s)", expoVersion));
+    System.setProperty(Constants.EXPO_VERSION, expoVersion);
+    promise.resolve(null);
   }
 
   public void setIncomingCallContactHandleTemplate(String template, ModuleProxy.UniversalPromise promise) {

--- a/ios/TwilioVoiceReactNative+PreflightTest.m
+++ b/ios/TwilioVoiceReactNative+PreflightTest.m
@@ -301,7 +301,7 @@ RCT_EXPORT_METHOD(preflightTest_flushEvents:(RCTPromiseResolveBlock)resolver
     }
 }
 
-- (void)preflight:(nonnull TVOPreflightTest *)preflightTest didCompleteWitReport:(nonnull TVOPreflightReport *)report {
+- (void)preflight:(nonnull TVOPreflightTest *)preflightTest didCompleteWithReport:(nonnull TVOPreflightReport *)report {
     [self sendPreflightEvent:@{
         kTwilioVoiceReactNativePreflightTestEventKeyUuid: self.preflightTestUuid,
         kTwilioVoiceReactNativePreflightTestEventKeyType: kTwilioVoiceReactNativePreflightTestEventTypeValueCompleted,

--- a/ios/TwilioVoiceReactNative.m
+++ b/ios/TwilioVoiceReactNative.m
@@ -700,7 +700,7 @@ RCT_EXPORT_METHOD(voice_setExpoVersion:(NSString *)expoVersion
                   resolver:(RCTPromiseResolveBlock)resolver
                   rejecter:(RCTPromiseRejectBlock)rejecter)
 {
-    if (expoVersion != null) {
+    if (expoVersion != nil) {
         setenv("com.twilio.voice.env.sdk.expo_version", [expoVersion UTF8String], 1);
     } else {
         unsetenv("com.twilio.voice.env.sdk.expo_version");

--- a/ios/TwilioVoiceReactNative.m
+++ b/ios/TwilioVoiceReactNative.m
@@ -696,6 +696,14 @@ RCT_EXPORT_METHOD(voice_showNativeAvRoutePicker:(RCTPromiseResolveBlock)resolver
     [self resolvePromise:resolver value:[NSNull null]];
 }
 
+RCT_EXPORT_METHOD(voice_setExpoVersion:(NSString *)expoVersion
+                  resolver:(RCTPromiseResolveBlock)resolver
+                  rejecter:(RCTPromiseRejectBlock)rejecter)
+{
+    setenv("com.twilio.voice.env.sdk.expo_version", [expoVersion UTF8String], 1);
+    [self resolvePromise:resolver value:[NSNull null]];
+}
+
 RCT_EXPORT_METHOD(voice_setIncomingCallContactHandleTemplate:(NSString *)template
                   resolver:(RCTPromiseResolveBlock)resolver
                   rejecter:(RCTPromiseRejectBlock)rejecter)

--- a/ios/TwilioVoiceReactNative.m
+++ b/ios/TwilioVoiceReactNative.m
@@ -700,7 +700,11 @@ RCT_EXPORT_METHOD(voice_setExpoVersion:(NSString *)expoVersion
                   resolver:(RCTPromiseResolveBlock)resolver
                   rejecter:(RCTPromiseRejectBlock)rejecter)
 {
-    setenv("com.twilio.voice.env.sdk.expo_version", [expoVersion UTF8String], 1);
+    if (expoVersion != null) {
+        setenv("com.twilio.voice.env.sdk.expo_version", [expoVersion UTF8String], 1);
+    } else {
+        unsetenv("com.twilio.voice.env.sdk.expo_version");
+    }
     [self resolvePromise:resolver value:[NSNull null]];
 }
 

--- a/ios/TwilioVoiceReactNative.m
+++ b/ios/TwilioVoiceReactNative.m
@@ -700,7 +700,7 @@ RCT_EXPORT_METHOD(voice_setExpoVersion:(NSString *)expoVersion
                   resolver:(RCTPromiseResolveBlock)resolver
                   rejecter:(RCTPromiseRejectBlock)rejecter)
 {
-    if (expoVersion != nil) {
+    if ([expoVersion length] > 0) {
         setenv("com.twilio.voice.env.sdk.expo_version", [expoVersion UTF8String], 1);
     } else {
         unsetenv("com.twilio.voice.env.sdk.expo_version");

--- a/src/PreflightTest.ts
+++ b/src/PreflightTest.ts
@@ -740,8 +740,9 @@ function parseReport(rawReport: string): PreflightTest.Report {
 
   const callSid: string = unprocessedReport.callSid;
 
-  // Note: Android returns enum values where the first letter is capitalized.
-  // The helper function normalizes this into all-lowercased values.
+  // Note: Native methods return enum values where the first letter is
+  // capitalized. The helper function normalizes this into all-lowercased
+  // values.
   const callQuality: PreflightTest.CallQuality | null = parseCallQuality(
     unprocessedReport.callQuality
   );
@@ -752,7 +753,6 @@ function parseReport(rawReport: string): PreflightTest.Report {
   const iceCandidateStats: PreflightTest.RTCIceCandidateStats[] =
     unprocessedReport.iceCandidates;
 
-  // Note: iOS returns a string, Android returns a boolean
   const isTurnRequired: boolean | null = parseIsTurnRequired(
     unprocessedReport.isTurnRequired
   );
@@ -793,14 +793,10 @@ function parseReport(rawReport: string): PreflightTest.Report {
   const selectedIceCandidatePairStats: PreflightTest.RTCSelectedIceCandidatePairStats =
     unprocessedReport.selectedIceCandidatePair;
 
-  // Note: iOS returns undefined where Android returns an empty array
-  // when there were no warnings
   const warnings: PreflightTest.Warning[] = parseWarnings(
     unprocessedReport.warnings
   );
 
-  // Note: iOS returns undefined where Android returns an empty array
-  // when there were no warningsCleared
   const warningsCleared: PreflightTest.WarningCleared[] = parseWarningsCleared(
     unprocessedReport.warningsCleared
   );

--- a/src/PreflightTest.ts
+++ b/src/PreflightTest.ts
@@ -597,25 +597,6 @@ function parseTimeMeasurement(nativeTimeMeasurement: {
 function parseCallQuality(
   nativeCallQuality: any
 ): PreflightTest.CallQuality | null {
-  switch (common.Platform.OS) {
-    case 'android': {
-      return parseCallQualityAndroid(nativeCallQuality);
-    }
-    case 'ios': {
-      return parseCallQualityIos(nativeCallQuality);
-    }
-    default: {
-      throw new InvalidStateError('Invalid platform.');
-    }
-  }
-}
-
-/**
- * Parse call quality value for Android platform.
- */
-function parseCallQualityAndroid(
-  nativeCallQuality: string | undefined | null
-): PreflightTest.CallQuality | null {
   if (typeof nativeCallQuality === 'undefined' || nativeCallQuality === null) {
     return null;
   }
@@ -626,38 +607,11 @@ function parseCallQualityAndroid(
     );
   }
 
-  const parsedCallQuality = callQualityMap.android.get(nativeCallQuality);
+  const parsedCallQuality = callQualityMap.get(nativeCallQuality);
 
   if (typeof parsedCallQuality !== 'string') {
     throw new InvalidStateError(
       `Call quality invalid. Expected a string, found "${nativeCallQuality}".`
-    );
-  }
-
-  return parsedCallQuality;
-}
-
-/**
- * Parse call quality for iOS platform.
- */
-function parseCallQualityIos(
-  nativeCallQuality: number | undefined | null
-): PreflightTest.CallQuality | null {
-  if (typeof nativeCallQuality === 'undefined' || nativeCallQuality === null) {
-    return null;
-  }
-
-  if (typeof nativeCallQuality !== 'number') {
-    throw new InvalidStateError(
-      `Call quality not of type "number". Found "${typeof nativeCallQuality}".`
-    );
-  }
-
-  const parsedCallQuality = callQualityMap.ios.get(nativeCallQuality);
-
-  if (typeof parsedCallQuality !== 'string') {
-    throw new InvalidStateError(
-      `Call quality invalid. Expected [0, 4], found "${nativeCallQuality}".`
     );
   }
 
@@ -727,25 +681,6 @@ function parseSample(
  * Parse native "isTurnRequired" value.
  */
 function parseIsTurnRequired(isTurnRequired: any): boolean | null {
-  switch (common.Platform.OS) {
-    case 'android': {
-      return parseIsTurnRequiredAndroid(isTurnRequired);
-    }
-    case 'ios': {
-      return parseIsTurnRequiredIos(isTurnRequired);
-    }
-    default: {
-      throw new InvalidStateError('Invalid platform.');
-    }
-  }
-}
-
-/**
- * Parse native "isTurnRequired" value on Android.
- */
-function parseIsTurnRequiredAndroid(
-  isTurnRequired: boolean | undefined | null
-): boolean | null {
   if (typeof isTurnRequired === 'undefined' || isTurnRequired === null) {
     return null;
   }
@@ -757,34 +692,6 @@ function parseIsTurnRequiredAndroid(
   }
 
   return isTurnRequired;
-}
-
-/**
- * Parse native "isTurnRequired" value on iOS.
- */
-function parseIsTurnRequiredIos(
-  isTurnRequired: string | undefined | null
-): boolean | null {
-  if (typeof isTurnRequired === 'undefined' || isTurnRequired === null) {
-    return null;
-  }
-
-  if (typeof isTurnRequired !== 'string') {
-    throw new InvalidStateError(
-      'PreflightTest "isTurnRequired" not of type "string". ' +
-        `Found "${isTurnRequired}".`
-    );
-  }
-
-  const parsedValue = isTurnRequiredMap.ios.get(isTurnRequired);
-
-  if (typeof parsedValue !== 'boolean') {
-    throw new InvalidStateError(
-      `PreflightTest "isTurnRequired" not valid. Found "${isTurnRequired}".`
-    );
-  }
-
-  return parsedValue;
 }
 
 /**
@@ -1442,32 +1349,13 @@ export namespace PreflightTest {
 /**
  * Map of call quality values from the native layer to the expected JS values.
  */
-const callQualityMap = {
-  ios: new Map<number, PreflightTest.CallQuality>([
-    [0, PreflightTest.CallQuality.Excellent],
-    [1, PreflightTest.CallQuality.Great],
-    [2, PreflightTest.CallQuality.Good],
-    [3, PreflightTest.CallQuality.Fair],
-    [4, PreflightTest.CallQuality.Degraded],
-  ]),
-  android: new Map<string, PreflightTest.CallQuality>([
-    ['Excellent', PreflightTest.CallQuality.Excellent],
-    ['Great', PreflightTest.CallQuality.Great],
-    ['Good', PreflightTest.CallQuality.Good],
-    ['Fair', PreflightTest.CallQuality.Fair],
-    ['Degraded', PreflightTest.CallQuality.Degraded],
-  ]),
-};
-
-/**
- * Map of isTurnRequired values from the native layer to the expected JS values.
- */
-const isTurnRequiredMap = {
-  ios: new Map<string, boolean>([
-    ['true', true],
-    ['false', false],
-  ]),
-};
+const callQualityMap = new Map<string, PreflightTest.CallQuality>([
+  ['Excellent', PreflightTest.CallQuality.Excellent],
+  ['Great', PreflightTest.CallQuality.Great],
+  ['Good', PreflightTest.CallQuality.Good],
+  ['Fair', PreflightTest.CallQuality.Fair],
+  ['Degraded', PreflightTest.CallQuality.Degraded],
+]);
 
 /**
  * Map of state values from the native layers/common constants to the expected

--- a/src/Voice.tsx
+++ b/src/Voice.tsx
@@ -9,7 +9,12 @@ import { EventEmitter } from 'eventemitter3';
 import { AudioDevice } from './AudioDevice';
 import { Call } from './Call';
 import { CallInvite } from './CallInvite';
-import { NativeEventEmitter, NativeModule, Platform } from './common';
+import {
+  getExpoVersion,
+  NativeEventEmitter,
+  NativeModule,
+  Platform,
+} from './common';
 import { Constants } from './constants';
 import { InvalidArgumentError } from './error/InvalidArgumentError';
 import type { TwilioError } from './error/TwilioError';
@@ -318,6 +323,8 @@ export class Voice extends EventEmitter {
       Constants.ScopeVoice,
       this._handleNativeEvent
     );
+
+    NativeModule.voice_setExpoVersion(getExpoVersion());
   }
 
   /**

--- a/src/__mocks__/common.ts
+++ b/src/__mocks__/common.ts
@@ -100,6 +100,7 @@ export const NativeModule = {
   voice_register: createMockWithResolvedValue(undefined),
   voice_selectAudioDevice: createMockWithResolvedValue(undefined),
   voice_setCallKitConfiguration: createMockWithResolvedValue(undefined),
+  voice_setExpoVersion: createMockWithResolvedValue(undefined),
   voice_showNativeAvRoutePicker: createMockWithResolvedValue(undefined),
   voice_setIncomingCallContactHandleTemplate:
     createMockWithResolvedValue(undefined),
@@ -163,3 +164,5 @@ class MockPlatform {
 export const Platform = new MockPlatform();
 
 export const setTimeout = jest.fn();
+
+export const getExpoVersion = jest.fn().mockReturnValue('52.0.0');

--- a/src/__tests__/PreflightTest.test.ts
+++ b/src/__tests__/PreflightTest.test.ts
@@ -227,60 +227,26 @@ describe('PreflightTest', () => {
         }).toThrowError(InvalidStateError);
       });
 
-      describe('android', () => {
-        beforeEach(() => {
-          jest.spyOn(Common.Platform, 'OS', 'get').mockReturnValue('android');
-        });
+      it('handles a valid event', async () => {
+        const preflight = new PreflightTest(mockUuid);
 
-        it('handles a valid event', async () => {
-          const preflight = new PreflightTest(mockUuid);
-
-          const reportPromise = new Promise((resolve) => {
-            preflight.on(PreflightTest.Event.Completed, (...args: any[]) => {
-              resolve(args);
-            });
+        const reportPromise = new Promise((resolve) => {
+          preflight.on(PreflightTest.Event.Completed, (...args: any[]) => {
+            resolve(args);
           });
-
-          preflight['_handleCompletedEvent']({
-            [Constants.PreflightTestCompletedEventKeyReport]: JSON.stringify({
-              ...baseMockReport,
-              callQuality: 'Excellent',
-              isTurnRequired: false,
-            }),
-          } as any);
-
-          const report = await reportPromise;
-
-          expect(report).toEqual([expectedReport]);
-        });
-      });
-
-      describe('ios', () => {
-        beforeEach(() => {
-          jest.spyOn(Common.Platform, 'OS', 'get').mockReturnValue('ios');
         });
 
-        it('handles a valid event', async () => {
-          const preflight = new PreflightTest(mockUuid);
+        preflight['_handleCompletedEvent']({
+          [Constants.PreflightTestCompletedEventKeyReport]: JSON.stringify({
+            ...baseMockReport,
+            callQuality: 'Excellent',
+            isTurnRequired: false,
+          }),
+        } as any);
 
-          const reportPromise = new Promise((resolve) => {
-            preflight.on(PreflightTest.Event.Completed, (...args: any[]) => {
-              resolve(args);
-            });
-          });
+        const report = await reportPromise;
 
-          preflight['_handleCompletedEvent']({
-            [Constants.PreflightTestCompletedEventKeyReport]: JSON.stringify({
-              ...baseMockReport,
-              callQuality: 0,
-              isTurnRequired: 'false',
-            }),
-          } as any);
-
-          const report = await reportPromise;
-
-          expect(report).toEqual([expectedReport]);
-        });
+        expect(report).toEqual([expectedReport]);
       });
     });
 
@@ -551,655 +517,288 @@ describe('PreflightTest', () => {
     });
 
     describe('getReport', () => {
-      describe('invalid platform', () => {
-        it('throws an error in "parseCallQuality"', async () => {
-          jest
-            .spyOn(Common.Platform, 'OS', 'get')
-            .mockReturnValue('foobar' as any);
+      it('invokes the native module', async () => {
+        const spy = jest
+          .spyOn(Common.NativeModule, 'preflightTest_getReport')
+          .mockResolvedValue(
+            mockNativePromiseResolutionValue(
+              JSON.stringify({ ...baseMockReport, callQuality: 'Excellent' })
+            )
+          );
 
-          jest
-            .spyOn(Common.NativeModule, 'preflightTest_getReport')
-            .mockImplementation(async () =>
-              mockNativePromiseResolutionValue(
-                JSON.stringify({
-                  ...baseMockReport,
-                  callQuality: 'foobar',
-                })
-              )
-            );
+        await preflight.getReport();
 
-          await expect(async () => {
-            await preflight.getReport();
-          }).rejects.toBeInstanceOf(InvalidStateError);
-        });
+        expect(spy.mock.calls).toEqual([[mockUuid]]);
+      });
 
-        it('throws an error in "parseIsTurnRequired"', async () => {
-          const mockReturnValues = (function* () {
-            yield 'android';
-            yield 'foobar';
-          })();
+      it('parses a valid native report', async () => {
+        jest
+          .spyOn(Common.NativeModule, 'preflightTest_getReport')
+          .mockResolvedValue(
+            mockNativePromiseResolutionValue(
+              JSON.stringify({
+                ...baseMockReport,
+                callQuality: 'Excellent',
+                isTurnRequired: false,
+              })
+            )
+          );
 
-          jest
-            .spyOn(Common.Platform, 'OS', 'get')
-            .mockImplementation(() => mockReturnValues.next().value as any);
+        const report = await preflight.getReport();
 
-          jest
-            .spyOn(Common.NativeModule, 'preflightTest_getReport')
-            .mockImplementation(async () =>
-              mockNativePromiseResolutionValue(
-                JSON.stringify({
-                  ...baseMockReport,
-                  callQuality: 'Excellent',
-                })
-              )
-            );
+        expect(report).toEqual(expectedReport);
+      });
 
-          await expect(async () => {
-            await preflight.getReport();
-          }).rejects.toBeInstanceOf(InvalidStateError);
+      it('handles null native call quality', async () => {
+        jest
+          .spyOn(Common.NativeModule, 'preflightTest_getReport')
+          .mockResolvedValue(
+            mockNativePromiseResolutionValue(
+              JSON.stringify({
+                ...baseMockReport,
+                callQuality: null,
+                isTurnRequired: false,
+              })
+            )
+          );
+
+        const report = await preflight.getReport();
+
+        expect(report).toEqual({ ...expectedReport, callQuality: null });
+      });
+
+      it('handles undefined native call quality', async () => {
+        jest
+          .spyOn(Common.NativeModule, 'preflightTest_getReport')
+          .mockResolvedValue(
+            mockNativePromiseResolutionValue(
+              JSON.stringify({
+                ...baseMockReport,
+                callQuality: undefined,
+                isTurnRequired: false,
+              })
+            )
+          );
+
+        const report = await preflight.getReport();
+
+        expect(report).toEqual({ ...expectedReport, callQuality: null });
+      });
+
+      it('throws if the native call quality is an invalid string', async () => {
+        jest
+          .spyOn(Common.NativeModule, 'preflightTest_getReport')
+          .mockResolvedValue(
+            mockNativePromiseResolutionValue(
+              JSON.stringify({ ...baseMockReport, callQuality: 'foobar' })
+            )
+          );
+
+        await expect(async () => {
+          await preflight.getReport();
+        }).rejects.toBeInstanceOf(InvalidStateError);
+      });
+
+      it('throws if the native call quality is not a string', async () => {
+        jest
+          .spyOn(Common.NativeModule, 'preflightTest_getReport')
+          .mockResolvedValue(
+            mockNativePromiseResolutionValue(
+              JSON.stringify({ ...baseMockReport, callQuality: 10 })
+            )
+          );
+
+        await expect(async () => {
+          await preflight.getReport();
+        }).rejects.toBeInstanceOf(InvalidStateError);
+      });
+
+      it('reports an empty warnings array if native warnings is undefined', async () => {
+        jest
+          .spyOn(Common.NativeModule, 'preflightTest_getReport')
+          .mockResolvedValue(
+            mockNativePromiseResolutionValue(
+              JSON.stringify({
+                ...baseMockReport,
+                callQuality: 'Excellent',
+                isTurnRequired: false,
+                warnings: undefined,
+              })
+            )
+          );
+
+        const report = await preflight.getReport();
+
+        expect(report).toEqual({
+          ...expectedReport,
+          warnings: [],
         });
       });
 
-      describe('android', () => {
-        beforeEach(() => {
-          jest.spyOn(Common.Platform, 'OS', 'get').mockReturnValue('android');
-        });
+      it('reports an empty warnings array if native warnings is null', async () => {
+        jest
+          .spyOn(Common.NativeModule, 'preflightTest_getReport')
+          .mockResolvedValue(
+            mockNativePromiseResolutionValue(
+              JSON.stringify({
+                ...baseMockReport,
+                callQuality: 'Excellent',
+                isTurnRequired: false,
+                warnings: null,
+              })
+            )
+          );
 
-        it('invokes the native module', async () => {
-          const spy = jest
-            .spyOn(Common.NativeModule, 'preflightTest_getReport')
-            .mockResolvedValue(
-              mockNativePromiseResolutionValue(
-                JSON.stringify({ ...baseMockReport, callQuality: 'Excellent' })
-              )
-            );
+        const report = await preflight.getReport();
 
-          await preflight.getReport();
-
-          expect(spy.mock.calls).toEqual([[mockUuid]]);
-        });
-
-        it('parses a valid native report', async () => {
-          jest
-            .spyOn(Common.NativeModule, 'preflightTest_getReport')
-            .mockResolvedValue(
-              mockNativePromiseResolutionValue(
-                JSON.stringify({
-                  ...baseMockReport,
-                  callQuality: 'Excellent',
-                  isTurnRequired: false,
-                })
-              )
-            );
-
-          const report = await preflight.getReport();
-
-          expect(report).toEqual(expectedReport);
-        });
-
-        it('handles null native call quality', async () => {
-          jest
-            .spyOn(Common.NativeModule, 'preflightTest_getReport')
-            .mockResolvedValue(
-              mockNativePromiseResolutionValue(
-                JSON.stringify({
-                  ...baseMockReport,
-                  callQuality: null,
-                  isTurnRequired: false,
-                })
-              )
-            );
-
-          const report = await preflight.getReport();
-
-          expect(report).toEqual({ ...expectedReport, callQuality: null });
-        });
-
-        it('handles undefined native call quality', async () => {
-          jest
-            .spyOn(Common.NativeModule, 'preflightTest_getReport')
-            .mockResolvedValue(
-              mockNativePromiseResolutionValue(
-                JSON.stringify({
-                  ...baseMockReport,
-                  callQuality: undefined,
-                  isTurnRequired: false,
-                })
-              )
-            );
-
-          const report = await preflight.getReport();
-
-          expect(report).toEqual({ ...expectedReport, callQuality: null });
-        });
-
-        it('throws if the native call quality is an invalid string', async () => {
-          jest
-            .spyOn(Common.NativeModule, 'preflightTest_getReport')
-            .mockResolvedValue(
-              mockNativePromiseResolutionValue(
-                JSON.stringify({ ...baseMockReport, callQuality: 'foobar' })
-              )
-            );
-
-          await expect(async () => {
-            await preflight.getReport();
-          }).rejects.toBeInstanceOf(InvalidStateError);
-        });
-
-        it('throws if the native call quality is not a string', async () => {
-          jest
-            .spyOn(Common.NativeModule, 'preflightTest_getReport')
-            .mockResolvedValue(
-              mockNativePromiseResolutionValue(
-                JSON.stringify({ ...baseMockReport, callQuality: 10 })
-              )
-            );
-
-          await expect(async () => {
-            await preflight.getReport();
-          }).rejects.toBeInstanceOf(InvalidStateError);
-        });
-
-        it('reports an empty warnings array if native warnings is undefined', async () => {
-          jest
-            .spyOn(Common.NativeModule, 'preflightTest_getReport')
-            .mockResolvedValue(
-              mockNativePromiseResolutionValue(
-                JSON.stringify({
-                  ...baseMockReport,
-                  callQuality: 'Excellent',
-                  isTurnRequired: false,
-                  warnings: undefined,
-                })
-              )
-            );
-
-          const report = await preflight.getReport();
-
-          expect(report).toEqual({
-            ...expectedReport,
-            warnings: [],
-          });
-        });
-
-        it('reports an empty warnings array if native warnings is null', async () => {
-          jest
-            .spyOn(Common.NativeModule, 'preflightTest_getReport')
-            .mockResolvedValue(
-              mockNativePromiseResolutionValue(
-                JSON.stringify({
-                  ...baseMockReport,
-                  callQuality: 'Excellent',
-                  isTurnRequired: false,
-                  warnings: null,
-                })
-              )
-            );
-
-          const report = await preflight.getReport();
-
-          expect(report).toEqual({
-            ...expectedReport,
-            warnings: [],
-          });
-        });
-
-        it('reports an empty warningsCleared array if native warningsCleared is undefined', async () => {
-          jest
-            .spyOn(Common.NativeModule, 'preflightTest_getReport')
-            .mockResolvedValue(
-              mockNativePromiseResolutionValue(
-                JSON.stringify({
-                  ...baseMockReport,
-                  callQuality: 'Excellent',
-                  isTurnRequired: false,
-                  warningsCleared: undefined,
-                })
-              )
-            );
-
-          const report = await preflight.getReport();
-
-          expect(report).toEqual({
-            ...expectedReport,
-            warningsCleared: [],
-          });
-        });
-
-        it('reports an empty warningsCleared array if native warningsCleared is null', async () => {
-          jest
-            .spyOn(Common.NativeModule, 'preflightTest_getReport')
-            .mockResolvedValue(
-              mockNativePromiseResolutionValue(
-                JSON.stringify({
-                  ...baseMockReport,
-                  callQuality: 'Excellent',
-                  isTurnRequired: false,
-                  warningsCleared: null,
-                })
-              )
-            );
-
-          const report = await preflight.getReport();
-
-          expect(report).toEqual({
-            ...expectedReport,
-            warningsCleared: [],
-          });
-        });
-
-        it('throws if warnings is not an array', async () => {
-          jest
-            .spyOn(Common.NativeModule, 'preflightTest_getReport')
-            .mockResolvedValue(
-              mockNativePromiseResolutionValue(
-                JSON.stringify({
-                  ...baseMockReport,
-                  callQuality: 'Excellent',
-                  isTurnRequired: false,
-                  warnings: 'foobar',
-                  warningsCleared: undefined,
-                })
-              )
-            );
-
-          expect(async () => {
-            await preflight.getReport();
-          }).rejects.toBeInstanceOf(InvalidStateError);
-        });
-
-        it('throws if warningsCleared is not an array', async () => {
-          jest
-            .spyOn(Common.NativeModule, 'preflightTest_getReport')
-            .mockResolvedValue(
-              mockNativePromiseResolutionValue(
-                JSON.stringify({
-                  ...baseMockReport,
-                  callQuality: 'Excellent',
-                  isTurnRequired: false,
-                  warnings: undefined,
-                  warningsCleared: 'foobar',
-                })
-              )
-            );
-
-          expect(async () => {
-            await preflight.getReport();
-          }).rejects.toBeInstanceOf(InvalidStateError);
-        });
-
-        it('throws if "isTurnRequired" is not a boolean', async () => {
-          jest
-            .spyOn(Common.NativeModule, 'preflightTest_getReport')
-            .mockResolvedValue(
-              mockNativePromiseResolutionValue(
-                JSON.stringify({
-                  ...baseMockReport,
-                  isTurnRequired: 10,
-                  warnings: [],
-                  warningsCleared: [],
-                })
-              )
-            );
-
-          expect(async () => {
-            await preflight.getReport();
-          }).rejects.toBeInstanceOf(InvalidStateError);
-        });
-
-        it('reports null if "isTurnRequired" is undefined', async () => {
-          jest
-            .spyOn(Common.NativeModule, 'preflightTest_getReport')
-            .mockResolvedValue(
-              mockNativePromiseResolutionValue(
-                JSON.stringify({
-                  ...baseMockReport,
-                  callQuality: 'Excellent',
-                  isTurnRequired: undefined,
-                })
-              )
-            );
-
-          const report = await preflight.getReport();
-
-          expect(report).toEqual({
-            ...expectedReport,
-            isTurnRequired: null,
-          });
-        });
-
-        it('reports null if "isTurnRequired" is null', async () => {
-          jest
-            .spyOn(Common.NativeModule, 'preflightTest_getReport')
-            .mockResolvedValue(
-              mockNativePromiseResolutionValue(
-                JSON.stringify({
-                  ...baseMockReport,
-                  callQuality: 'Excellent',
-                  isTurnRequired: null,
-                })
-              )
-            );
-
-          const report = await preflight.getReport();
-
-          expect(report).toEqual({
-            ...expectedReport,
-            isTurnRequired: null,
-          });
+        expect(report).toEqual({
+          ...expectedReport,
+          warnings: [],
         });
       });
 
-      describe('ios', () => {
-        beforeEach(() => {
-          jest.spyOn(Common.Platform, 'OS', 'get').mockReturnValue('ios');
+      it('reports an empty warningsCleared array if native warningsCleared is undefined', async () => {
+        jest
+          .spyOn(Common.NativeModule, 'preflightTest_getReport')
+          .mockResolvedValue(
+            mockNativePromiseResolutionValue(
+              JSON.stringify({
+                ...baseMockReport,
+                callQuality: 'Excellent',
+                isTurnRequired: false,
+                warningsCleared: undefined,
+              })
+            )
+          );
+
+        const report = await preflight.getReport();
+
+        expect(report).toEqual({
+          ...expectedReport,
+          warningsCleared: [],
         });
+      });
 
-        it('invokes the native module', async () => {
-          const spy = jest
-            .spyOn(Common.NativeModule, 'preflightTest_getReport')
-            .mockResolvedValue(
-              mockNativePromiseResolutionValue(
-                JSON.stringify({
-                  ...baseMockReport,
-                  callQuality: 0,
-                  isTurnRequired: 'false',
-                })
-              )
-            );
+      it('reports an empty warningsCleared array if native warningsCleared is null', async () => {
+        jest
+          .spyOn(Common.NativeModule, 'preflightTest_getReport')
+          .mockResolvedValue(
+            mockNativePromiseResolutionValue(
+              JSON.stringify({
+                ...baseMockReport,
+                callQuality: 'Excellent',
+                isTurnRequired: false,
+                warningsCleared: null,
+              })
+            )
+          );
 
+        const report = await preflight.getReport();
+
+        expect(report).toEqual({
+          ...expectedReport,
+          warningsCleared: [],
+        });
+      });
+
+      it('throws if warnings is not an array', async () => {
+        jest
+          .spyOn(Common.NativeModule, 'preflightTest_getReport')
+          .mockResolvedValue(
+            mockNativePromiseResolutionValue(
+              JSON.stringify({
+                ...baseMockReport,
+                callQuality: 'Excellent',
+                isTurnRequired: false,
+                warnings: 'foobar',
+                warningsCleared: undefined,
+              })
+            )
+          );
+
+        await expect(async () => {
           await preflight.getReport();
+        }).rejects.toBeInstanceOf(InvalidStateError);
+      });
 
-          expect(spy.mock.calls).toEqual([[mockUuid]]);
+      it('throws if warningsCleared is not an array', async () => {
+        jest
+          .spyOn(Common.NativeModule, 'preflightTest_getReport')
+          .mockResolvedValue(
+            mockNativePromiseResolutionValue(
+              JSON.stringify({
+                ...baseMockReport,
+                callQuality: 'Excellent',
+                isTurnRequired: false,
+                warnings: undefined,
+                warningsCleared: 'foobar',
+              })
+            )
+          );
+
+        await expect(async () => {
+          await preflight.getReport();
+        }).rejects.toBeInstanceOf(InvalidStateError);
+      });
+
+      it('throws if "isTurnRequired" is not a boolean', async () => {
+        jest
+          .spyOn(Common.NativeModule, 'preflightTest_getReport')
+          .mockResolvedValue(
+            mockNativePromiseResolutionValue(
+              JSON.stringify({
+                ...baseMockReport,
+                isTurnRequired: 10,
+                warnings: [],
+                warningsCleared: [],
+              })
+            )
+          );
+
+        await expect(async () => {
+          await preflight.getReport();
+        }).rejects.toBeInstanceOf(InvalidStateError);
+      });
+
+      it('reports null if "isTurnRequired" is undefined', async () => {
+        jest
+          .spyOn(Common.NativeModule, 'preflightTest_getReport')
+          .mockResolvedValue(
+            mockNativePromiseResolutionValue(
+              JSON.stringify({
+                ...baseMockReport,
+                callQuality: 'Excellent',
+                isTurnRequired: undefined,
+              })
+            )
+          );
+
+        const report = await preflight.getReport();
+
+        expect(report).toEqual({
+          ...expectedReport,
+          isTurnRequired: null,
         });
+      });
 
-        it('parses a valid native report', async () => {
-          jest
-            .spyOn(Common.NativeModule, 'preflightTest_getReport')
-            .mockResolvedValue(
-              mockNativePromiseResolutionValue(
-                JSON.stringify({
-                  ...baseMockReport,
-                  callQuality: 0,
-                  isTurnRequired: 'false',
-                })
-              )
-            );
+      it('reports null if "isTurnRequired" is null', async () => {
+        jest
+          .spyOn(Common.NativeModule, 'preflightTest_getReport')
+          .mockResolvedValue(
+            mockNativePromiseResolutionValue(
+              JSON.stringify({
+                ...baseMockReport,
+                callQuality: 'Excellent',
+                isTurnRequired: null,
+              })
+            )
+          );
 
-          const report = await preflight.getReport();
+        const report = await preflight.getReport();
 
-          expect(report).toEqual(expectedReport);
-        });
-
-        it('handles null native call quality', async () => {
-          jest
-            .spyOn(Common.NativeModule, 'preflightTest_getReport')
-            .mockResolvedValue(
-              mockNativePromiseResolutionValue(
-                JSON.stringify({
-                  ...baseMockReport,
-                  callQuality: null,
-                  isTurnRequired: 'false',
-                })
-              )
-            );
-
-          const report = await preflight.getReport();
-
-          expect(report).toEqual({ ...expectedReport, callQuality: null });
-        });
-
-        it('handles undefined native call quality', async () => {
-          jest
-            .spyOn(Common.NativeModule, 'preflightTest_getReport')
-            .mockResolvedValue(
-              mockNativePromiseResolutionValue(
-                JSON.stringify({
-                  ...baseMockReport,
-                  callQuality: undefined,
-                  isTurnRequired: 'false',
-                })
-              )
-            );
-
-          const report = await preflight.getReport();
-
-          expect(report).toEqual({ ...expectedReport, callQuality: null });
-        });
-
-        it('throws if the native call quality is an invalid number', async () => {
-          jest
-            .spyOn(Common.NativeModule, 'preflightTest_getReport')
-            .mockResolvedValue(
-              mockNativePromiseResolutionValue(
-                JSON.stringify({ ...baseMockReport, callQuality: 100 })
-              )
-            );
-
-          await expect(async () => {
-            await preflight.getReport();
-          }).rejects.toBeInstanceOf(InvalidStateError);
-        });
-
-        it('throws if the native call quality is not a number', async () => {
-          jest
-            .spyOn(Common.NativeModule, 'preflightTest_getReport')
-            .mockResolvedValue(
-              mockNativePromiseResolutionValue(
-                JSON.stringify({ ...baseMockReport, callQuality: 'foobar' })
-              )
-            );
-
-          await expect(async () => {
-            await preflight.getReport();
-          }).rejects.toBeInstanceOf(InvalidStateError);
-        });
-
-        it('throws if the native "isTurnRequired" is not a string', async () => {
-          jest
-            .spyOn(Common.NativeModule, 'preflightTest_getReport')
-            .mockResolvedValue(
-              mockNativePromiseResolutionValue(
-                JSON.stringify({
-                  ...baseMockReport,
-                  callQuality: 0,
-                  isTurnRequired: 10,
-                })
-              )
-            );
-
-          await expect(async () => {
-            await preflight.getReport();
-          }).rejects.toBeInstanceOf(InvalidStateError);
-        });
-
-        it('throws if the native "isTurnRequired" is not valid', async () => {
-          jest
-            .spyOn(Common.NativeModule, 'preflightTest_getReport')
-            .mockResolvedValue(
-              mockNativePromiseResolutionValue(
-                JSON.stringify({
-                  ...baseMockReport,
-                  callQuality: 0,
-                  isTurnRequired: 'foobar',
-                })
-              )
-            );
-
-          await expect(async () => {
-            await preflight.getReport();
-          }).rejects.toBeInstanceOf(InvalidStateError);
-        });
-
-        it('reports null if "isTurnRequired" is undefined', async () => {
-          jest
-            .spyOn(Common.NativeModule, 'preflightTest_getReport')
-            .mockResolvedValue(
-              mockNativePromiseResolutionValue(
-                JSON.stringify({
-                  ...baseMockReport,
-                  callQuality: 0,
-                  isTurnRequired: undefined,
-                })
-              )
-            );
-
-          const report = await preflight.getReport();
-
-          expect(report).toEqual({
-            ...expectedReport,
-            isTurnRequired: null,
-          });
-        });
-
-        it('reports null if "isTurnRequired" is null', async () => {
-          jest
-            .spyOn(Common.NativeModule, 'preflightTest_getReport')
-            .mockResolvedValue(
-              mockNativePromiseResolutionValue(
-                JSON.stringify({
-                  ...baseMockReport,
-                  callQuality: 0,
-                  isTurnRequired: null,
-                })
-              )
-            );
-
-          const report = await preflight.getReport();
-
-          expect(report).toEqual({
-            ...expectedReport,
-            isTurnRequired: null,
-          });
-        });
-
-        it('reports an empty warnings array if native warnings is undefined', async () => {
-          jest
-            .spyOn(Common.NativeModule, 'preflightTest_getReport')
-            .mockResolvedValue(
-              mockNativePromiseResolutionValue(
-                JSON.stringify({
-                  ...baseMockReport,
-                  callQuality: 0,
-                  isTurnRequired: 'false',
-                  warnings: undefined,
-                })
-              )
-            );
-
-          const report = await preflight.getReport();
-
-          expect(report).toEqual({
-            ...expectedReport,
-            warnings: [],
-          });
-        });
-
-        it('reports an empty warnings array if native warnings is null', async () => {
-          jest
-            .spyOn(Common.NativeModule, 'preflightTest_getReport')
-            .mockResolvedValue(
-              mockNativePromiseResolutionValue(
-                JSON.stringify({
-                  ...baseMockReport,
-                  callQuality: 0,
-                  isTurnRequired: 'false',
-                  warnings: null,
-                })
-              )
-            );
-
-          const report = await preflight.getReport();
-
-          expect(report).toEqual({
-            ...expectedReport,
-            warnings: [],
-          });
-        });
-
-        it('reports an empty warningsCleared array if native warningsCleared is undefined', async () => {
-          jest
-            .spyOn(Common.NativeModule, 'preflightTest_getReport')
-            .mockResolvedValue(
-              mockNativePromiseResolutionValue(
-                JSON.stringify({
-                  ...baseMockReport,
-                  callQuality: 0,
-                  isTurnRequired: 'false',
-                  warningsCleared: undefined,
-                })
-              )
-            );
-
-          const report = await preflight.getReport();
-
-          expect(report).toEqual({
-            ...expectedReport,
-            warningsCleared: [],
-          });
-        });
-
-        it('reports an empty warningsCleared array if native warningsCleared is null', async () => {
-          jest
-            .spyOn(Common.NativeModule, 'preflightTest_getReport')
-            .mockResolvedValue(
-              mockNativePromiseResolutionValue(
-                JSON.stringify({
-                  ...baseMockReport,
-                  callQuality: 0,
-                  isTurnRequired: 'false',
-                  warningsCleared: null,
-                })
-              )
-            );
-
-          const report = await preflight.getReport();
-
-          expect(report).toEqual({
-            ...expectedReport,
-            warningsCleared: [],
-          });
-        });
-
-        it('throws if warnings is not an array', async () => {
-          jest
-            .spyOn(Common.NativeModule, 'preflightTest_getReport')
-            .mockResolvedValue(
-              mockNativePromiseResolutionValue(
-                JSON.stringify({
-                  ...baseMockReport,
-                  callQuality: 0,
-                  isTurnRequired: 'false',
-                  warnings: 'foobar',
-                  warningsCleared: undefined,
-                })
-              )
-            );
-
-          expect(async () => {
-            await preflight.getReport();
-          }).rejects.toBeInstanceOf(InvalidStateError);
-        });
-
-        it('throws if warningsCleared is not an array', async () => {
-          jest
-            .spyOn(Common.NativeModule, 'preflightTest_getReport')
-            .mockResolvedValue(
-              mockNativePromiseResolutionValue(
-                JSON.stringify({
-                  ...baseMockReport,
-                  callQuality: 0,
-                  isTurnRequired: 'false',
-                  warnings: undefined,
-                  warningsCleared: 'foobar',
-                })
-              )
-            );
-
-          expect(async () => {
-            await preflight.getReport();
-          }).rejects.toBeInstanceOf(InvalidStateError);
+        expect(report).toEqual({
+          ...expectedReport,
+          isTurnRequired: null,
         });
       });
     });
@@ -1260,7 +859,7 @@ describe('PreflightTest', () => {
           .spyOn(Common.NativeModule, 'preflightTest_getState')
           .mockImplementation(async () => 10 as any);
 
-        expect(async () => {
+        await expect(async () => {
           await preflight.getState();
         }).rejects.toThrowError(InvalidStateError);
       });

--- a/src/__tests__/Voice.test.ts
+++ b/src/__tests__/Voice.test.ts
@@ -94,6 +94,14 @@ describe('Voice class', () => {
           [Constants.ScopeVoice, voice['_handleNativeEvent']],
         ]);
       });
+
+      it('sets the expo version', () => {
+        // eslint-disable-next-line no-new
+        new Voice();
+        expect(
+          jest.mocked(MockNativeModule.voice_setExpoVersion).mock.calls
+        ).toEqual([['52.0.0']]);
+      });
     });
   });
 

--- a/src/__tests__/Voice.test.ts
+++ b/src/__tests__/Voice.test.ts
@@ -4,7 +4,12 @@ import type { NativeEventEmitter as MockNativeEventEmitterType } from '../__mock
 import { mockVoiceNativeEvents } from '../__mocks__/Voice';
 import type { AudioDevice } from '../AudioDevice';
 import type { CallInvite } from '../CallInvite';
-import { NativeEventEmitter, NativeModule, Platform } from '../common';
+import {
+  NativeEventEmitter,
+  NativeModule,
+  Platform,
+  getExpoVersion,
+} from '../common';
 import { Constants } from '../constants';
 import {
   InvalidArgumentError,
@@ -101,6 +106,15 @@ describe('Voice class', () => {
         expect(
           jest.mocked(MockNativeModule.voice_setExpoVersion).mock.calls
         ).toEqual([['52.0.0']]);
+      });
+
+      it('passes undefined expo version when not in an Expo app', () => {
+        jest.mocked(getExpoVersion).mockReturnValueOnce(undefined);
+        // eslint-disable-next-line no-new
+        new Voice();
+        expect(
+          jest.mocked(MockNativeModule.voice_setExpoVersion).mock.calls
+        ).toEqual([[undefined]]);
       });
     });
   });

--- a/src/__tests__/expoVersion.test.ts
+++ b/src/__tests__/expoVersion.test.ts
@@ -1,0 +1,64 @@
+import { getExpoVersion } from '../utility/expoVersion';
+
+function setExpoManifest(manifest: any) {
+  global.expo = {
+    modules: { ExponentConstants: { manifest } },
+  } as any;
+}
+
+describe('getExpoVersion', () => {
+  it('should get the version if the expo manifest is an object', () => {
+    setExpoManifest({ sdkVersion: 'foobar' });
+    expect(getExpoVersion()).toBe('foobar');
+  });
+
+  it('should get the version if the expo manifest is a valid json string', () => {
+    setExpoManifest(JSON.stringify({ sdkVersion: 'foobar' }));
+    expect(getExpoVersion()).toBe('foobar');
+  });
+
+  it('should return undefined if the expo manifest is not a json string', () => {
+    setExpoManifest('foobar');
+    expect(getExpoVersion()).toBe(undefined);
+  });
+
+  it('should return undefined if the expo manifest is null', () => {
+    setExpoManifest(null);
+    expect(getExpoVersion()).toBe(undefined);
+  });
+
+  it('should return undefined if the expo manifest is not an object or a string', () => {
+    setExpoManifest(10);
+    expect(getExpoVersion()).toBe(undefined);
+  });
+
+  it('should return undefined if the json-parsed expo manifest is null', () => {
+    setExpoManifest(JSON.stringify(null));
+    expect(getExpoVersion()).toBe(undefined);
+  });
+
+  it('should return undefined if the json-parsed expo manifest is not an object or a string', () => {
+    setExpoManifest(JSON.stringify(10));
+    expect(getExpoVersion()).toBe(undefined);
+  });
+
+  it('should return undefined if the expo object is not in the global scope', () => {
+    global.expo = undefined as any;
+    expect(getExpoVersion()).toBe(undefined);
+  });
+
+  it('should return undefined if the modules member is not in the expo object', () => {
+    global.expo = {} as any;
+    expect(getExpoVersion()).toBe(undefined);
+  });
+
+  it('should return undefined if the ExponentConstants member is not in the modules object', () => {
+    global.expo = { modules: {} } as any;
+    expect(getExpoVersion()).toBe(undefined);
+  });
+
+  it('should return undefined if the manifest member is not in the ExponentConstants object', () => {
+    global.expo = { modules: { ExponentConstants: {} } } as any;
+    expect(getExpoVersion()).toBe(undefined);
+  });
+});

--- a/src/__tests__/expoVersion.test.ts
+++ b/src/__tests__/expoVersion.test.ts
@@ -7,6 +7,16 @@ function setExpoManifest(manifest: any) {
 }
 
 describe('getExpoVersion', () => {
+  let originalExpoGlobal: any;
+
+  beforeEach(() => {
+    originalExpoGlobal = global.expo;
+  });
+
+  afterEach(() => {
+    global.expo = originalExpoGlobal;
+  });
+
   it('should get the version if the expo manifest is an object', () => {
     setExpoManifest({ sdkVersion: 'foobar' });
     expect(getExpoVersion()).toBe('foobar');
@@ -15,6 +25,21 @@ describe('getExpoVersion', () => {
   it('should get the version if the expo manifest is a valid json string', () => {
     setExpoManifest(JSON.stringify({ sdkVersion: 'foobar' }));
     expect(getExpoVersion()).toBe('foobar');
+  });
+
+  it('should stringify a number sdk version', () => {
+    setExpoManifest(JSON.stringify({ sdkVersion: 52 }));
+    expect(getExpoVersion()).toBe('52');
+  });
+
+  it('should return undefined if the sdk version is not a string or a number', () => {
+    const invalidValues = [null, {}, false, true, undefined];
+    expect.assertions(invalidValues.length);
+
+    for (const val of invalidValues) {
+      setExpoManifest(JSON.stringify({ sdkVersion: val }));
+      expect(getExpoVersion()).toBe(undefined);
+    }
   });
 
   it('should return undefined if the expo manifest is not a json string', () => {

--- a/src/__tests__/expoVersion.test.ts
+++ b/src/__tests__/expoVersion.test.ts
@@ -1,7 +1,7 @@
 import { getExpoVersion } from '../utility/expoVersion';
 
 function setExpoManifest(manifest: any) {
-  global.expo = {
+  (global as any).expo = {
     modules: { ExponentConstants: { manifest } },
   } as any;
 }
@@ -10,11 +10,11 @@ describe('getExpoVersion', () => {
   let originalExpoGlobal: any;
 
   beforeEach(() => {
-    originalExpoGlobal = global.expo;
+    originalExpoGlobal = (global as any).expo;
   });
 
   afterEach(() => {
-    global.expo = originalExpoGlobal;
+    (global as any).expo = originalExpoGlobal;
   });
 
   it('should get the version if the expo manifest is an object', () => {
@@ -68,22 +68,22 @@ describe('getExpoVersion', () => {
   });
 
   it('should return undefined if the expo object is not in the global scope', () => {
-    global.expo = undefined as any;
+    (global as any).expo = undefined as any;
     expect(getExpoVersion()).toBe(undefined);
   });
 
   it('should return undefined if the modules member is not in the expo object', () => {
-    global.expo = {} as any;
+    (global as any).expo = {} as any;
     expect(getExpoVersion()).toBe(undefined);
   });
 
   it('should return undefined if the ExponentConstants member is not in the modules object', () => {
-    global.expo = { modules: {} } as any;
+    (global as any).expo = { modules: {} } as any;
     expect(getExpoVersion()).toBe(undefined);
   });
 
   it('should return undefined if the manifest member is not in the ExponentConstants object', () => {
-    global.expo = { modules: { ExponentConstants: {} } } as any;
+    (global as any).expo = { modules: { ExponentConstants: {} } } as any;
     expect(getExpoVersion()).toBe(undefined);
   });
 });

--- a/src/common.ts
+++ b/src/common.ts
@@ -8,6 +8,7 @@
 import { requireNativeModule } from 'expo-modules-core';
 import * as ReactNative from 'react-native';
 import type { TwilioVoiceReactNative as TwilioVoiceReactNativeType } from './type/NativeModule';
+import { getExpoVersion } from './utility/expoVersion';
 
 export const Platform = ReactNative.Platform;
 
@@ -22,3 +23,5 @@ export const NativeEventEmitter =
     : new ReactNative.NativeEventEmitter(NativeModule);
 
 export const setTimeout = global.setTimeout;
+
+export { getExpoVersion };

--- a/src/type/NativeModule.ts
+++ b/src/type/NativeModule.ts
@@ -111,6 +111,7 @@ export interface TwilioVoiceReactNative extends NativeModulesStatic {
   voice_setCallKitConfiguration(
     configuration: Record<string, any>
   ): NativePromise<void>;
+  voice_setExpoVersion(expoVersion: string | undefined): NativePromise<void>;
   voice_setIncomingCallContactHandleTemplate(
     template?: string
   ): NativePromise<void>;

--- a/src/utility/expoVersion.ts
+++ b/src/utility/expoVersion.ts
@@ -1,0 +1,15 @@
+export function getExpoVersion(): string | undefined {
+  const expoManifest = global.expo?.modules?.ExponentConstants?.manifest;
+
+  if (!expoManifest) return undefined;
+
+  try {
+    const manifest =
+      typeof expoManifest === 'string'
+        ? JSON.parse(expoManifest)
+        : expoManifest;
+    return manifest?.sdkVersion;
+  } catch {
+    return undefined;
+  }
+}

--- a/src/utility/expoVersion.ts
+++ b/src/utility/expoVersion.ts
@@ -1,14 +1,27 @@
 export function getExpoVersion(): string | undefined {
   const expoManifest = global.expo?.modules?.ExponentConstants?.manifest;
 
-  if (!expoManifest) return undefined;
+  if (!expoManifest) {
+    return undefined;
+  }
 
   try {
     const manifest =
       typeof expoManifest === 'string'
         ? JSON.parse(expoManifest)
         : expoManifest;
-    return manifest?.sdkVersion;
+
+    const sdkVersion = manifest?.sdkVersion;
+
+    if (typeof sdkVersion === 'string') {
+      return sdkVersion;
+    }
+
+    if (typeof sdkVersion === 'number') {
+      return String(sdkVersion);
+    }
+
+    return undefined;
   } catch {
     return undefined;
   }

--- a/test/expo/detox/scripts/patch-all.bash
+++ b/test/expo/detox/scripts/patch-all.bash
@@ -2,6 +2,8 @@
 
 # Please see `test/expo/README.md` for info on why this script exists
 
+echo "Patching native files for Detox support"
+
 bash detox/scripts/verify-checksums.bash
 if [[ $? -ne 0 ]]; then
   echo "Checksum validation failed"

--- a/twilio-voice-react-native.podspec
+++ b/twilio-voice-react-native.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
   s.source_files = "ios/**/*.{h,m,mm}"
 
   s.dependency "React-Core"
-  s.dependency "TwilioVoice", "6.13.3"
+  s.dependency "TwilioVoice", "6.13.6"
   s.xcconfig  =  { 'VALID_ARCHS' => 'arm64 x86_64' }
   s.pod_target_xcconfig   = { 'VALID_ARCHS[sdk=iphoneos*]' => 'arm64', 'VALID_ARCHS[sdk=iphonesimulator*]' => 'arm64 x86_64' }
 end


### PR DESCRIPTION
## Submission Checklist

 - [ ] Updated the `CHANGELOG.md` to reflect any **feature**, **bug fixes**, or **known issues** made in the source code
 - [ ] Tested code changes and observed expected behavior in the example app
 - [x] Performed a visual inspection of the `Files changed` tab prior to submitting the pull request for review to ensure proper usage of the style guide

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Description

This PR pulls the latest versions of the native iOS and Android SDKs. This PR also updates/removes the shimming that we did for some differently named keys in the PreflightTest reports.

## Breakdown

- Pull latest versions of the native iOS and Android SDKs.
- Remove shimming of PreflightTest report keys.

## Validation

- Integration tests passing.
- Local tests passing.

## Additional Notes

N/A
