### PR TITLE
feat: add default value for release tag

### DIFF
--- a/.release.json
+++ b/.release.json
@@ -51,6 +51,9 @@
       ]
     },
     "publish": {
+      "env": {
+        "RELEASE_TAG": ""
+      },
       "commands": [
         "git checkout ${RELEASE_VERSION}",
         "RELEASE_TAG=$(echo \"$RELEASE_VERSION\" | sed -E -n 's/^[0-9]+\\.[0-9]+\\.[0-9]+-([a-z]+)\\..*/\\1/p'); NPM_ID_TOKEN=$(circleci run oidc get --claims '{\"aud\": \"npm:registry.npmjs.org\"}') npm publish ${RELEASE_TAG:+--tag \"$RELEASE_TAG\"}"


### PR DESCRIPTION
## Submission Checklist

 - [ ] Updated the `CHANGELOG.md` to reflect any **feature**, **bug fixes**, or **known issues** made in the source code
 - [ ] Tested code changes and observed expected behavior in the example app
 - [x] Performed a visual inspection of the `Files changed` tab prior to submitting the pull request for review to ensure proper usage of the style guide

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Description

This PR adds a default blank value for the RELEASE_TAG env var to satisfy the script preflight checks.

## Breakdown

- Add default blank value for RELEASE_TAG.

## Validation

- N/A

## Additional Notes

N/A
