### PR TITLE
[VBLOCKS-6432] feat: relax null-related crashing

### DIFF
--- a/android/src/main/java/com/twiliovoicereactnative/CallListenerProxy.java
+++ b/android/src/main/java/com/twiliovoicereactnative/CallListenerProxy.java
@@ -34,7 +34,6 @@ import static com.twiliovoicereactnative.ReactNativeArgumentsSerializer.*;
 import com.twiliovoicereactnative.CallRecordDatabase.CallRecord;
 
 import java.util.Date;
-import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
 
@@ -57,7 +56,8 @@ class CallListenerProxy implements Call.Listener {
     getAudioSwitchManager().getAudioSwitch().deactivate();
 
     // find call record & remove
-    CallRecord callRecord = Objects.requireNonNull(getCallRecordDatabase().remove(new CallRecord(uuid)));
+    CallRecord callRecord = getCallRecordDatabase().remove(new CallRecord(uuid));
+    if (null == callRecord) { return; }
 
     // take down notification
     getVoiceServiceApi().cancelActiveCallNotification(callRecord);
@@ -75,7 +75,8 @@ class CallListenerProxy implements Call.Listener {
     debug("onRinging");
 
     // find call record
-    CallRecord callRecord = Objects.requireNonNull(getCallRecordDatabase().get(new CallRecord(uuid)));
+    CallRecord callRecord = getCallRecordDatabase().get(new CallRecord(uuid));
+    if (null == callRecord) { return; }
     callRecord.setCall(call);
 
     // create notification & sound
@@ -95,11 +96,14 @@ class CallListenerProxy implements Call.Listener {
   public void onConnected(@NonNull Call call) {
     debug("onConnected");
 
+    // stop outgoing ringtone
+    getMediaPlayerManager().stop();
+
     // find call record
-    CallRecord callRecord = Objects.requireNonNull(getCallRecordDatabase().get(new CallRecord(uuid)));
+    CallRecord callRecord = getCallRecordDatabase().get(new CallRecord(uuid));
+    if (null == callRecord) { return; }
     callRecord.setCall(call);
     callRecord.setTimestamp(new Date());
-    getMediaPlayerManager().stop();
 
     // notify JS layer
     sendJSEvent(
@@ -113,7 +117,8 @@ class CallListenerProxy implements Call.Listener {
     debug("onReconnecting");
 
     // find & update call record
-    CallRecord callRecord = Objects.requireNonNull(getCallRecordDatabase().get(new CallRecord(uuid)));
+    CallRecord callRecord = getCallRecordDatabase().get(new CallRecord(uuid));
+    if (null == callRecord) { return; }
 
     // notify JS layer
     sendJSEvent(
@@ -128,7 +133,8 @@ class CallListenerProxy implements Call.Listener {
     debug("onReconnected");
 
     // find & update call record
-    CallRecord callRecord = Objects.requireNonNull(getCallRecordDatabase().get(new CallRecord(uuid)));
+    CallRecord callRecord = getCallRecordDatabase().get(new CallRecord(uuid));
+    if (null == callRecord) { return; }
 
     // notify JS layer
     sendJSEvent(
@@ -141,13 +147,16 @@ class CallListenerProxy implements Call.Listener {
   public void onDisconnected(@NonNull Call call, @Nullable CallException callException) {
     debug("onDisconnected");
 
-    // find & remove call record
-    CallRecord callRecord = Objects.requireNonNull(getCallRecordDatabase().remove(new CallRecord(uuid)));
-
-    // stop audio & cancel notification
+    // stop audio & restore routing
     getMediaPlayerManager().stop();
     getMediaPlayerManager().play(MediaPlayerManager.SoundTable.DISCONNECT);
     getAudioSwitchManager().getAudioSwitch().deactivate();
+
+    // find & remove call record
+    CallRecord callRecord = getCallRecordDatabase().remove(new CallRecord(uuid));
+    if (null == callRecord) { return; }
+
+    // cancel notification
     getVoiceServiceApi().cancelActiveCallNotification(callRecord);
 
     // notify JS layer
@@ -165,7 +174,8 @@ class CallListenerProxy implements Call.Listener {
     debug("onCallQualityWarningsChanged");
 
     // find call record
-    CallRecord callRecord = Objects.requireNonNull(getCallRecordDatabase().get(new CallRecord(uuid)));
+    CallRecord callRecord = getCallRecordDatabase().get(new CallRecord(uuid));
+    if (null == callRecord) { return; }
 
     // notify JS layer
     sendJSEvent(

--- a/android/src/main/java/com/twiliovoicereactnative/CallMessageListenerProxy.java
+++ b/android/src/main/java/com/twiliovoicereactnative/CallMessageListenerProxy.java
@@ -32,7 +32,6 @@ import com.twilio.voice.VoiceException;
 
 import com.twiliovoicereactnative.CallRecordDatabase.CallRecord;
 
-import java.util.Objects;
 
 
 public class CallMessageListenerProxy implements Call.CallMessageListener {
@@ -69,8 +68,8 @@ public class CallMessageListenerProxy implements Call.CallMessageListener {
     logger.debug("onMessageReceived");
 
     //final call record
-    final CallRecord callRecord =
-      Objects.requireNonNull(getCallRecordDatabase().get(new CallRecord(callSid)));
+    final CallRecord callRecord = getCallRecordDatabase().get(new CallRecord(callSid));
+    if (null == callRecord) { return; }
 
     // notify JS layer ScopeCallInvite or ScopeCall
     final String event =

--- a/android/src/main/java/com/twiliovoicereactnative/CallRecordDatabase.java
+++ b/android/src/main/java/com/twiliovoicereactnative/CallRecordDatabase.java
@@ -82,7 +82,7 @@ class CallRecordDatabase  {
       return this.voiceCall;
     }
     public final Map<String, String> getCustomParameters() {
-      if (this.direction == Direction.INCOMING) {
+      if (this.direction == Direction.INCOMING && null != this.callInvite) {
         return this.callInvite.getCustomParameters();
       }
       return this.customParameters;
@@ -158,19 +158,15 @@ class CallRecordDatabase  {
     callRecordList.clear();
   }
 
-  public CallRecord get(final CallRecord record) {
-    try {
-      return callRecordList.get(callRecordList.indexOf(record));
-    } catch (IndexOutOfBoundsException e) {
-      return null;
-    }
+  public synchronized CallRecord get(final CallRecord record) {
+    int index = callRecordList.indexOf(record);
+    if (index < 0) { return null; }
+    return callRecordList.get(index);
   }
-  public CallRecord remove(final CallRecord record) {
-    try {
-      return callRecordList.remove(callRecordList.indexOf(record));
-    } catch (IndexOutOfBoundsException e) {
-      return null;
-    }
+  public synchronized CallRecord remove(final CallRecord record) {
+    int index = callRecordList.indexOf(record);
+    if (index < 0) { return null; }
+    return callRecordList.remove(index);
   }
   public Collection<CallRecord> getCollection() {
     return callRecordList;

--- a/android/src/main/java/com/twiliovoicereactnative/Constants.java
+++ b/android/src/main/java/com/twiliovoicereactnative/Constants.java
@@ -15,6 +15,7 @@ class Constants {
   public static final String ACTION_PUSH_APP_TO_FOREGROUND = "ACTION_PUSH_APP_TO_FOREGROUND";
   public static final String ACTION_FOREGROUND_AND_DEPRIORITIZE_INCOMING_CALL_NOTIFICATION = "ACTION_FOREGROUND_AND_DEPRIORITIZE_INCOMING_CALL_NOTIFICATION";
   public static final String MSG_KEY_UUID = "UUID";
+  public static final String MSG_KEY_NOTIFICATION_ID = "NOTIFICATION_ID";
   public static final String JS_EVENT_KEY_CALL_INFO = "call";
   public static final String JS_EVENT_KEY_CALL_INVITE_INFO = "callInvite";
   public static final String JS_EVENT_KEY_CANCELLED_CALL_INVITE_INFO = "cancelledCallInvite";

--- a/android/src/main/java/com/twiliovoicereactnative/NotificationUtility.java
+++ b/android/src/main/java/com/twiliovoicereactnative/NotificationUtility.java
@@ -149,6 +149,7 @@ class NotificationUtility {
       Constants.ACTION_FOREGROUND_AND_DEPRIORITIZE_INCOMING_CALL_NOTIFICATION,
       Objects.requireNonNull(VoiceApplicationProxy.getMainActivityClass()),
       callRecord.getUuid());
+    foregroundIntent.putExtra(Constants.MSG_KEY_NOTIFICATION_ID, callRecord.getNotificationId());
     PendingIntent piForegroundIntent = constructPendingIntentForActivity(context, foregroundIntent);
 
     Intent rejectIntent = constructMessage(
@@ -156,6 +157,7 @@ class NotificationUtility {
       Constants.ACTION_REJECT_CALL,
       VoiceService.class,
       callRecord.getUuid());
+    rejectIntent.putExtra(Constants.MSG_KEY_NOTIFICATION_ID, callRecord.getNotificationId());
     PendingIntent piRejectIntent = constructPendingIntentForService(context, rejectIntent);
 
     Intent acceptIntent = constructMessage(
@@ -163,6 +165,7 @@ class NotificationUtility {
       Constants.ACTION_ACCEPT_CALL,
       Objects.requireNonNull(VoiceApplicationProxy.getMainActivityClass()),
       callRecord.getUuid());
+    acceptIntent.putExtra(Constants.MSG_KEY_NOTIFICATION_ID, callRecord.getNotificationId());
     PendingIntent piAcceptIntent = constructPendingIntentForActivity(context, acceptIntent);
 
     return constructNotificationBuilder(context, channelImportance)
@@ -193,6 +196,7 @@ class NotificationUtility {
       Constants.ACTION_PUSH_APP_TO_FOREGROUND,
       Objects.requireNonNull(VoiceApplicationProxy.getMainActivityClass()),
       callRecord.getUuid());
+    foregroundIntent.putExtra(Constants.MSG_KEY_NOTIFICATION_ID, callRecord.getNotificationId());
     PendingIntent piForegroundIntent = constructPendingIntentForActivity(context, foregroundIntent);
 
     Intent endCallIntent = constructMessage(
@@ -200,6 +204,7 @@ class NotificationUtility {
       Constants.ACTION_CALL_DISCONNECT,
       VoiceService.class,
       callRecord.getUuid());
+    endCallIntent.putExtra(Constants.MSG_KEY_NOTIFICATION_ID, callRecord.getNotificationId());
     PendingIntent piEndCallIntent = constructPendingIntentForService(context, endCallIntent);
 
     return constructNotificationBuilder(context, Constants.VOICE_CHANNEL_LOW_IMPORTANCE)
@@ -230,6 +235,7 @@ class NotificationUtility {
       Constants.ACTION_PUSH_APP_TO_FOREGROUND,
       Objects.requireNonNull(VoiceApplicationProxy.getMainActivityClass()),
       callRecord.getUuid());
+    foregroundIntent.putExtra(Constants.MSG_KEY_NOTIFICATION_ID, callRecord.getNotificationId());
     PendingIntent piForegroundIntent = constructPendingIntentForActivity(context, foregroundIntent);
 
     Intent endCallIntent = constructMessage(
@@ -237,6 +243,7 @@ class NotificationUtility {
       Constants.ACTION_CALL_DISCONNECT,
       VoiceService.class,
       callRecord.getUuid());
+    endCallIntent.putExtra(Constants.MSG_KEY_NOTIFICATION_ID, callRecord.getNotificationId());
     PendingIntent piEndCallIntent = constructPendingIntentForService(context, endCallIntent);
 
     return constructNotificationBuilder(context, Constants.VOICE_CHANNEL_LOW_IMPORTANCE)

--- a/android/src/main/java/com/twiliovoicereactnative/VoiceActivityProxy.java
+++ b/android/src/main/java/com/twiliovoicereactnative/VoiceActivityProxy.java
@@ -76,6 +76,7 @@ public class VoiceActivityProxy {
     return true;
   }
   private void handleIntent(Intent intent) {
+    if (null == intent) { return; }
     String action = intent.getAction();
     if ((null != action) && (!action.equals(Constants.ACTION_PUSH_APP_TO_FOREGROUND))) {
       Intent copiedIntent = new Intent(intent);

--- a/android/src/main/java/com/twiliovoicereactnative/VoiceFirebaseMessagingService.java
+++ b/android/src/main/java/com/twiliovoicereactnative/VoiceFirebaseMessagingService.java
@@ -17,7 +17,6 @@ import com.twilio.voice.CancelledCallInvite;
 import com.twilio.voice.MessageListener;
 import com.twilio.voice.Voice;
 
-import java.util.Objects;
 import java.util.UUID;
 
 public class VoiceFirebaseMessagingService extends FirebaseMessagingService {
@@ -39,8 +38,12 @@ public class VoiceFirebaseMessagingService extends FirebaseMessagingService {
                                       @Nullable CallException callException) {
       logger.log(String.format("onCancelledCallInvite %s", cancelledCallInvite.getCallSid()));
 
-      CallRecord callRecord = Objects.requireNonNull(
-        getCallRecordDatabase().remove(new CallRecord(cancelledCallInvite.getCallSid())));
+      CallRecord callRecord =
+        getCallRecordDatabase().remove(new CallRecord(cancelledCallInvite.getCallSid()));
+      if (null == callRecord) {
+        logger.warning("onCancelledCallInvite: CallRecord not found, already handled");
+        return;
+      }
 
       callRecord.setCancelledCallInvite(cancelledCallInvite);
       callRecord.setCallException(callException);

--- a/android/src/main/java/com/twiliovoicereactnative/VoiceService.java
+++ b/android/src/main/java/com/twiliovoicereactnative/VoiceService.java
@@ -55,10 +55,10 @@ import androidx.core.app.ServiceCompat;
 import com.facebook.react.bridge.WritableMap;
 import com.twilio.voice.AcceptOptions;
 import com.twilio.voice.Call;
+import com.twilio.voice.CallInvite;
 import com.twilio.voice.ConnectOptions;
 import com.twilio.voice.Voice;
 
-import java.util.Objects;
 import java.util.UUID;
 
 public class VoiceService extends Service {
@@ -100,47 +100,59 @@ public class VoiceService extends Service {
 
   @Override
   public int onStartCommand(Intent intent, int flags, int startId) {
-    // apparently the system can recreate the service without sending it an intent so protect
-    // against that case (GH-430).
-    if (null != intent) {
-      switch (Objects.requireNonNull(intent.getAction())) {
-        case ACTION_INCOMING_CALL:
-          incomingCall(getCallRecord(Objects.requireNonNull(getMessageUUID(intent))));
-          break;
-        case ACTION_ACCEPT_CALL:
-          try {
-            acceptCall(getCallRecord(Objects.requireNonNull(getMessageUUID(intent))));
-          } catch (SecurityException e) {
-            sendPermissionsError();
-            logger.warning(e, "Cannot accept call, lacking necessary permissions");
-          }
-          break;
-        case ACTION_REJECT_CALL:
-          rejectCall(getCallRecord(Objects.requireNonNull(getMessageUUID(intent))));
-          break;
-        case ACTION_CANCEL_CALL:
-          cancelCall(getCallRecord(Objects.requireNonNull(getMessageUUID(intent))));
-          break;
-        case ACTION_CALL_DISCONNECT:
-          disconnect(getCallRecord(Objects.requireNonNull(getMessageUUID(intent))));
-          break;
-        case ACTION_RAISE_OUTGOING_CALL_NOTIFICATION:
-          raiseOutgoingCallNotification(getCallRecord(Objects.requireNonNull(getMessageUUID(intent))));
-          break;
-        case ACTION_CANCEL_ACTIVE_CALL_NOTIFICATION:
-          cancelActiveCallNotification(getCallRecord(Objects.requireNonNull(getMessageUUID(intent))));
-          break;
-        case ACTION_FOREGROUND_AND_DEPRIORITIZE_INCOMING_CALL_NOTIFICATION:
-          foregroundAndDeprioritizeIncomingCallNotification(
-            getCallRecord(Objects.requireNonNull(getMessageUUID(intent))));
-          break;
-        case ACTION_PUSH_APP_TO_FOREGROUND:
-          logger.warning("VoiceService received foreground request, ignoring");
-          break;
-        default:
-          logger.log("Unknown notification, ignoring");
-          break;
-      }
+    if (null == intent) { return START_NOT_STICKY; }
+    String action = intent.getAction();
+    if (null == action) { return START_NOT_STICKY; }
+
+    UUID uuid = getMessageUUID(intent);
+    if (null == uuid) {
+      logger.warning("VoiceService received intent with null UUID, ignoring");
+      return START_NOT_STICKY;
+    }
+
+    CallRecordDatabase.CallRecord callRecord = getCallRecord(uuid);
+    if (null == callRecord) {
+      logger.warning("VoiceService received intent but CallRecord not found, uuid: " + uuid);
+      dismissNotificationFromIntent(intent);
+      return START_NOT_STICKY;
+    }
+
+    switch (action) {
+      case ACTION_INCOMING_CALL:
+        incomingCall(callRecord);
+        break;
+      case ACTION_ACCEPT_CALL:
+        try {
+          acceptCall(callRecord);
+        } catch (SecurityException e) {
+          sendPermissionsError();
+          logger.warning(e, "Cannot accept call, lacking necessary permissions");
+        }
+        break;
+      case ACTION_REJECT_CALL:
+        rejectCall(callRecord);
+        break;
+      case ACTION_CANCEL_CALL:
+        cancelCall(callRecord);
+        break;
+      case ACTION_CALL_DISCONNECT:
+        disconnect(callRecord);
+        break;
+      case ACTION_RAISE_OUTGOING_CALL_NOTIFICATION:
+        raiseOutgoingCallNotification(callRecord);
+        break;
+      case ACTION_CANCEL_ACTIVE_CALL_NOTIFICATION:
+        cancelActiveCallNotification(callRecord);
+        break;
+      case ACTION_FOREGROUND_AND_DEPRIORITIZE_INCOMING_CALL_NOTIFICATION:
+        foregroundAndDeprioritizeIncomingCallNotification(callRecord);
+        break;
+      case ACTION_PUSH_APP_TO_FOREGROUND:
+        logger.warning("VoiceService received foreground request, ignoring");
+        break;
+      default:
+        logger.log("Unknown notification, ignoring");
+        break;
     }
     return START_NOT_STICKY;
   }
@@ -160,10 +172,10 @@ public class VoiceService extends Service {
   }
   private void disconnect(final CallRecordDatabase.CallRecord callRecord) {
     logger.debug("disconnect");
-    if (null != callRecord) {
-      Objects.requireNonNull(callRecord.getVoiceCall()).disconnect();
+    if (null != callRecord && null != callRecord.getVoiceCall()) {
+      callRecord.getVoiceCall().disconnect();
     } else {
-      logger.warning("No call record found");
+      logger.warning("No call record or voice call found");
     }
   }
   private void incomingCall(final CallRecordDatabase.CallRecord callRecord) {
@@ -224,6 +236,16 @@ public class VoiceService extends Service {
       return;
     }
 
+    // verify callInvite is still available (may have been nulled by a concurrent cancel)
+    CallInvite callInvite = callRecord.getCallInvite();
+    if (null == callInvite) {
+      logger.warning("Cannot accept call, callInvite is null (likely cancelled)");
+      removeNotification(callRecord.getNotificationId());
+      VoiceApplicationProxy.getMediaPlayerManager().stop();
+      VoiceApplicationProxy.getAudioSwitchManager().getAudioSwitch().deactivate();
+      return;
+    }
+
     // cancel existing notification & put up in call
     Notification notification = NotificationUtility.createCallAnsweredNotificationWithLowImportance(
       VoiceService.this,
@@ -240,7 +262,7 @@ public class VoiceService extends Service {
       .build();
 
     callRecord.setCall(
-      callRecord.getCallInvite().accept(
+      callInvite.accept(
         VoiceService.this,
         acceptOptions,
         new CallListenerProxy(callRecord.getUuid(), VoiceService.this)));
@@ -272,9 +294,14 @@ public class VoiceService extends Service {
     VoiceApplicationProxy.getMediaPlayerManager().stop();
     VoiceApplicationProxy.getAudioSwitchManager().getAudioSwitch().deactivate();
 
-    // reject call
-    callRecord.getCallInvite().reject(VoiceService.this);
-    callRecord.setCallInviteUsedState();
+    // reject call (if callInvite still available)
+    CallInvite callInvite = callRecord.getCallInvite();
+    if (null != callInvite) {
+      callInvite.reject(VoiceService.this);
+      callRecord.setCallInviteUsedState();
+    } else {
+      logger.warning("Cannot reject call, callInvite is null (likely cancelled)");
+    }
 
     // handle if event spawned from JS
     if (null != callRecord.getCallRejectedPromise()) {
@@ -387,7 +414,14 @@ public class VoiceService extends Service {
     return (UUID)intent.getSerializableExtra(Constants.MSG_KEY_UUID);
   }
   private static CallRecordDatabase.CallRecord getCallRecord(final UUID uuid) {
-    return Objects.requireNonNull(getCallRecordDatabase().get(new CallRecordDatabase.CallRecord(uuid)));
+    return getCallRecordDatabase().get(new CallRecordDatabase.CallRecord(uuid));
+  }
+  private void dismissNotificationFromIntent(@NonNull final Intent intent) {
+    int notificationId = intent.getIntExtra(Constants.MSG_KEY_NOTIFICATION_ID, -1);
+    if (notificationId != -1) {
+      removeNotification(notificationId);
+    }
+    removeForegroundNotification();
   }
   private static void sendJSEvent(@NonNull String scope, @NonNull WritableMap event) {
     getJSEventEmitter().sendEvent(scope, event);


### PR DESCRIPTION
## Submission Checklist

 - [ ] Updated the `CHANGELOG.md` to reflect any **feature**, **bug fixes**, or **known issues** made in the source code
 - [ ] Tested code changes and observed expected behavior in the example app
 - [x] Performed a visual inspection of the `Files changed` tab prior to submitting the pull request for review to ensure proper usage of the style guide

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Description

This PR relaxes the null-checking restrictiveness of some code paths. This should fix some issues with OEM non-AOSP versions of Android that send out-of-spec Intents to applications.

## Breakdown

- Add notification IDs to our CallRecords so that we can clean things up more consistently.
- Relax null-check crashing and instead opt for cleaning up and early-return instead of throwing exceptions.

## Validation

- N/A

## Additional Notes

N/A
