### PR TITLE
Fix previously incorrect license field in `package.json` from MIT to Apache-2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   ],
   "repository": "https://github.com/twilio/twilio-voice-react-native",
   "author": "Michael Huynh <mhuynh@twilio.com> (https://github.com/twilio)",
-  "license": "MIT",
+  "license": "Apache-2.0",
   "bugs": {
     "url": "https://github.com/twilio/twilio-voice-react-native/issues"
   },


### PR DESCRIPTION
## Submission Checklist

 - [ ] Updated the `CHANGELOG.md` to reflect any **feature**, **bug fixes**, or **known issues** made in the source code
 - [ ] Tested code changes and observed expected behavior in the example app
 - [x] Performed a visual inspection of the `Files changed` tab prior to submitting the pull request for review to ensure proper usage of the style guide

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Description

Fix the incorrect license in the `package.json`. We have always included the correct `LICENSE` file in the root of the project. See `./LICENSE` for more information.

## Breakdown

- Change `package.json`.

## Validation

- N/A

## Additional Notes

N/A
