### PR TITLE
[VBLOCKS-6682] Clean up potential null records after process end

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+2.0.0-preview.3 (In Progress)
+=============================
+
+## Fixes
+
+### Platform Specific Fixes
+
+#### Android
+
+- Fixed a crash that could occur when an incoming call invite was active and the user swiped the app away from the recent apps (multitasking) view. The SDK now rejects any pending invites and clears their notifications and ringer when the app's task is removed.
+
+- Fixed a `NullPointerException` when a cancelled call invite was received after its call record had already been cleaned up (for example, after the app was swiped away). The cancellation is now handled gracefully.
+
+- Fixed a `NullPointerException` when a disconnect was requested for a call whose process had already been killed (for example, by an OEM battery optimizer or under memory pressure). The SDK now clears the stale notification instead of crashing.
+
 2.0.0-preview.2 (April 29, 2026)
 ================================
 

--- a/android/src/main/java/com/twiliovoicereactnative/VoiceFirebaseMessagingService.java
+++ b/android/src/main/java/com/twiliovoicereactnative/VoiceFirebaseMessagingService.java
@@ -1,10 +1,13 @@
 package com.twiliovoicereactnative;
 
+import static com.twiliovoicereactnative.VoiceApplicationProxy.getApplicationContext;
 import static com.twiliovoicereactnative.VoiceApplicationProxy.getCallRecordDatabase;
 import static com.twiliovoicereactnative.VoiceApplicationProxy.getVoiceServiceApi;
 
 import com.twiliovoicereactnative.CallRecordDatabase.CallRecord;
 
+import android.content.Context;
+import android.content.Intent;
 import android.os.PowerManager;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -31,7 +34,15 @@ public class VoiceFirebaseMessagingService extends FirebaseMessagingService {
       final CallRecord callRecord = new CallRecord(UUID.randomUUID(), callInvite);
 
       getCallRecordDatabase().add(callRecord);
-      getVoiceServiceApi().incomingCall(callRecord);
+
+      // Route through startService so VoiceService enters the "started" state,
+      // which is what causes onTaskRemoved to fire when the user swipes the app away.
+      final Context context = getApplicationContext();
+      context.startService(VoiceService.constructMessage(
+        context,
+        Constants.ACTION_INCOMING_CALL,
+        VoiceService.class,
+        callRecord.getUuid()));
     }
 
     @Override
@@ -39,8 +50,13 @@ public class VoiceFirebaseMessagingService extends FirebaseMessagingService {
                                       @Nullable CallException callException) {
       logger.log(String.format("onCancelledCallInvite %s", cancelledCallInvite.getCallSid()));
 
-      CallRecord callRecord = Objects.requireNonNull(
-        getCallRecordDatabase().remove(new CallRecord(cancelledCallInvite.getCallSid())));
+      CallRecord callRecord =
+        getCallRecordDatabase().remove(new CallRecord(cancelledCallInvite.getCallSid()));
+
+      if (null == callRecord) {
+        logger.log("No matching call record for cancelled invite; already reaped on task removal");
+        return;
+      }
 
       callRecord.setCancelledCallInvite(cancelledCallInvite);
       callRecord.setCallException(callException);

--- a/android/src/main/java/com/twiliovoicereactnative/VoiceFirebaseMessagingService.java
+++ b/android/src/main/java/com/twiliovoicereactnative/VoiceFirebaseMessagingService.java
@@ -1,6 +1,5 @@
 package com.twiliovoicereactnative;
 
-import static com.twiliovoicereactnative.VoiceApplicationProxy.getApplicationContext;
 import static com.twiliovoicereactnative.VoiceApplicationProxy.getCallRecordDatabase;
 import static com.twiliovoicereactnative.VoiceApplicationProxy.getVoiceServiceApi;
 
@@ -37,7 +36,7 @@ public class VoiceFirebaseMessagingService extends FirebaseMessagingService {
 
       // Route through startService so VoiceService enters the "started" state,
       // which is what causes onTaskRemoved to fire when the user swipes the app away.
-      final Context context = getApplicationContext();
+      final Context context = VoiceApplicationProxy.getApplicationContext();
       context.startService(VoiceService.constructMessage(
         context,
         Constants.ACTION_INCOMING_CALL,

--- a/android/src/main/java/com/twiliovoicereactnative/VoiceService.java
+++ b/android/src/main/java/com/twiliovoicereactnative/VoiceService.java
@@ -58,6 +58,8 @@ import com.twilio.voice.Call;
 import com.twilio.voice.ConnectOptions;
 import com.twilio.voice.Voice;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
 
@@ -121,9 +123,22 @@ public class VoiceService extends Service {
         case ACTION_CANCEL_CALL:
           cancelCall(getCallRecord(Objects.requireNonNull(getMessageUUID(intent))));
           break;
-        case ACTION_CALL_DISCONNECT:
-          disconnect(getCallRecord(Objects.requireNonNull(getMessageUUID(intent))));
+        case ACTION_CALL_DISCONNECT: {
+          UUID uuid = Objects.requireNonNull(getMessageUUID(intent));
+          CallRecordDatabase.CallRecord record =
+            getCallRecordDatabase().get(new CallRecordDatabase.CallRecord(uuid));
+          if (null == record) {
+            // Process was killed after the call was answered (e.g. OEM battery killer, OOM).
+            // The Call object is gone and the socket is closed, so there's nothing left to
+            // disconnect — just clear the stale notification so the user isn't stuck with it.
+            logger.warning("Disconnect for unknown call, clearing stale notification");
+            removeForegroundNotification();
+            stopSelf();
+          } else {
+            disconnect(record);
+          }
           break;
+        }
         case ACTION_RAISE_OUTGOING_CALL_NOTIFICATION:
           raiseOutgoingCallNotification(getCallRecord(Objects.requireNonNull(getMessageUUID(intent))));
           break;
@@ -148,6 +163,25 @@ public class VoiceService extends Service {
   @Override
   public IBinder onBind(Intent intent) {
     return new VoiceServiceAPI();
+  }
+
+  @Override
+  public void onTaskRemoved(Intent rootIntent) {
+    logger.debug("onTaskRemoved: rejecting active incoming invites");
+    List<CallRecordDatabase.CallRecord> snapshot =
+      new ArrayList<>(getCallRecordDatabase().getCollection());
+    for (CallRecordDatabase.CallRecord callRecord : snapshot) {
+      if (CallRecordDatabase.CallRecord.CallInviteState.ACTIVE != callRecord.getCallInviteState()) {
+        continue;
+      }
+      try {
+        rejectCall(callRecord);
+      } catch (Exception e) {
+        logger.warning(e, "Failed to reject invite during task removal");
+        removeNotification(callRecord.getNotificationId());
+      }
+    }
+    super.onTaskRemoved(rootIntent);
   }
   public static Intent constructMessage(@NonNull Context context,
                                         @NonNull final String action,


### PR DESCRIPTION
## Submission Checklist

 - [ ] Updated the `CHANGELOG.md` to reflect any **feature**, **bug fixes**, or **known issues** made in the source code
 - [x] Tested code changes and observed expected behavior in the example app
 - [x] Performed a visual inspection of the `Files changed` tab prior to submitting the pull request for review to ensure proper usage of the style guide

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Description

This PR implements cleanup functions upon process end to reduce null pointer exceptions around in-memory and invalidated call records.

## Breakdown

- Clean up call records when invalidated (i.e. when the process ends and the in-memory data is invalidated).

## Validation

- Manually tested with test app.

## Additional Notes

N/A
