### PR TITLE
[VBLOCKS-6682] feat: ignore accept and reject for invalid callinvites

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+2.0.0-preview.3 (In Progress)
+=============================
+
+## Fixes
+
+### Platform Specific Fixes
+
+#### Android
+
+- Fixed null pointer exception related crashing that could occur when accepting or rejecting invalid CallInvites using the native notification.
+
 2.0.0-preview.2 (April 29, 2026)
 ================================
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 
 #### Android
 
-- Fixed null pointer exception related crashing that could occur when accepting or rejecting invalid CallInvites using the native notification.
+- Fixed null pointer exception related crashes that could occur when accepting or rejecting invalid CallInvites using the native notification.
 
 2.0.0-preview.2 (April 29, 2026)
 ================================

--- a/android/src/main/java/com/twiliovoicereactnative/CallRecordDatabase.java
+++ b/android/src/main/java/com/twiliovoicereactnative/CallRecordDatabase.java
@@ -22,7 +22,8 @@ class CallRecordDatabase  {
   public static class CallRecord {
     public enum CallInviteState { NONE, ACTIVE, USED }
     public enum Direction { INCOMING, OUTGOING }
-    // No notification raised; valid ids are always >= 1.
+    // No notification raised
+    // notifications in this library are always assigned a value >= 1.
     public static final int INVALID_NOTIFICATION_ID = -1;
     private final UUID uuid;
     private String callSid = null;

--- a/android/src/main/java/com/twiliovoicereactnative/CallRecordDatabase.java
+++ b/android/src/main/java/com/twiliovoicereactnative/CallRecordDatabase.java
@@ -22,8 +22,7 @@ class CallRecordDatabase  {
   public static class CallRecord {
     public enum CallInviteState { NONE, ACTIVE, USED }
     public enum Direction { INCOMING, OUTGOING }
-    // Sentinel returned by getNotificationId() when no notification has been raised for this record.
-    // Valid ids produced by NotificationUtility.createNotificationIdentifier() are always >= 1.
+    // No notification raised; valid ids are always >= 1.
     public static final int INVALID_NOTIFICATION_ID = -1;
     private final UUID uuid;
     private String callSid = null;

--- a/android/src/main/java/com/twiliovoicereactnative/CallRecordDatabase.java
+++ b/android/src/main/java/com/twiliovoicereactnative/CallRecordDatabase.java
@@ -22,10 +22,13 @@ class CallRecordDatabase  {
   public static class CallRecord {
     public enum CallInviteState { NONE, ACTIVE, USED }
     public enum Direction { INCOMING, OUTGOING }
+    // Sentinel returned by getNotificationId() when no notification has been raised for this record.
+    // Valid ids produced by NotificationUtility.createNotificationIdentifier() are always >= 1.
+    public static final int INVALID_NOTIFICATION_ID = -1;
     private final UUID uuid;
     private String callSid = null;
     private Date timestamp = null;
-    private int notificationId = -1;
+    private int notificationId = INVALID_NOTIFICATION_ID;
     private Call voiceCall = null;
     private String callRecipient = "";
     private CallInvite callInvite = null;

--- a/android/src/main/java/com/twiliovoicereactnative/Constants.java
+++ b/android/src/main/java/com/twiliovoicereactnative/Constants.java
@@ -15,6 +15,7 @@ class Constants {
   public static final String ACTION_PUSH_APP_TO_FOREGROUND = "ACTION_PUSH_APP_TO_FOREGROUND";
   public static final String ACTION_FOREGROUND_AND_DEPRIORITIZE_INCOMING_CALL_NOTIFICATION = "ACTION_FOREGROUND_AND_DEPRIORITIZE_INCOMING_CALL_NOTIFICATION";
   public static final String MSG_KEY_UUID = "UUID";
+  public static final String MSG_KEY_NOTIFICATION_ID = "NOTIFICATION_ID";
   public static final String JS_EVENT_KEY_CALL_INFO = "call";
   public static final String JS_EVENT_KEY_CALL_INVITE_INFO = "callInvite";
   public static final String JS_EVENT_KEY_CANCELLED_CALL_INVITE_INFO = "cancelledCallInvite";

--- a/android/src/main/java/com/twiliovoicereactnative/NotificationUtility.java
+++ b/android/src/main/java/com/twiliovoicereactnative/NotificationUtility.java
@@ -163,6 +163,10 @@ class NotificationUtility {
     rejectIntent.putExtra(Constants.MSG_KEY_NOTIFICATION_ID, callRecord.getNotificationId());
     PendingIntent piRejectIntent = constructPendingIntentForService(context, rejectIntent);
 
+    // Unlike reject, accept targets the main activity (not VoiceService) because accepting must
+    // bring the in-call UI to the foreground, which a service cannot do on Android 12+. The activity
+    // forwards this intent to VoiceService in VoiceActivityProxy.handleIntent, preserving the
+    // notification-id extra so the service can still dismiss a stale notification after process death.
     Intent acceptIntent = constructMessage(
       context,
       Constants.ACTION_ACCEPT_CALL,

--- a/android/src/main/java/com/twiliovoicereactnative/NotificationUtility.java
+++ b/android/src/main/java/com/twiliovoicereactnative/NotificationUtility.java
@@ -151,10 +151,8 @@ class NotificationUtility {
       callRecord.getUuid());
     PendingIntent piForegroundIntent = constructPendingIntentForActivity(context, foregroundIntent);
 
-    // Carry the notification id on the accept/reject intents so the service can dismiss this
-    // notification even if the call record (which also holds the id) has been evicted from the
-    // database by the time the action is delivered (e.g. after process death). Otherwise a stale
-    // accept/reject button would linger on the lock screen / shade forever.
+    // Carry the id so the service can still dismiss the notification after the call record is
+    // evicted (for example, after process death); otherwise the accept/reject button lingers forever.
     Intent rejectIntent = constructMessage(
       context,
       Constants.ACTION_REJECT_CALL,
@@ -163,10 +161,9 @@ class NotificationUtility {
     rejectIntent.putExtra(Constants.MSG_KEY_NOTIFICATION_ID, callRecord.getNotificationId());
     PendingIntent piRejectIntent = constructPendingIntentForService(context, rejectIntent);
 
-    // Unlike reject, accept targets the main activity (not VoiceService) because accepting must
-    // bring the in-call UI to the foreground, which a service cannot do on Android 12+. The activity
-    // forwards this intent to VoiceService in VoiceActivityProxy.handleIntent, preserving the
-    // notification-id extra so the service can still dismiss a stale notification after process death.
+    // Accept targets the main activity, not VoiceService: it must foreground the in-call UI (a
+    // service cannot launch activities on Android 12+). VoiceActivityProxy forwards it to the
+    // service, extra intact.
     Intent acceptIntent = constructMessage(
       context,
       Constants.ACTION_ACCEPT_CALL,

--- a/android/src/main/java/com/twiliovoicereactnative/NotificationUtility.java
+++ b/android/src/main/java/com/twiliovoicereactnative/NotificationUtility.java
@@ -151,11 +151,16 @@ class NotificationUtility {
       callRecord.getUuid());
     PendingIntent piForegroundIntent = constructPendingIntentForActivity(context, foregroundIntent);
 
+    // Carry the notification id on the accept/reject intents so the service can dismiss this
+    // notification even if the call record (which also holds the id) has been evicted from the
+    // database by the time the action is delivered (e.g. after process death). Otherwise a stale
+    // accept/reject button would linger on the lock screen / shade forever.
     Intent rejectIntent = constructMessage(
       context,
       Constants.ACTION_REJECT_CALL,
       VoiceService.class,
       callRecord.getUuid());
+    rejectIntent.putExtra(Constants.MSG_KEY_NOTIFICATION_ID, callRecord.getNotificationId());
     PendingIntent piRejectIntent = constructPendingIntentForService(context, rejectIntent);
 
     Intent acceptIntent = constructMessage(
@@ -163,6 +168,7 @@ class NotificationUtility {
       Constants.ACTION_ACCEPT_CALL,
       Objects.requireNonNull(VoiceApplicationProxy.getMainActivityClass()),
       callRecord.getUuid());
+    acceptIntent.putExtra(Constants.MSG_KEY_NOTIFICATION_ID, callRecord.getNotificationId());
     PendingIntent piAcceptIntent = constructPendingIntentForActivity(context, acceptIntent);
 
     return constructNotificationBuilder(context, channelImportance)

--- a/android/src/main/java/com/twiliovoicereactnative/VoiceActivityProxy.java
+++ b/android/src/main/java/com/twiliovoicereactnative/VoiceActivityProxy.java
@@ -80,10 +80,11 @@ public class VoiceActivityProxy {
     if ((null != action) && (!action.equals(Constants.ACTION_PUSH_APP_TO_FOREGROUND))) {
       // Accept is delivered as an activity PendingIntent (it must foreground the in-call UI, which a
       // service can no longer launch on Android 12+), so the only way it reaches VoiceService is by
-      // being forwarded here. The Intent(Intent) copy constructor deep-copies the extras bundle, so
-      // MSG_KEY_NOTIFICATION_ID survives onto the service intent; setFlags(0) only resets the launch
-      // flags, not the extras. That is what lets VoiceService dismiss a stale incoming-call
-      // notification after process death even though accept never targets the service directly.
+      // being forwarded here. The Intent(Intent) copy constructor clones the intent (the same as
+      // Intent.clone()), giving the copy its own extras bundle, so MSG_KEY_NOTIFICATION_ID survives
+      // onto the service intent; setFlags(0) only resets the launch flags, not the extras. That is
+      // what lets VoiceService dismiss a stale incoming-call notification after process death even
+      // though accept never targets the service directly.
       Intent copiedIntent = new Intent(intent);
       copiedIntent.setClass(context.getApplicationContext(), VoiceService.class);
       copiedIntent.setFlags(0);

--- a/android/src/main/java/com/twiliovoicereactnative/VoiceActivityProxy.java
+++ b/android/src/main/java/com/twiliovoicereactnative/VoiceActivityProxy.java
@@ -78,6 +78,12 @@ public class VoiceActivityProxy {
   private void handleIntent(Intent intent) {
     String action = intent.getAction();
     if ((null != action) && (!action.equals(Constants.ACTION_PUSH_APP_TO_FOREGROUND))) {
+      // Accept is delivered as an activity PendingIntent (it must foreground the in-call UI, which a
+      // service can no longer launch on Android 12+), so the only way it reaches VoiceService is by
+      // being forwarded here. The Intent(Intent) copy constructor deep-copies the extras bundle, so
+      // MSG_KEY_NOTIFICATION_ID survives onto the service intent; setFlags(0) only resets the launch
+      // flags, not the extras. That is what lets VoiceService dismiss a stale incoming-call
+      // notification after process death even though accept never targets the service directly.
       Intent copiedIntent = new Intent(intent);
       copiedIntent.setClass(context.getApplicationContext(), VoiceService.class);
       copiedIntent.setFlags(0);

--- a/android/src/main/java/com/twiliovoicereactnative/VoiceActivityProxy.java
+++ b/android/src/main/java/com/twiliovoicereactnative/VoiceActivityProxy.java
@@ -78,13 +78,8 @@ public class VoiceActivityProxy {
   private void handleIntent(Intent intent) {
     String action = intent.getAction();
     if ((null != action) && (!action.equals(Constants.ACTION_PUSH_APP_TO_FOREGROUND))) {
-      // Accept is delivered as an activity PendingIntent (it must foreground the in-call UI, which a
-      // service can no longer launch on Android 12+), so the only way it reaches VoiceService is by
-      // being forwarded here. The Intent(Intent) copy constructor clones the intent (the same as
-      // Intent.clone()), giving the copy its own extras bundle, so MSG_KEY_NOTIFICATION_ID survives
-      // onto the service intent; setFlags(0) only resets the launch flags, not the extras. That is
-      // what lets VoiceService dismiss a stale incoming-call notification after process death even
-      // though accept never targets the service directly.
+      // Accept is an activity PendingIntent, so forwarding is its only path to VoiceService. The
+      // copy constructor preserves extras (including the notification id); setFlags(0) resets flags only.
       Intent copiedIntent = new Intent(intent);
       copiedIntent.setClass(context.getApplicationContext(), VoiceService.class);
       copiedIntent.setFlags(0);

--- a/android/src/main/java/com/twiliovoicereactnative/VoiceService.java
+++ b/android/src/main/java/com/twiliovoicereactnative/VoiceService.java
@@ -107,33 +107,18 @@ public class VoiceService extends Service {
     }
 
     final int notificationId = getMessageNotificationId(intent);
-
     final String action = intent.getAction();
-    if (null == action) {
-      logger.warning("intent action null");
-      removeNotificationIfPresent(notificationId);
-      return START_NOT_STICKY;
-    }
-
-    if (ACTION_PUSH_APP_TO_FOREGROUND.equals(action)) {
-      logger.warning("VoiceService received foreground request, ignoring");
-      return START_NOT_STICKY;
-    }
-
     final UUID messageUUID = getMessageUUID(intent);
-    if (null == messageUUID) {
-      logger.warning("message uuid null");
-      removeNotificationIfPresent(notificationId);
-      return START_NOT_STICKY;
-    }
+    final CallRecordDatabase.CallRecord callRecord = (null == messageUUID)
+      ? null
+      : getCallRecordDatabase().get(new CallRecordDatabase.CallRecord(messageUUID));
 
-    // The record for this UUID may be settled or evicted before the action is delivered; bail out
-    // here instead of throwing a null pointer exception downstream. Single guard for every action handler below.
-    final CallRecordDatabase.CallRecord callRecord =
-      getCallRecordDatabase().get(new CallRecordDatabase.CallRecord(messageUUID));
-
-    if (null == callRecord) {
-      logger.warning("No call record found for action \"" + action + "\", ignoring");
+    // A notification action (for example accept or reject) can arrive with a null action or uuid, or
+    // after its call record has been settled or evicted. Guard all three together and bail out here,
+    // dismissing any stale notification, rather than throwing a null pointer exception in a handler below.
+    if (null == action || null == messageUUID || null == callRecord) {
+      logger.warning(
+        "Ignoring intent; missing action, uuid, or call record. action=" + action + ", uuid=" + messageUUID);
       removeNotificationIfPresent(notificationId);
       return START_NOT_STICKY;
     }
@@ -173,9 +158,12 @@ public class VoiceService extends Service {
       case ACTION_FOREGROUND_AND_DEPRIORITIZE_INCOMING_CALL_NOTIFICATION:
         foregroundAndDeprioritizeIncomingCallNotification(callRecord);
         break;
+      case ACTION_PUSH_APP_TO_FOREGROUND:
+        // Normally consumed by VoiceActivityProxy and never forwarded to the service; ignore if it is.
+        logger.warning("VoiceService received foreground request, ignoring");
+        break;
       default:
         logger.log("Unknown notification, ignoring");
-        removeNotificationIfPresent(notificationId);
         break;
     }
     return START_NOT_STICKY;

--- a/android/src/main/java/com/twiliovoicereactnative/VoiceService.java
+++ b/android/src/main/java/com/twiliovoicereactnative/VoiceService.java
@@ -128,10 +128,13 @@ public class VoiceService extends Service {
 
     switch (action) {
       case ACTION_INCOMING_CALL: {
-        // Incoming calls arrive via the binder API, not onStartCommand; reaching here is unexpected.
+        // Incoming calls arrive via the binder API, not onStartCommand
+        // reaching here is unexpected.
         logger.warning(String.format(
           "Unexpected ACTION_INCOMING_CALL intent for callSid=%s, uuid=%s",
           callRecord.getCallSid(), callRecord.getUuid()));
+        // we still handle the incoming call here just in case; we don't want
+        // to introduce a breaking behavior
         incomingCall(callRecord);
         break;
       }

--- a/android/src/main/java/com/twiliovoicereactnative/VoiceService.java
+++ b/android/src/main/java/com/twiliovoicereactnative/VoiceService.java
@@ -102,45 +102,69 @@ public class VoiceService extends Service {
   public int onStartCommand(Intent intent, int flags, int startId) {
     // apparently the system can recreate the service without sending it an intent so protect
     // against that case (GH-430).
-    if (null != intent) {
-      switch (Objects.requireNonNull(intent.getAction())) {
-        case ACTION_INCOMING_CALL:
-          incomingCall(getCallRecord(Objects.requireNonNull(getMessageUUID(intent))));
-          break;
-        case ACTION_ACCEPT_CALL:
-          try {
-            acceptCall(getCallRecord(Objects.requireNonNull(getMessageUUID(intent))));
-          } catch (SecurityException e) {
-            sendPermissionsError();
-            logger.warning(e, "Cannot accept call, lacking necessary permissions");
-          }
-          break;
-        case ACTION_REJECT_CALL:
-          rejectCall(getCallRecord(Objects.requireNonNull(getMessageUUID(intent))));
-          break;
-        case ACTION_CANCEL_CALL:
-          cancelCall(getCallRecord(Objects.requireNonNull(getMessageUUID(intent))));
-          break;
-        case ACTION_CALL_DISCONNECT:
-          disconnect(getCallRecord(Objects.requireNonNull(getMessageUUID(intent))));
-          break;
-        case ACTION_RAISE_OUTGOING_CALL_NOTIFICATION:
-          raiseOutgoingCallNotification(getCallRecord(Objects.requireNonNull(getMessageUUID(intent))));
-          break;
-        case ACTION_CANCEL_ACTIVE_CALL_NOTIFICATION:
-          cancelActiveCallNotification(getCallRecord(Objects.requireNonNull(getMessageUUID(intent))));
-          break;
-        case ACTION_FOREGROUND_AND_DEPRIORITIZE_INCOMING_CALL_NOTIFICATION:
-          foregroundAndDeprioritizeIncomingCallNotification(
-            getCallRecord(Objects.requireNonNull(getMessageUUID(intent))));
-          break;
-        case ACTION_PUSH_APP_TO_FOREGROUND:
-          logger.warning("VoiceService received foreground request, ignoring");
-          break;
-        default:
-          logger.log("Unknown notification, ignoring");
-          break;
+    if (null == intent) {
+      return START_NOT_STICKY;
+    }
+    final String action = Objects.requireNonNull(intent.getAction());
+
+    // Actions that do not operate on a specific call record are handled before the lookup below.
+    if (ACTION_PUSH_APP_TO_FOREGROUND.equals(action)) {
+      logger.warning("VoiceService received foreground request, ignoring");
+      return START_NOT_STICKY;
+    }
+
+    // Every remaining action operates on a call record identified by the intent's UUID. By the
+    // time a notification action (e.g. accept/reject) is delivered, that call invite may have
+    // already been settled or evicted from the database, so look the record up tolerantly here and
+    // ignore the intent if it no longer exists rather than throwing a null-pointer exception
+    // further down. This is the single guard that protects every action handler.
+    final CallRecordDatabase.CallRecord callRecord =
+      getCallRecordDatabase().get(new CallRecordDatabase.CallRecord(getMessageUUID(intent)));
+    if (null == callRecord) {
+      logger.warning("No call record found for action \"" + action + "\", ignoring");
+      // The call invite is gone (settled/cancelled, or the process was restarted and the in-memory
+      // database was lost), but its incoming-call notification may still be showing. Dismiss it
+      // using the id carried on the intent so a stale accept/reject button does not linger forever.
+      final int notificationId = getMessageNotificationId(intent);
+      if (CallRecordDatabase.CallRecord.INVALID_NOTIFICATION_ID != notificationId) {
+        removeNotification(notificationId);
       }
+      return START_NOT_STICKY;
+    }
+
+    switch (action) {
+      case ACTION_INCOMING_CALL:
+        incomingCall(callRecord);
+        break;
+      case ACTION_ACCEPT_CALL:
+        try {
+          acceptCall(callRecord);
+        } catch (SecurityException e) {
+          sendPermissionsError();
+          logger.warning(e, "Cannot accept call, lacking necessary permissions");
+        }
+        break;
+      case ACTION_REJECT_CALL:
+        rejectCall(callRecord);
+        break;
+      case ACTION_CANCEL_CALL:
+        cancelCall(callRecord);
+        break;
+      case ACTION_CALL_DISCONNECT:
+        disconnect(callRecord);
+        break;
+      case ACTION_RAISE_OUTGOING_CALL_NOTIFICATION:
+        raiseOutgoingCallNotification(callRecord);
+        break;
+      case ACTION_CANCEL_ACTIVE_CALL_NOTIFICATION:
+        cancelActiveCallNotification(callRecord);
+        break;
+      case ACTION_FOREGROUND_AND_DEPRIORITIZE_INCOMING_CALL_NOTIFICATION:
+        foregroundAndDeprioritizeIncomingCallNotification(callRecord);
+        break;
+      default:
+        logger.log("Unknown notification, ignoring");
+        break;
     }
     return START_NOT_STICKY;
   }
@@ -386,8 +410,10 @@ public class VoiceService extends Service {
   private static UUID getMessageUUID(@NonNull final Intent intent) {
     return (UUID)intent.getSerializableExtra(Constants.MSG_KEY_UUID);
   }
-  private static CallRecordDatabase.CallRecord getCallRecord(final UUID uuid) {
-    return Objects.requireNonNull(getCallRecordDatabase().get(new CallRecordDatabase.CallRecord(uuid)));
+  private static int getMessageNotificationId(@NonNull final Intent intent) {
+    return intent.getIntExtra(
+      Constants.MSG_KEY_NOTIFICATION_ID,
+      CallRecordDatabase.CallRecord.INVALID_NOTIFICATION_ID);
   }
   private static void sendJSEvent(@NonNull String scope, @NonNull WritableMap event) {
     getJSEventEmitter().sendEvent(scope, event);

--- a/android/src/main/java/com/twiliovoicereactnative/VoiceService.java
+++ b/android/src/main/java/com/twiliovoicereactnative/VoiceService.java
@@ -105,11 +105,32 @@ public class VoiceService extends Service {
     if (null == intent) {
       return START_NOT_STICKY;
     }
-    final String action = Objects.requireNonNull(intent.getAction());
+
+    final int notificationId = getMessageNotificationId(intent);
+
+    final String action = intent.getAction();
+    if (null == action) {
+      logger.warning("intent action null");
+      if (CallRecordDatabase.CallRecord.INVALID_NOTIFICATION_ID != notificationId) {
+        logger.warning("notificationId detected, attempting to remove notification");
+        removeNotification(notificationId);
+      }
+      return START_NOT_STICKY;
+    }
 
     // Actions that do not operate on a specific call record are handled before the lookup below.
     if (ACTION_PUSH_APP_TO_FOREGROUND.equals(action)) {
       logger.warning("VoiceService received foreground request, ignoring");
+      return START_NOT_STICKY;
+    }
+
+    final UUID messageUUID = getMessageUUID(intent);
+    if (null == messageUUID) {
+      logger.warning("message uuid null");
+      if (CallRecordDatabase.CallRecord.INVALID_NOTIFICATION_ID != notificationId) {
+        logger.warning("notificationId detected, attempting to remove notification");
+        removeNotification(notificationId);
+      }
       return START_NOT_STICKY;
     }
 
@@ -119,23 +140,26 @@ public class VoiceService extends Service {
     // ignore the intent if it no longer exists rather than throwing a null-pointer exception
     // further down. This is the single guard that protects every action handler.
     final CallRecordDatabase.CallRecord callRecord =
-      getCallRecordDatabase().get(new CallRecordDatabase.CallRecord(getMessageUUID(intent)));
+      getCallRecordDatabase().get(new CallRecordDatabase.CallRecord(messageUUID));
+
     if (null == callRecord) {
       logger.warning("No call record found for action \"" + action + "\", ignoring");
       // The call invite is gone (settled/cancelled, or the process was restarted and the in-memory
       // database was lost), but its incoming-call notification may still be showing. Dismiss it
       // using the id carried on the intent so a stale accept/reject button does not linger forever.
-      final int notificationId = getMessageNotificationId(intent);
       if (CallRecordDatabase.CallRecord.INVALID_NOTIFICATION_ID != notificationId) {
+        logger.warning("notificationId detected, attempting to remove notification");
         removeNotification(notificationId);
       }
       return START_NOT_STICKY;
     }
 
     switch (action) {
-      case ACTION_INCOMING_CALL:
+      case ACTION_INCOMING_CALL: {
+        logger.warning("Incoming call intent received. This should not happen!");
         incomingCall(callRecord);
         break;
+      }
       case ACTION_ACCEPT_CALL:
         try {
           acceptCall(callRecord);

--- a/android/src/main/java/com/twiliovoicereactnative/VoiceService.java
+++ b/android/src/main/java/com/twiliovoicereactnative/VoiceService.java
@@ -119,7 +119,10 @@ public class VoiceService extends Service {
     if (null == action || null == messageUUID || null == callRecord) {
       logger.warning(
         "Ignoring intent; missing action, uuid, or call record. action=" + action + ", uuid=" + messageUUID);
-      removeNotificationIfPresent(notificationId);
+      // Dismiss the orphaned notification so a stale accept/reject button does not linger.
+      if (CallRecordDatabase.CallRecord.INVALID_NOTIFICATION_ID != notificationId) {
+        removeNotification(notificationId);
+      }
       return START_NOT_STICKY;
     }
 
@@ -390,13 +393,6 @@ public class VoiceService extends Service {
     NotificationManager mNotificationManager =
       (NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE);
     mNotificationManager.cancel(notificationId);
-  }
-  private void removeNotificationIfPresent(final int notificationId) {
-    // Dismiss the orphaned notification so a stale accept/reject button does not linger.
-    if (CallRecordDatabase.CallRecord.INVALID_NOTIFICATION_ID != notificationId) {
-      logger.debug("removeNotificationIfPresent: notificationId detected, attempting to remove notification");
-      removeNotification(notificationId);
-    }
   }
   private void removeForegroundNotification() {
     logger.debug("removeForegroundNotification");

--- a/android/src/main/java/com/twiliovoicereactnative/VoiceService.java
+++ b/android/src/main/java/com/twiliovoicereactnative/VoiceService.java
@@ -115,7 +115,6 @@ public class VoiceService extends Service {
       return START_NOT_STICKY;
     }
 
-    // Actions that do not operate on a specific call record are handled before the lookup below.
     if (ACTION_PUSH_APP_TO_FOREGROUND.equals(action)) {
       logger.warning("VoiceService received foreground request, ignoring");
       return START_NOT_STICKY;
@@ -128,11 +127,8 @@ public class VoiceService extends Service {
       return START_NOT_STICKY;
     }
 
-    // Every remaining action operates on a call record identified by the intent's UUID. By the
-    // time a notification action (e.g. accept/reject) is delivered, that call invite may have
-    // already been settled or evicted from the database, so look the record up tolerantly here and
-    // ignore the intent if it no longer exists rather than throwing a null-pointer exception
-    // further down. This is the single guard that protects every action handler.
+    // The record for this UUID may be settled or evicted before the action is delivered; bail out
+    // here instead of throwing a null pointer exception downstream. Single guard for every action handler below.
     final CallRecordDatabase.CallRecord callRecord =
       getCallRecordDatabase().get(new CallRecordDatabase.CallRecord(messageUUID));
 
@@ -144,9 +140,7 @@ public class VoiceService extends Service {
 
     switch (action) {
       case ACTION_INCOMING_CALL: {
-        // Incoming calls are raised internally via the binder API, not delivered to onStartCommand,
-        // so reaching here means an ACTION_INCOMING_CALL intent was dispatched to the service
-        // unexpectedly. Log the identifiers so the originating call can be traced.
+        // Incoming calls arrive via the binder API, not onStartCommand; reaching here is unexpected.
         logger.warning(String.format(
           "Unexpected ACTION_INCOMING_CALL intent for callSid=%s, uuid=%s",
           callRecord.getCallSid(), callRecord.getUuid()));
@@ -410,9 +404,7 @@ public class VoiceService extends Service {
     mNotificationManager.cancel(notificationId);
   }
   private void removeNotificationIfPresent(final int notificationId) {
-    // The intent did not resolve to a live call record (bad/duplicate intent, or the in-memory
-    // database was lost to process death), but its incoming-call notification may still be showing.
-    // Dismiss it using the id carried on the intent so a stale accept/reject button does not linger.
+    // Dismiss the orphaned notification so a stale accept/reject button does not linger.
     if (CallRecordDatabase.CallRecord.INVALID_NOTIFICATION_ID != notificationId) {
       logger.debug("removeNotificationIfPresent: notificationId detected, attempting to remove notification");
       removeNotification(notificationId);

--- a/android/src/main/java/com/twiliovoicereactnative/VoiceService.java
+++ b/android/src/main/java/com/twiliovoicereactnative/VoiceService.java
@@ -181,6 +181,7 @@ public class VoiceService extends Service {
         break;
       default:
         logger.log("Unknown notification, ignoring");
+        removeNotificationIfPresent(notificationId);
         break;
     }
     return START_NOT_STICKY;
@@ -413,7 +414,7 @@ public class VoiceService extends Service {
     // database was lost to process death), but its incoming-call notification may still be showing.
     // Dismiss it using the id carried on the intent so a stale accept/reject button does not linger.
     if (CallRecordDatabase.CallRecord.INVALID_NOTIFICATION_ID != notificationId) {
-      logger.warning("notificationId detected, attempting to remove notification");
+      logger.debug("removeNotificationIfPresent: notificationId detected, attempting to remove notification");
       removeNotification(notificationId);
     }
   }

--- a/android/src/main/java/com/twiliovoicereactnative/VoiceService.java
+++ b/android/src/main/java/com/twiliovoicereactnative/VoiceService.java
@@ -111,10 +111,7 @@ public class VoiceService extends Service {
     final String action = intent.getAction();
     if (null == action) {
       logger.warning("intent action null");
-      if (CallRecordDatabase.CallRecord.INVALID_NOTIFICATION_ID != notificationId) {
-        logger.warning("notificationId detected, attempting to remove notification");
-        removeNotification(notificationId);
-      }
+      removeNotificationIfPresent(notificationId);
       return START_NOT_STICKY;
     }
 
@@ -127,10 +124,7 @@ public class VoiceService extends Service {
     final UUID messageUUID = getMessageUUID(intent);
     if (null == messageUUID) {
       logger.warning("message uuid null");
-      if (CallRecordDatabase.CallRecord.INVALID_NOTIFICATION_ID != notificationId) {
-        logger.warning("notificationId detected, attempting to remove notification");
-        removeNotification(notificationId);
-      }
+      removeNotificationIfPresent(notificationId);
       return START_NOT_STICKY;
     }
 
@@ -144,19 +138,18 @@ public class VoiceService extends Service {
 
     if (null == callRecord) {
       logger.warning("No call record found for action \"" + action + "\", ignoring");
-      // The call invite is gone (settled/cancelled, or the process was restarted and the in-memory
-      // database was lost), but its incoming-call notification may still be showing. Dismiss it
-      // using the id carried on the intent so a stale accept/reject button does not linger forever.
-      if (CallRecordDatabase.CallRecord.INVALID_NOTIFICATION_ID != notificationId) {
-        logger.warning("notificationId detected, attempting to remove notification");
-        removeNotification(notificationId);
-      }
+      removeNotificationIfPresent(notificationId);
       return START_NOT_STICKY;
     }
 
     switch (action) {
       case ACTION_INCOMING_CALL: {
-        logger.warning("Incoming call intent received. This should not happen!");
+        // Incoming calls are raised internally via the binder API, not delivered to onStartCommand,
+        // so reaching here means an ACTION_INCOMING_CALL intent was dispatched to the service
+        // unexpectedly. Log the identifiers so the originating call can be traced.
+        logger.warning(String.format(
+          "Unexpected ACTION_INCOMING_CALL intent for callSid=%s, uuid=%s",
+          callRecord.getCallSid(), callRecord.getUuid()));
         incomingCall(callRecord);
         break;
       }
@@ -414,6 +407,15 @@ public class VoiceService extends Service {
     NotificationManager mNotificationManager =
       (NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE);
     mNotificationManager.cancel(notificationId);
+  }
+  private void removeNotificationIfPresent(final int notificationId) {
+    // The intent did not resolve to a live call record (bad/duplicate intent, or the in-memory
+    // database was lost to process death), but its incoming-call notification may still be showing.
+    // Dismiss it using the id carried on the intent so a stale accept/reject button does not linger.
+    if (CallRecordDatabase.CallRecord.INVALID_NOTIFICATION_ID != notificationId) {
+      logger.warning("notificationId detected, attempting to remove notification");
+      removeNotification(notificationId);
+    }
   }
   private void removeForegroundNotification() {
     logger.debug("removeForegroundNotification");


### PR DESCRIPTION
## Submission Checklist

 - [x] Updated the `CHANGELOG.md` to reflect any **feature**, **bug fixes**, or **known issues** made in the source code
 - [x] Tested code changes and observed expected behavior in the example app
 - [x] Performed a visual inspection of the `Files changed` tab prior to submitting the pull request for review to ensure proper usage of the style guide

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Description

This PR implements a null-guard in the intent handler to prevent NPEs when trying to interact with CallInvites that have been invalidated either by process reaping or otherwise.

## Breakdown

- Null guard against invalid CallInvites.

## Validation

- Manually tested with app

## Additional Notes

N/A
