### PR TITLE
[VBLOCKS-4141] Add unknown type audio device

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,22 +1,29 @@
 2.0.0-preview.3 (In Progress)
 =============================
 
-## Features
+## Breaking Changes
 
-- Added `AudioDevice.nativeType`, which exposes the audio device type exactly as reported by the native layer. Added `AudioDevice.Type.Unknown`, reported via `AudioDevice.type` when the native layer reports a device type that isn't one of the other well-known `AudioDevice.Type` values.
+### AudioDevice.Type and AudioDevice.nativeType
+
+- Added `AudioDevice.nativeType`, which exposes the audio device type exactly as reported by the native layer.
+
+- Added `AudioDevice.Type.Unknown`, reported via `AudioDevice.type` when the native layer reports a device type that isn't one of the other well-known `AudioDevice.Type` values.
+
+#### iOS
+
+- Audio devices with an unrecognized native port type (for example, non-HFP Bluetooth profiles) previously reported that raw native type string, e.g. `"BluetoothA2DP"`, as `AudioDevice.type` instead of a well-known `AudioDevice.Type` value. These devices now report `AudioDevice.Type.Unknown` and `AudioDevice.nativeType` now reports the native value, e.g. `"BluetoothA2DP"`.
+
+#### Android
+
+- Audio devices of an unrecognized type previously reported `AudioDevice.type` as `null` instead of a well-known `AudioDevice.Type` value. These devices now report `AudioDevice.Type.Unknown`.
 
 ## Fixes
 
 ### Platform Specific Fixes
 
-#### iOS
-
-- Fixed an issue where audio devices with an unrecognized native port type (for example, non-HFP Bluetooth profiles) would report that raw native type string, e.g. `BluetoothA2DP`, as `AudioDevice.type` instead of a well-known `AudioDevice.Type` value. These devices now report `AudioDevice.Type.Unknown`.
-
 #### Android
 
 - Fixed null pointer exception related crashes that could occur when accepting or rejecting invalid CallInvites using the native notification.
-- Fixed an issue where an audio device of an unrecognized type could report `AudioDevice.type` as `null` instead of a well-known `AudioDevice.Type` value. These devices now report `AudioDevice.Type.Unknown`.
 
 2.0.0-preview.2 (April 29, 2026)
 ================================

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,22 @@
 2.0.0-preview.3 (In Progress)
 =============================
 
+## Features
+
+- Added `AudioDevice.nativeType`, which exposes the audio device type exactly as reported by the native layer. Added `AudioDevice.Type.Unknown`, reported via `AudioDevice.type` when the native layer reports a device type that isn't one of the other well-known `AudioDevice.Type` values.
+
 ## Fixes
 
 ### Platform Specific Fixes
 
+#### iOS
+
+- Fixed an issue where audio devices with an unrecognized native port type (for example, non-HFP Bluetooth profiles) would report that raw native type string, e.g. `BluetoothA2DP`, as `AudioDevice.type` instead of a well-known `AudioDevice.Type` value. These devices now report `AudioDevice.Type.Unknown`.
+
 #### Android
 
 - Fixed null pointer exception related crashes that could occur when accepting or rejecting invalid CallInvites using the native notification.
+- Fixed an issue where an audio device of an unrecognized type could report `AudioDevice.type` as `null` instead of a well-known `AudioDevice.Type` value. These devices now report `AudioDevice.Type.Unknown`.
 
 2.0.0-preview.2 (April 29, 2026)
 ================================

--- a/android/src/main/java/com/twiliovoicereactnative/AudioSwitchManager.java
+++ b/android/src/main/java/com/twiliovoicereactnative/AudioSwitchManager.java
@@ -54,6 +54,30 @@ class AudioSwitchManager {
   }
 
   /**
+   * Maps an AudioDevice to a string describing its native, unprocessed type, for the same
+   * `instanceof`-over-reflection reason as {@link #getAudioDeviceType}.
+   */
+  public static String getAudioDeviceNativeType(AudioDevice audioDevice) {
+    if (audioDevice instanceof AudioDevice.Speakerphone) {
+      return "Speakerphone";
+    } else if (audioDevice instanceof AudioDevice.BluetoothHeadset) {
+      return "BluetoothHeadset";
+    } else if (audioDevice instanceof AudioDevice.WiredHeadset) {
+      return "WiredHeadset";
+    } else if (audioDevice instanceof AudioDevice.Earpiece) {
+      return "Earpiece";
+    } else {
+      // AudioDevice is a sealed class with only the four subclasses handled above, so this
+      // branch is currently unreachable. It only becomes reachable if a future AudioSwitch
+      // release adds a new subclass and this method isn't updated to match before the
+      // dependency is bumped. See VBLOCKS-6942. In that case, falling back to reflection here
+      // remains subject to renaming by code shrinkers such as R8 in a consuming app's release
+      // build.
+      return audioDevice.getClass().getSimpleName();
+    }
+  }
+
+  /**
    * Map of UUIDs to all available AudioDevices. Kept up-to-date by the AudioSwitch.
    */
   private final HashMap<String, AudioDevice> audioDevices;

--- a/android/src/main/java/com/twiliovoicereactnative/AudioSwitchManager.java
+++ b/android/src/main/java/com/twiliovoicereactnative/AudioSwitchManager.java
@@ -12,6 +12,7 @@ import java.util.UUID;
 import static com.twiliovoicereactnative.CommonConstants.AudioDeviceKeyEarpiece;
 import static com.twiliovoicereactnative.CommonConstants.AudioDeviceKeySpeaker;
 import static com.twiliovoicereactnative.CommonConstants.AudioDeviceKeyBluetooth;
+import static com.twiliovoicereactnative.CommonConstants.AudioDeviceKeyUnknown;
 
 import kotlin.Unit;
 
@@ -34,13 +35,23 @@ class AudioSwitchManager {
   }
 
   /**
-   * Audio device type mapping. Normalizes the class name into a string the JS layer expects.
+   * Maps an AudioDevice to the string the JS layer expects. Uses `instanceof` rather than the
+   * class name (e.g. via reflection) because code shrinkers such as R8 can rename AudioSwitch's
+   * classes in a consuming app's release build, and AudioSwitch does not ship a consumer
+   * ProGuard rule that prevents this.
    */
-  public static final Map<String, String> AUDIO_DEVICE_TYPE = Map.of(
-    "Speakerphone", AudioDeviceKeySpeaker,
-    "BluetoothHeadset", AudioDeviceKeyBluetooth,
-    "WiredHeadset", AudioDeviceKeyEarpiece,
-    "Earpiece", AudioDeviceKeyEarpiece);
+  public static String getAudioDeviceType(AudioDevice audioDevice) {
+    if (audioDevice instanceof AudioDevice.Speakerphone) {
+      return AudioDeviceKeySpeaker;
+    } else if (audioDevice instanceof AudioDevice.BluetoothHeadset) {
+      return AudioDeviceKeyBluetooth;
+    } else if (audioDevice instanceof AudioDevice.WiredHeadset
+      || audioDevice instanceof AudioDevice.Earpiece) {
+      return AudioDeviceKeyEarpiece;
+    } else {
+      return AudioDeviceKeyUnknown;
+    }
+  }
 
   /**
    * Map of UUIDs to all available AudioDevices. Kept up-to-date by the AudioSwitch.

--- a/android/src/main/java/com/twiliovoicereactnative/ReactNativeArgumentsSerializer.java
+++ b/android/src/main/java/com/twiliovoicereactnative/ReactNativeArgumentsSerializer.java
@@ -2,8 +2,10 @@ package com.twiliovoicereactnative;
 
 import static com.twiliovoicereactnative.CommonConstants.AudioDeviceKeyAudioDevices;
 import static com.twiliovoicereactnative.CommonConstants.AudioDeviceKeyName;
+import static com.twiliovoicereactnative.CommonConstants.AudioDeviceKeyNativeType;
 import static com.twiliovoicereactnative.CommonConstants.AudioDeviceKeySelectedDevice;
 import static com.twiliovoicereactnative.CommonConstants.AudioDeviceKeyType;
+import static com.twiliovoicereactnative.CommonConstants.AudioDeviceKeyUnknown;
 import static com.twiliovoicereactnative.CommonConstants.AudioDeviceKeyUuid;
 import static com.twiliovoicereactnative.CommonConstants.CallInfoFrom;
 import static com.twiliovoicereactnative.CommonConstants.CallInfoInitialConnectedTimestamp;
@@ -177,11 +179,12 @@ class ReactNativeArgumentsSerializer {
    */
   public static WritableMap serializeAudioDevice(String uuid, @Nullable AudioDevice audioDevice) {
     if (null != audioDevice) {
-      String type = audioDevice.getClass().getSimpleName();
+      String nativeType = audioDevice.getClass().getSimpleName();
       return constructJSMap(
         new Pair<>(AudioDeviceKeyUuid, uuid),
         new Pair<>(AudioDeviceKeyName, audioDevice.getName()),
-        new Pair<>(AudioDeviceKeyType, AudioSwitchManager.AUDIO_DEVICE_TYPE.get(type)));
+        new Pair<>(AudioDeviceKeyType, AudioSwitchManager.AUDIO_DEVICE_TYPE.getOrDefault(nativeType, AudioDeviceKeyUnknown)),
+        new Pair<>(AudioDeviceKeyNativeType, nativeType));
     }
     return null;
   }

--- a/android/src/main/java/com/twiliovoicereactnative/ReactNativeArgumentsSerializer.java
+++ b/android/src/main/java/com/twiliovoicereactnative/ReactNativeArgumentsSerializer.java
@@ -5,7 +5,6 @@ import static com.twiliovoicereactnative.CommonConstants.AudioDeviceKeyName;
 import static com.twiliovoicereactnative.CommonConstants.AudioDeviceKeyNativeType;
 import static com.twiliovoicereactnative.CommonConstants.AudioDeviceKeySelectedDevice;
 import static com.twiliovoicereactnative.CommonConstants.AudioDeviceKeyType;
-import static com.twiliovoicereactnative.CommonConstants.AudioDeviceKeyUnknown;
 import static com.twiliovoicereactnative.CommonConstants.AudioDeviceKeyUuid;
 import static com.twiliovoicereactnative.CommonConstants.CallInfoFrom;
 import static com.twiliovoicereactnative.CommonConstants.CallInfoInitialConnectedTimestamp;
@@ -183,7 +182,7 @@ class ReactNativeArgumentsSerializer {
       return constructJSMap(
         new Pair<>(AudioDeviceKeyUuid, uuid),
         new Pair<>(AudioDeviceKeyName, audioDevice.getName()),
-        new Pair<>(AudioDeviceKeyType, AudioSwitchManager.AUDIO_DEVICE_TYPE.getOrDefault(nativeType, AudioDeviceKeyUnknown)),
+        new Pair<>(AudioDeviceKeyType, AudioSwitchManager.getAudioDeviceType(audioDevice)),
         new Pair<>(AudioDeviceKeyNativeType, nativeType));
     }
     return null;

--- a/android/src/main/java/com/twiliovoicereactnative/ReactNativeArgumentsSerializer.java
+++ b/android/src/main/java/com/twiliovoicereactnative/ReactNativeArgumentsSerializer.java
@@ -178,7 +178,7 @@ class ReactNativeArgumentsSerializer {
    */
   public static WritableMap serializeAudioDevice(String uuid, @Nullable AudioDevice audioDevice) {
     if (null != audioDevice) {
-      String nativeType = audioDevice.getClass().getSimpleName();
+      String nativeType = AudioSwitchManager.getAudioDeviceNativeType(audioDevice);
       return constructJSMap(
         new Pair<>(AudioDeviceKeyUuid, uuid),
         new Pair<>(AudioDeviceKeyName, audioDevice.getName()),

--- a/api/voice-react-native-sdk.api.md
+++ b/api/voice-react-native-sdk.api.md
@@ -20,8 +20,9 @@ export class AudioDevice {
     // Warning: (ae-forgotten-export) The symbol "NativeAudioDeviceInfo" needs to be exported by the entry point index.d.ts
     //
     // @internal
-    constructor({ uuid, type, name }: NativeAudioDeviceInfo);
+    constructor({ uuid, type, nativeType, name }: NativeAudioDeviceInfo);
     name: string;
+    nativeType: string;
     select(): Promise<void>;
     type: AudioDevice.Type;
     // Warning: (ae-forgotten-export) The symbol "Uuid" needs to be exported by the entry point index.d.ts
@@ -38,7 +39,9 @@ export namespace AudioDevice {
         // (undocumented)
         Earpiece = "earpiece",
         // (undocumented)
-        Speaker = "speaker"
+        Speaker = "speaker",
+        // (undocumented)
+        Unknown = "unknown"
     }
 }
 

--- a/api/voice-react-native-sdk.api.md
+++ b/api/voice-react-native-sdk.api.md
@@ -34,13 +34,9 @@ export class AudioDevice {
 // @public
 export namespace AudioDevice {
     export enum Type {
-        // (undocumented)
         Bluetooth = "bluetooth",
-        // (undocumented)
         Earpiece = "earpiece",
-        // (undocumented)
         Speaker = "speaker",
-        // (undocumented)
         Unknown = "unknown"
     }
 }

--- a/constants/constants.src
+++ b/constants/constants.src
@@ -96,6 +96,8 @@ AudioDeviceKeySelectedDevice=selectedDevice
 AudioDeviceKeyEarpiece=earpiece
 AudioDeviceKeySpeaker=speaker
 AudioDeviceKeyBluetooth=bluetooth
+AudioDeviceKeyUnknown=unknown
+AudioDeviceKeyNativeType=nativeType
 
 // CallInvite events
 CallInviteEventKeyType=type

--- a/ios/TwilioVoiceReactNative.m
+++ b/ios/TwilioVoiceReactNative.m
@@ -166,6 +166,7 @@ static TVODefaultAudioDevice *sTwilioAudioDevice;
     NSUUID *receiverUuid = [NSUUID UUID];
     NSDictionary *builtInReceiver = @{ kTwilioVoiceReactNativeAudioDeviceKeyUuid: receiverUuid.UUIDString,
                                        kTwilioVoiceReactNativeAudioDeviceKeyType: kTwilioVoiceReactNativeAudioDeviceKeyEarpiece,
+                                       kTwilioVoiceReactNativeAudioDeviceKeyNativeType: AVAudioSessionPortBuiltInReceiver,
                                        kTwilioVoiceReactNativeAudioDeviceKeyName: @"iPhone",
                                        kTwilioVoiceAudioDeviceUid: AVAudioSessionPortBuiltInReceiver};
     self.audioDevices[receiverUuid.UUIDString] = builtInReceiver;
@@ -173,6 +174,7 @@ static TVODefaultAudioDevice *sTwilioAudioDevice;
     NSUUID *speakerUuid = [NSUUID UUID];
     NSDictionary *builtInSpeaker = @{ kTwilioVoiceReactNativeAudioDeviceKeyUuid: speakerUuid.UUIDString,
                                       kTwilioVoiceReactNativeAudioDeviceKeyType: kTwilioVoiceReactNativeAudioDeviceKeySpeaker,
+                                      kTwilioVoiceReactNativeAudioDeviceKeyNativeType: AVAudioSessionPortBuiltInSpeaker,
                                       kTwilioVoiceReactNativeAudioDeviceKeyName: @"Speaker",
                                       kTwilioVoiceAudioDeviceUid: AVAudioSessionPortBuiltInSpeaker};
     self.audioDevices[speakerUuid.UUIDString] = builtInSpeaker;
@@ -199,6 +201,7 @@ static TVODefaultAudioDevice *sTwilioAudioDevice;
             NSUUID *uuid = [NSUUID UUID];
             NSDictionary *bluetoothHfpDevice = @{ kTwilioVoiceReactNativeAudioDeviceKeyUuid: uuid.UUIDString,
                                                   kTwilioVoiceReactNativeAudioDeviceKeyType: [self audioPortTypeMapping:port.portType],
+                                                  kTwilioVoiceReactNativeAudioDeviceKeyNativeType: port.portType,
                                                   kTwilioVoiceReactNativeAudioDeviceKeyName: port.portName,
                                                   kTwilioVoiceAudioDeviceUid: port.UID };
             self.audioDevices[uuid.UUIDString] = bluetoothHfpDevice;
@@ -248,6 +251,7 @@ static TVODefaultAudioDevice *sTwilioAudioDevice;
                 NSUUID *uuid = [NSUUID UUID];
                 NSDictionary *unidentifiedDevice = @{ kTwilioVoiceReactNativeAudioDeviceKeyUuid: uuid.UUIDString,
                                                       kTwilioVoiceReactNativeAudioDeviceKeyType: [self audioPortTypeMapping:port.portType],
+                                                      kTwilioVoiceReactNativeAudioDeviceKeyNativeType: port.portType,
                                                       kTwilioVoiceReactNativeAudioDeviceKeyName: port.portName,
                                                       kTwilioVoiceAudioDeviceUid: port.UID };
                 self.audioDevices[uuid.UUIDString] = unidentifiedDevice;
@@ -268,7 +272,7 @@ static TVODefaultAudioDevice *sTwilioAudioDevice;
         return kTwilioVoiceReactNativeAudioDeviceKeyBluetooth;
     }
 
-    return portType;
+    return kTwilioVoiceReactNativeAudioDeviceKeyUnknown;
 }
 
 - (BOOL)selectAudioDevice:(NSString *)uuid {

--- a/ios/TwilioVoiceReactNative.m
+++ b/ios/TwilioVoiceReactNative.m
@@ -314,6 +314,19 @@ static TVODefaultAudioDevice *sTwilioAudioDevice;
             NSLog(@"Bluetooth device %@ not found", device[kTwilioVoiceReactNativeAudioDeviceKeyName]);
             return NO;
         }
+    } else if ([portType isEqualToString:kTwilioVoiceReactNativeAudioDeviceKeyUnknown]) {
+        NSArray *availableInputs = [[AVAudioSession sharedInstance] availableInputs];
+        for (AVAudioSessionPortDescription *port in availableInputs) {
+            if ([port.UID isEqualToString:portUid]) {
+                portDescription = port;
+                break;
+            }
+        }
+
+        if (!portDescription) {
+            NSLog(@"Unknown device %@ not found", device[kTwilioVoiceReactNativeAudioDeviceKeyName]);
+            return NO;
+        }
     }
 
     // Update preferred input

--- a/src/AudioDevice.tsx
+++ b/src/AudioDevice.tsx
@@ -109,9 +109,29 @@ export namespace AudioDevice {
    * {@link (AudioDevice:class).nativeType} carries the raw, unprocessed value.
    */
   export enum Type {
+    /**
+     * Audio device type representing an earpiece.
+     */
     Earpiece = 'earpiece',
+
+    /**
+     * Audio device type representing a speaker.
+     */
     Speaker = 'speaker',
+
+    /**
+     * Audio device type representing a Bluetooth device.
+     */
     Bluetooth = 'bluetooth',
+
+    /**
+     * Audio device type representing a device that is not recognized as one
+     * of the other well-known {@link (AudioDevice:namespace).Type} values.
+     *
+     * @remarks
+     * See {@link (AudioDevice:class).nativeType} for the raw, unprocessed
+     * device type reported by the native layer in this case.
+     */
     Unknown = 'unknown',
   }
 }

--- a/src/AudioDevice.tsx
+++ b/src/AudioDevice.tsx
@@ -45,8 +45,8 @@ export class AudioDevice {
   type: AudioDevice.Type;
 
   /**
-   * The type of the audio device as reported verbatim by the native layer, without
-   * being mapped to a {@link (AudioDevice:namespace).Type}.
+   * The type of the audio device as reported by the native layer. This value
+   * may not be mapped to a {@link (AudioDevice:namespace).Type}.
    *
    * @remarks
    * Native platform APIs can report audio device types that are not represented by

--- a/src/AudioDevice.tsx
+++ b/src/AudioDevice.tsx
@@ -53,6 +53,12 @@ export class AudioDevice {
    * {@link (AudioDevice:namespace).Type}, for example due to OS updates introducing
    * new device categories. This field is provided as an escape hatch for those cases
    * and its value is not guaranteed to be stable across native SDK or OS versions.
+   *
+   * On iOS platforms, these values correlate to the Apple-defined
+   * `AVAudioSessionPort` constant.
+   *
+   * On Android platforms, these values correlate to the class names found in the
+   * Twilio AudioSwitch library.
    */
   nativeType: string;
 

--- a/src/AudioDevice.tsx
+++ b/src/AudioDevice.tsx
@@ -33,8 +33,28 @@ export class AudioDevice {
 
   /**
    * The type of the audio device.
+   *
+   * @remarks
+   * This is a best-effort categorization of {@link (AudioDevice:class).nativeType}
+   * into one of the well-known {@link (AudioDevice:namespace).Type} values. If the
+   * native layer reports a device type that this SDK does not recognize, this will be
+   * {@link (AudioDevice:namespace).Type.Unknown}; see
+   * {@link (AudioDevice:class).nativeType} for the raw, unprocessed value in that
+   * case.
    */
   type: AudioDevice.Type;
+
+  /**
+   * The type of the audio device as reported verbatim by the native layer, without
+   * being mapped to a {@link (AudioDevice:namespace).Type}.
+   *
+   * @remarks
+   * Native platform APIs can report audio device types that are not represented by
+   * {@link (AudioDevice:namespace).Type}, for example due to OS updates introducing
+   * new device categories. This field is provided as an escape hatch for those cases
+   * and its value is not guaranteed to be stable across native SDK or OS versions.
+   */
+  nativeType: string;
 
   /**
    * The name of the audio device.
@@ -47,9 +67,10 @@ export class AudioDevice {
    *
    * @internal
    */
-  constructor({ uuid, type, name }: NativeAudioDeviceInfo) {
+  constructor({ uuid, type, nativeType, name }: NativeAudioDeviceInfo) {
     this.uuid = uuid;
     this.type = type;
+    this.nativeType = nativeType;
     this.name = name;
   }
 
@@ -77,12 +98,20 @@ export class AudioDevice {
  */
 export namespace AudioDevice {
   /**
-   * Audio device type enumeration. Describes all possible audio device types as
-   * reportable by the native layer.
+   * Audio device type enumeration. Describes the well-known audio device types
+   * recognized by this SDK.
+   *
+   * @remarks
+   * The native layer can report device types outside of this enumeration, for
+   * example due to OS updates introducing new device categories. In those cases,
+   * the {@link (AudioDevice:class) | AudioDevice} `type` property is
+   * {@link (AudioDevice:namespace).Type.Unknown} and
+   * {@link (AudioDevice:class).nativeType} carries the raw, unprocessed value.
    */
   export enum Type {
     Earpiece = 'earpiece',
     Speaker = 'speaker',
     Bluetooth = 'bluetooth',
+    Unknown = 'unknown',
   }
 }

--- a/src/__mocks__/AudioDevice.ts
+++ b/src/__mocks__/AudioDevice.ts
@@ -8,6 +8,7 @@ export function createNativeAudioDeviceInfo(): NativeAudioDeviceInfo {
   return {
     uuid: 'mock-nativeaudiodeviceinfo-uuid',
     type: 'earpiece' as AudioDevice.Type,
+    nativeType: 'mock-nativeaudiodeviceinfo-nativetype',
     name: 'mock-nativeaudiodeviceinfo-name',
   };
 }
@@ -18,22 +19,26 @@ export function createNativeAudioDevicesInfo(): NativeAudioDevicesInfo {
       {
         uuid: 'mock-nativeaudiodeviceinfo-uuid-one',
         type: 'earpiece' as AudioDevice.Type,
+        nativeType: 'mock-nativeaudiodeviceinfo-nativetype-one',
         name: 'mock-nativeaudiodeviceinfo-name-one',
       },
       {
         uuid: 'mock-nativeaudiodeviceinfo-uuid-two',
         type: 'speaker' as AudioDevice.Type,
+        nativeType: 'mock-nativeaudiodeviceinfo-nativetype-two',
         name: 'mock-nativeaudiodeviceinfo-name-two',
       },
       {
         uuid: 'mock-nativeaudiodeviceinfo-uuid-three',
         type: 'bluetooth' as AudioDevice.Type,
+        nativeType: 'mock-nativeaudiodeviceinfo-nativetype-three',
         name: 'mock-nativeaudiodeviceinfo-name-three',
       },
     ],
     selectedDevice: {
       uuid: 'mock-nativeaudiodeviceinfo-uuid-two',
       type: 'speaker' as AudioDevice.Type,
+      nativeType: 'mock-nativeaudiodeviceinfo-nativetype-two',
       name: 'mock-nativeaudiodeviceinfo-name-two',
     },
   };

--- a/src/__tests__/AudioDevice.test.ts
+++ b/src/__tests__/AudioDevice.test.ts
@@ -20,6 +20,14 @@ describe('AudioDevice class', () => {
       it('contains the type of the AudioDevice', () => {
         expect(audioDevice.type).toBe(createNativeAudioDeviceInfo().type);
       });
+
+      it('round-trips AudioDevice.Type.Unknown through construction', () => {
+        const unknownAudioDevice = new AudioDevice({
+          ...createNativeAudioDeviceInfo(),
+          type: AudioDevice.Type.Unknown,
+        });
+        expect(unknownAudioDevice.type).toBe(AudioDevice.Type.Unknown);
+      });
     });
 
     describe('.nativeType', () => {

--- a/src/__tests__/AudioDevice.test.ts
+++ b/src/__tests__/AudioDevice.test.ts
@@ -22,6 +22,14 @@ describe('AudioDevice class', () => {
       });
     });
 
+    describe('.nativeType', () => {
+      it('contains the native type of the AudioDevice', () => {
+        expect(audioDevice.nativeType).toBe(
+          createNativeAudioDeviceInfo().nativeType
+        );
+      });
+    });
+
     describe('.uuid', () => {
       it('contains the uuid of the AudioDevice', () => {
         expect(audioDevice.uuid).toBe(createNativeAudioDeviceInfo().uuid);
@@ -57,6 +65,10 @@ describe('AudioDevice namespace', () => {
     it('Type', () => {
       expect(AudioDevice.Type).toBeDefined();
       expect(typeof AudioDevice.Type).toBe('object');
+    });
+
+    it('Type.Unknown', () => {
+      expect(AudioDevice.Type.Unknown).toBe('unknown');
     });
   });
 });

--- a/src/type/AudioDevice.ts
+++ b/src/type/AudioDevice.ts
@@ -5,6 +5,7 @@ import type { Uuid } from './common';
 export interface NativeAudioDeviceInfo {
   uuid: Uuid;
   type: AudioDevice.Type;
+  nativeType: string;
   name: string;
 }
 


### PR DESCRIPTION
## Submission Checklist

 - [x] Updated the `CHANGELOG.md` to reflect any **feature**, **bug fixes**, or **known issues** made in the source code
 - [x] Tested code changes and observed expected behavior in the example app
 - [x] Performed a visual inspection of the `Files changed` tab prior to submitting the pull request for review to ensure proper usage of the style guide

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Description

This PR implements a new AudioDevice type member with value "unknown". This is a fallback audio device type for when the OS returns an unexpected audio device type. Now, there is also a `nativeType` member of the AudioDevice that can be used to see the value that the native layer returns.

This solution was chosen instead of further marshaling because the underlying OS and those values are subject to continuous change.

## Breakdown

- Add "unknown" to the AudioDevice enum.
- Add new "nativeType" to the AudioDevice type.

## Validation

- Tested on iOS with a Bluetooth device that previously was detected as BluetoothA2DP, which would fail the enum and be passed in audioDevice.type and not fall under the JS enum value set. Now, the reported audio device is `{ type: AudioDevice.Type.Unknown, nativeType: 'BluetoothA2DP' }`.
- Tested on a real Android device in a real outgoing call by mocking the returned type from the native layer. Mocked to "unknown" and the audio device selection still works properly, as well as the `audioDevice.type` and `audioDevice.nativeType` are proper.

## Additional Notes

N/A
