### PR TITLE
fix: fail CallKit answer action gracefully when the call invite is missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+Unreleased
+==========
+
+## Fixes
+
+- Fixed a fatal iOS crash (`NSInvalidArgumentException: A call invite is required.`) when a CallKit answer action is performed for a call invite that no longer exists, such as a cancellation racing the user's answer. The invite lookup was guarded only by an `NSAssert`, which compiles out of release builds. The answer action now fails gracefully so CallKit dismisses the call UI, leaving the process — and any other active call — intact.
+
 2.0.0-preview.2 (April 29, 2026)
 ================================
 

--- a/ios/TwilioVoiceReactNative+CallKit.m
+++ b/ios/TwilioVoiceReactNative+CallKit.m
@@ -242,9 +242,17 @@ NSString * const kDefaultCallKitConfigurationName = @"Twilio Voice React Native"
 
 - (void)performAnswerVoiceCallWithUUID:(NSUUID *)uuid
                             completion:(void(^)(BOOL success))completionHandler {
-    NSAssert(self.callInviteMap[uuid.UUIDString], @"No call invite");
-    
     TVOCallInvite *callInvite = self.callInviteMap[uuid.UUIDString];
+    // The invite can be gone by the time the answer action arrives, e.g. a
+    // cancellation racing the user's tap. NSAssert compiles out of release
+    // builds, and passing nil into TVOAcceptOptions raises
+    // NSInvalidArgumentException, terminating the app along with any other
+    // active call.
+    if (!callInvite) {
+        NSLog(@"No call invite found for UUID %@; cannot answer", uuid.UUIDString);
+        completionHandler(NO);
+        return;
+    }
     TVOAcceptOptions *acceptOptions = [TVOAcceptOptions optionsWithCallInvite:callInvite block:^(TVOAcceptOptionsBuilder *builder) {
         builder.uuid = uuid;
         builder.callMessageDelegate = self;
@@ -338,9 +346,17 @@ NSString * const kDefaultCallKitConfigurationName = @"Twilio Voice React Native"
 }
 
 - (void)provider:(CXProvider *)provider performAnswerCallAction:(CXAnswerCallAction *)action {
+    // Fail the action cleanly when the invite no longer exists so CallKit
+    // dismisses the call UI instead of the process crashing mid-answer.
+    if (!self.callInviteMap[action.callUUID.UUIDString]) {
+        NSLog(@"No call invite for UUID %@; failing answer action", action.callUUID.UUIDString);
+        [action fail];
+        return;
+    }
+
     [TwilioVoiceReactNative twilioAudioDevice].enabled = NO;
     [TwilioVoiceReactNative twilioAudioDevice].block();
-    
+
     [self performAnswerVoiceCallWithUUID:action.callUUID completion:^(BOOL success) {
         if (success) {
             NSLog(@"performAnswerVoiceCallWithUUID successful");
@@ -348,7 +364,7 @@ NSString * const kDefaultCallKitConfigurationName = @"Twilio Voice React Native"
             NSLog(@"performAnswerVoiceCallWithUUID failed");
         }
     }];
-        
+
     [action fulfill];
 }
 


### PR DESCRIPTION
Fixes #704 (filed at @mhuynh5757's invitation — thanks!).

## Problem

`performAnswerVoiceCallWithUUID:completion:` guards the `callInviteMap` lookup with only an `NSAssert`, which compiles out of release builds (`NS_BLOCK_ASSERTIONS`). When a `CXAnswerCallAction` arrives for an invite that no longer exists — most commonly a cancellation racing the user's Answer tap (caller hangs up, or a ring-all/queue setup cancels the losing devices) — the nil invite reaches `+[TVOAcceptOptions optionsWithCallInvite:block:]`, which raises `NSInvalidArgumentException: A call invite is required.` and terminates the process. If the user is on another active call at the time, that call dies too.

`provider:performAnswerCallAction:` also calls `[action fulfill]` unconditionally, so there is no failure path even when the answer cannot proceed.

In our production fleet (call-center usage, heavy ring-all queues) this is our most frequent crash by a wide margin, frequently occurring while backgrounded (answering from the lock screen). Server-side, both legs terminate normally, so it presents to end users as an unexplained dropped/failed call rather than a crash.

## Change

- `performAnswerVoiceCallWithUUID:` nil-checks the invite and reports failure through the completion handler instead of proceeding into `TVOAcceptOptions`
- `provider:performAnswerCallAction:` checks the invite before claiming the audio device and calls `[action fail]` when it is gone, so CallKit dismisses the stale call UI; behavior when the invite exists is unchanged (same fulfill timing)
- Changelog entry under an `Unreleased` heading (happy to move/reformat to match your conventions)

This is the iOS counterpart of the Android hardening in VBLOCKS-6682 / #695. We have been running this exact change in production via patch-package and it eliminated the crash for our fleet.

## Reproduction

Deterministic without the race: report an incoming call to CallKit, remove the invite from `callInviteMap` (simulate the cancel handling), answer from the CallKit UI. Before: `NSInvalidArgumentException` crash. After: the answer action fails and the CallKit UI dismisses.