### PR TITLE
[VBLOCKS-7049] fix: expo version race

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@
 
 ## Fixes
 
+- Fixed issues where the Expo SDK version could be absent from call insights metadata. On iOS, this could previously persist for the remainder of an app session when a call, registration, or preflight test was started before the SDK had finished recording the version, which is more likely shortly after `Voice` construction. On all platforms, the version was not reported for apps running an over-the-air update.
+
 ### Platform Specific Fixes
 
 #### Android

--- a/src/Voice.tsx
+++ b/src/Voice.tsx
@@ -289,6 +289,17 @@ export class Voice extends EventEmitter {
   >;
 
   /**
+   * Resolves once the native layer has recorded the Expo version. Awaited by
+   * the entry points that can cause the native layer to emit an insights
+   * event, so that the version is present in that event's metadata.
+   *
+   * @privateRemarks
+   * Never rejects. Failing to record the Expo version is a telemetry concern
+   * and must never prevent a call, registration, or preflight test.
+   */
+  private _expoVersionPromise: Promise<void>;
+
+  /**
    * Main entry-point of the Voice SDK. Provides access to the entire
    * feature-set of the library.
    */
@@ -324,7 +335,9 @@ export class Voice extends EventEmitter {
       this._handleNativeEvent
     );
 
-    NativeModule.voice_setExpoVersion(getExpoVersion());
+    this._expoVersionPromise = settleNativePromise(
+      NativeModule.voice_setExpoVersion(getExpoVersion())
+    ).catch(() => undefined);
   }
 
   /**
@@ -565,6 +578,8 @@ export class Voice extends EventEmitter {
 
     validateConnectOptions({ iceServers, iceTransportPolicy });
 
+    await this._expoVersionPromise;
+
     switch (Platform.OS) {
       case 'ios':
         return this._connect_ios(
@@ -702,6 +717,7 @@ export class Voice extends EventEmitter {
    *  - Resolves when the device has been registered.
    */
   async register(token: string): Promise<void> {
+    await this._expoVersionPromise;
     await settleNativePromise(NativeModule.voice_register(token));
   }
 
@@ -713,6 +729,7 @@ export class Voice extends EventEmitter {
    *  - Resolves when the device has been unregistered.
    */
   async unregister(token: string): Promise<void> {
+    await this._expoVersionPromise;
     await settleNativePromise(NativeModule.voice_unregister(token));
   }
 
@@ -800,6 +817,7 @@ export class Voice extends EventEmitter {
   async initializePushRegistry(): Promise<void> {
     switch (Platform.OS) {
       case 'ios':
+        await this._expoVersionPromise;
         await settleNativePromise(NativeModule.voice_initializePushRegistry());
         return;
       default:
@@ -958,6 +976,8 @@ export class Voice extends EventEmitter {
     if (optionValidationResult.status === 'error') {
       throw optionValidationResult.error;
     }
+
+    await this._expoVersionPromise;
 
     const preflightTestUuid = await settleNativePromise(
       NativeModule.voice_runPreflight(accessToken, options)

--- a/src/__tests__/Voice.test.ts
+++ b/src/__tests__/Voice.test.ts
@@ -69,6 +69,49 @@ beforeEach(() => {
   MockNativeEventEmitter.reset();
 });
 
+/**
+ * Lets every promise continuation that is already queued run.
+ */
+function flushPromises() {
+  return new Promise<void>((resolve) => setImmediate(resolve));
+}
+
+/**
+ * Replaces the mocked `voice_setExpoVersion` binding with a promise that the
+ * test controls. Lets a test assert that an entry point waits for the Expo
+ * version to be recorded before it invokes the native layer.
+ *
+ * The shared mock in `src/__mocks__/common.ts` is already resolved, so without
+ * this a test asserting ordering would pass trivially.
+ */
+function deferSetExpoVersion() {
+  let settle!: (value: unknown) => void;
+  const nativePromise = new Promise((resolve) => {
+    settle = resolve;
+  });
+
+  jest
+    .mocked(MockNativeModule.voice_setExpoVersion)
+    .mockReturnValueOnce(nativePromise as any);
+
+  return {
+    resolve: () => {
+      settle(mockNativePromiseResolutionValue(undefined));
+      return flushPromises();
+    },
+  };
+}
+
+/**
+ * Every native connect call made, regardless of platform.
+ */
+function nativeConnectCalls() {
+  return [
+    ...jest.mocked(MockNativeModule.voice_connect_android).mock.calls,
+    ...jest.mocked(MockNativeModule.voice_connect_ios).mock.calls,
+  ];
+}
+
 describe('Voice class', () => {
   describe('constructor', () => {
     describe('event handler mapping', () => {
@@ -346,6 +389,57 @@ describe('Voice class', () => {
           contactHandle: 'mock-contact-handle',
         };
       });
+
+      performTestForPlatforms(
+        ['android', 'ios'],
+        'waits for the expo version to be recorded before connecting',
+        async () => {
+          const deferredExpoVersion = deferSetExpoVersion();
+
+          const connectPromise = new Voice().connect(token, options);
+          await flushPromises();
+
+          expect(nativeConnectCalls()).toHaveLength(0);
+
+          await deferredExpoVersion.resolve();
+          await connectPromise;
+
+          expect(nativeConnectCalls()).toHaveLength(1);
+        }
+      );
+
+      performTestForPlatforms(
+        ['android', 'ios'],
+        'connects when the expo version binding rejects',
+        async () => {
+          jest
+            .mocked(MockNativeModule.voice_setExpoVersion)
+            .mockRejectedValueOnce(new Error('mock expo version failure'));
+
+          await new Voice().connect(token, options);
+
+          expect(nativeConnectCalls()).toHaveLength(1);
+        }
+      );
+
+      performTestForPlatforms(
+        ['android', 'ios'],
+        'connects when the expo version binding rejects with a code',
+        async () => {
+          jest
+            .mocked(MockNativeModule.voice_setExpoVersion)
+            .mockResolvedValueOnce(
+              mockNativePromiseRejectionWithCodeValue(
+                31401,
+                'mock expo version failure'
+              )
+            );
+
+          await new Voice().connect(token, options);
+
+          expect(nativeConnectCalls()).toHaveLength(1);
+        }
+      );
 
       performTestForPlatforms(
         ['android', 'ios'],
@@ -865,6 +959,51 @@ describe('Voice class', () => {
         const registerPromise = new Voice().register('mock-voice-token');
         await expect(registerPromise).resolves.toBeUndefined();
       });
+
+      it('waits for the expo version to be recorded before registering', async () => {
+        const deferredExpoVersion = deferSetExpoVersion();
+
+        const registerPromise = new Voice().register('mock-voice-token');
+        await flushPromises();
+
+        expect(MockNativeModule.voice_register).not.toHaveBeenCalled();
+
+        await deferredExpoVersion.resolve();
+        await registerPromise;
+
+        expect(jest.mocked(MockNativeModule.voice_register).mock.calls).toEqual(
+          [['mock-voice-token']]
+        );
+      });
+
+      it('registers when the expo version binding rejects', async () => {
+        jest
+          .mocked(MockNativeModule.voice_setExpoVersion)
+          .mockRejectedValueOnce(new Error('mock expo version failure'));
+
+        await new Voice().register('mock-voice-token');
+
+        expect(jest.mocked(MockNativeModule.voice_register).mock.calls).toEqual(
+          [['mock-voice-token']]
+        );
+      });
+
+      it('registers when the expo version binding rejects with a code', async () => {
+        jest
+          .mocked(MockNativeModule.voice_setExpoVersion)
+          .mockResolvedValueOnce(
+            mockNativePromiseRejectionWithCodeValue(
+              31401,
+              'mock expo version failure'
+            )
+          );
+
+        await new Voice().register('mock-voice-token');
+
+        expect(jest.mocked(MockNativeModule.voice_register).mock.calls).toEqual(
+          [['mock-voice-token']]
+        );
+      });
     });
 
     describe('.unregister', () => {
@@ -878,6 +1017,50 @@ describe('Voice class', () => {
       it('returns a Promise<void>', async () => {
         const registerPromise = new Voice().unregister('mock-voice-token');
         await expect(registerPromise).resolves.toBeUndefined();
+      });
+      it('waits for the expo version to be recorded before unregistering', async () => {
+        const deferredExpoVersion = deferSetExpoVersion();
+
+        const unregisterPromise = new Voice().unregister('mock-voice-token');
+        await flushPromises();
+
+        expect(MockNativeModule.voice_unregister).not.toHaveBeenCalled();
+
+        await deferredExpoVersion.resolve();
+        await unregisterPromise;
+
+        expect(
+          jest.mocked(MockNativeModule.voice_unregister).mock.calls
+        ).toEqual([['mock-voice-token']]);
+      });
+
+      it('unregisters when the expo version binding rejects', async () => {
+        jest
+          .mocked(MockNativeModule.voice_setExpoVersion)
+          .mockRejectedValueOnce(new Error('mock expo version failure'));
+
+        await new Voice().unregister('mock-voice-token');
+
+        expect(
+          jest.mocked(MockNativeModule.voice_unregister).mock.calls
+        ).toEqual([['mock-voice-token']]);
+      });
+
+      it('unregisters when the expo version binding rejects with a code', async () => {
+        jest
+          .mocked(MockNativeModule.voice_setExpoVersion)
+          .mockResolvedValueOnce(
+            mockNativePromiseRejectionWithCodeValue(
+              31401,
+              'mock expo version failure'
+            )
+          );
+
+        await new Voice().unregister('mock-voice-token');
+
+        expect(
+          jest.mocked(MockNativeModule.voice_unregister).mock.calls
+        ).toEqual([['mock-voice-token']]);
       });
     });
 
@@ -968,6 +1151,55 @@ describe('Voice class', () => {
           new Voice().initializePushRegistry()
         ).resolves.toBeUndefined();
       });
+      it('waits for the expo version to be recorded before initializing', async () => {
+        jest.spyOn(Platform, 'OS', 'get').mockReturnValue('ios');
+        const deferredExpoVersion = deferSetExpoVersion();
+
+        const initializePromise = new Voice().initializePushRegistry();
+        await flushPromises();
+
+        expect(
+          MockNativeModule.voice_initializePushRegistry
+        ).not.toHaveBeenCalled();
+
+        await deferredExpoVersion.resolve();
+        await initializePromise;
+
+        expect(
+          jest.mocked(MockNativeModule.voice_initializePushRegistry).mock.calls
+        ).toEqual([[]]);
+      });
+
+      it('initializes when the expo version binding rejects', async () => {
+        jest.spyOn(Platform, 'OS', 'get').mockReturnValue('ios');
+        jest
+          .mocked(MockNativeModule.voice_setExpoVersion)
+          .mockRejectedValueOnce(new Error('mock expo version failure'));
+
+        await new Voice().initializePushRegistry();
+
+        expect(
+          jest.mocked(MockNativeModule.voice_initializePushRegistry).mock.calls
+        ).toEqual([[]]);
+      });
+
+      it('initializes when the expo version binding rejects with a code', async () => {
+        jest.spyOn(Platform, 'OS', 'get').mockReturnValue('ios');
+        jest
+          .mocked(MockNativeModule.voice_setExpoVersion)
+          .mockResolvedValueOnce(
+            mockNativePromiseRejectionWithCodeValue(
+              31401,
+              'mock expo version failure'
+            )
+          );
+
+        await new Voice().initializePushRegistry();
+
+        expect(
+          jest.mocked(MockNativeModule.voice_initializePushRegistry).mock.calls
+        ).toEqual([[]]);
+      });
     });
 
     describe('.setCallKitConfiguration', () => {
@@ -1027,6 +1259,51 @@ describe('Voice class', () => {
     describe('.runPreflight', () => {
       it('invokes the native module', async () => {
         await new Voice().runPreflight('token');
+        expect(
+          jest.mocked(MockNativeModule.voice_runPreflight).mock.calls
+        ).toEqual([['token', {}]]);
+      });
+
+      it('waits for the expo version to be recorded before running', async () => {
+        const deferredExpoVersion = deferSetExpoVersion();
+
+        const preflightPromise = new Voice().runPreflight('token');
+        await flushPromises();
+
+        expect(MockNativeModule.voice_runPreflight).not.toHaveBeenCalled();
+
+        await deferredExpoVersion.resolve();
+        await preflightPromise;
+
+        expect(
+          jest.mocked(MockNativeModule.voice_runPreflight).mock.calls
+        ).toEqual([['token', {}]]);
+      });
+
+      it('runs when the expo version binding rejects', async () => {
+        jest
+          .mocked(MockNativeModule.voice_setExpoVersion)
+          .mockRejectedValueOnce(new Error('mock expo version failure'));
+
+        await new Voice().runPreflight('token');
+
+        expect(
+          jest.mocked(MockNativeModule.voice_runPreflight).mock.calls
+        ).toEqual([['token', {}]]);
+      });
+
+      it('runs when the expo version binding rejects with a code', async () => {
+        jest
+          .mocked(MockNativeModule.voice_setExpoVersion)
+          .mockResolvedValueOnce(
+            mockNativePromiseRejectionWithCodeValue(
+              31401,
+              'mock expo version failure'
+            )
+          );
+
+        await new Voice().runPreflight('token');
+
         expect(
           jest.mocked(MockNativeModule.voice_runPreflight).mock.calls
         ).toEqual([['token', {}]]);

--- a/src/__tests__/expoVersion.test.ts
+++ b/src/__tests__/expoVersion.test.ts
@@ -42,6 +42,60 @@ describe('getExpoVersion', () => {
     }
   });
 
+  it('should get the version from an expo-updates manifest', () => {
+    setExpoManifest({
+      metadata: {},
+      extra: { expoClient: { sdkVersion: '52.0.0' } },
+    });
+    expect(getExpoVersion()).toBe('52.0.0');
+  });
+
+  it('should get the version from an expo-updates manifest json string', () => {
+    setExpoManifest(
+      JSON.stringify({
+        metadata: {},
+        extra: { expoClient: { sdkVersion: '52.0.0' } },
+      })
+    );
+    expect(getExpoVersion()).toBe('52.0.0');
+  });
+
+  it('should stringify a number sdk version nested under extra', () => {
+    setExpoManifest({ extra: { expoClient: { sdkVersion: 52 } } });
+    expect(getExpoVersion()).toBe('52');
+  });
+
+  it('should prefer the top level sdk version over the nested one', () => {
+    setExpoManifest({
+      sdkVersion: 'top-level',
+      extra: { expoClient: { sdkVersion: 'nested' } },
+    });
+    expect(getExpoVersion()).toBe('top-level');
+  });
+
+  it('should fall back to the nested sdk version if the top level one is null', () => {
+    setExpoManifest({
+      sdkVersion: null,
+      extra: { expoClient: { sdkVersion: '52.0.0' } },
+    });
+    expect(getExpoVersion()).toBe('52.0.0');
+  });
+
+  it('should return undefined if neither sdk version is present', () => {
+    setExpoManifest({ metadata: {}, extra: { expoClient: {} } });
+    expect(getExpoVersion()).toBe(undefined);
+  });
+
+  it('should return undefined if the extra member is not an object', () => {
+    const invalidValues = [null, 10, 'foobar', false];
+    expect.assertions(invalidValues.length);
+
+    for (const val of invalidValues) {
+      setExpoManifest({ extra: val });
+      expect(getExpoVersion()).toBe(undefined);
+    }
+  });
+
   it('should return undefined if the expo manifest is not a json string', () => {
     setExpoManifest('foobar');
     expect(getExpoVersion()).toBe(undefined);

--- a/src/utility/expoVersion.ts
+++ b/src/utility/expoVersion.ts
@@ -11,7 +11,14 @@ export function getExpoVersion(): string | undefined {
         ? JSON.parse(expoManifest)
         : expoManifest;
 
-    const sdkVersion = manifest?.sdkVersion;
+    /**
+     * Embedded manifests carry the SDK version at the top level. Manifests
+     * served by expo-updates instead nest the app config under
+     * `extra.expoClient`, so the top-level lookup finds nothing for an app
+     * running an over-the-air update.
+     */
+    const sdkVersion =
+      manifest?.sdkVersion ?? manifest?.extra?.expoClient?.sdkVersion;
 
     if (typeof sdkVersion === 'string') {
       return sdkVersion;


### PR DESCRIPTION
## Submission Checklist

 - [x] Updated the `CHANGELOG.md` to reflect any **feature**, **bug fixes**, or **known issues** made in the source code
 - [x] Tested code changes and observed expected behavior in the example app
 - [x] Performed a visual inspection of the `Files changed` tab prior to submitting the pull request for review to ensure proper usage of the style guide

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Description

https://twilio-engineering.atlassian.net/browse/VBLOCKS-7049

## Breakdown

- Awaited the voice_setExpoVersion promise in connect, register, unregister, runPreflight, and initializePushRegistry.
- The call was previously fire-and-forget, so these could reach native before the Expo version was recorded.
- On iOS the native SDK memoizes publisher metadata on the first insights event, freezing the miss for the whole session.
- Added .catch(() => undefined) so failing to record the version can never reject a call or registration.
- Added an extra.expoClient.sdkVersion fallback in getExpoVersion for expo-updates OTA manifests, which have no top-level sdkVersion.

## Validation

- Added 22 unit tests: ordering plus both native-rejection flavors for all five entry points, and 7 for the manifest fallback.
- Mutation-verified each one: dropping any await, the .catch, or the fallback fails only the tests that cover it.
- On simulator, delayed the native setenv 15s to force the race: getenv read (null) pre-fix at both entry points, 52.0.0 post-fix.
- Swapped in a real expo-updates-shaped app.config: resolved 52.0.0 with the fallback, undefined without, and the embedded shape still resolved 52.0.0.

